### PR TITLE
MAINT: Setup a linear path helper for the NEB

### DIFF
--- a/client/NudgedElasticBand.h
+++ b/client/NudgedElasticBand.h
@@ -73,4 +73,10 @@ private:
   Parameters *parameters;
 };
 
+namespace helper_functions {
+  namespace neb_paths {
+    std::vector<Matter> linearPath(const Matter& initImg, const Matter& finalImg, const size_t nimgs);
+  }
+}
+
 #endif


### PR DESCRIPTION
This is not wholely clean, since the `linear_path` should be used everywhere instead of just being put for the initialization, but, it is still better, since we need the initial paths anyway for the GP models.