### PR TITLE
ENH: Take in an initial NEB path

### DIFF
--- a/client/ClientEON.cpp
+++ b/client/ClientEON.cpp
@@ -1,4 +1,3 @@
-
 #include "BaseStructures.h"
 #include "Bundling.h"
 #include "CommandLine.h"
@@ -348,8 +347,9 @@ int main(int argc, char **argv) {
 
     printSystemInfo();
 
-    bool bundlingEnabled = true;
-    int bundleSize = getBundleSize();
+    // XXX(rg): Be more gentle here
+    bool bundlingEnabled = false;
+    int bundleSize = -1; // getBundleSize();
     if (bundleSize == 0) {
       bundleSize = 1;
     } else if (bundleSize == -1) {

--- a/client/NudgedElasticBand.cpp
+++ b/client/NudgedElasticBand.cpp
@@ -26,6 +26,40 @@ std::vector<Matter> linearPath(const Matter &initImg, const Matter &finalImg,
   }
   return all_images_on_path;
 }
+
+std::vector<Matter> filePathInit(const std::vector<fs::path> &fsrcs,
+                                 const Matter &refImg, const size_t nimgs) {
+  std::vector<Matter> all_images_on_path;
+  assert(nimgs + 2 == fsrcs.size());
+  all_images_on_path.reserve(nimgs + 2);
+  // For all images
+  for (const auto &filePath : fsrcs) {
+    Matter img(refImg);
+    img.con2matter(filePath.string());
+    all_images_on_path.push_back(img);
+  }
+  return all_images_on_path;
+}
+
+std::vector<fs::path> readFilePaths(const std::string& listFilePath) {
+    std::vector<fs::path> paths;
+    std::ifstream inputFile(listFilePath);
+
+    if (!inputFile.is_open()) {
+        std::cerr << "Error: Could not open path list file: " << listFilePath << std::endl;
+        return paths; // Return empty vector on failure
+    }
+
+    std::string line;
+    while (std::getline(inputFile, line)) {
+        // Skip any empty lines in the input file
+        if (!line.empty()) {
+            paths.emplace_back(line);
+        }
+    }
+
+    return paths;
+}
 } // namespace helper_functions::neb_paths
 
 // NEBObjectiveFunction definitions
@@ -117,8 +151,17 @@ NudgedElasticBand::NudgedElasticBand(
       pot{potPassed} {
   numImages = params->nebImages;
   atoms = initialPassed->numberOfAtoms();
-  auto linear_path = helper_functions::neb_paths::linearPath(
-      *initialPassed, *finalPassed, params->nebImages);
+  std::vector<Matter> initial_path;
+  if (!params->nebIpath.empty()) {
+    SPDLOG_LOGGER_DEBUG(log, "\nNEB: reading initial path from file\n");
+    std::vector<fs::path> file_paths = helper_functions::neb_paths::readFilePaths(params->nebIpath);
+    initial_path = helper_functions::neb_paths::filePathInit(
+        file_paths, *initialPassed, params->nebImages);
+  } else {
+    SPDLOG_LOGGER_DEBUG(log, "\nNEB: initializing with linear path\n");
+    initial_path = helper_functions::neb_paths::linearPath(
+        *initialPassed, *finalPassed, params->nebImages);
+  }
   path.resize(numImages + 2);
   tangent.resize(numImages + 2);
   projectedForce.resize(numImages + 2);
@@ -128,10 +171,9 @@ NudgedElasticBand::NudgedElasticBand(
   numExtrema = 0;
   this->status = NEBStatus::INIT;
   log = spdlog::get("combi");
-  SPDLOG_LOGGER_DEBUG(log, "\nNEB: initializing with linear path\n");
   for (long i = 0; i <= numImages + 1; i++) {
     path[i] = std::make_shared<Matter>(pot, params);
-    *path[i] = linear_path[i];
+    *path[i] = initial_path[i];
     tangent[i] = std::make_shared<AtomMatrix>();
     tangent[i]->resize(atoms, 3);
     projectedForce[i] = std::make_shared<AtomMatrix>();

--- a/client/NudgedElasticBand.cpp
+++ b/client/NudgedElasticBand.cpp
@@ -149,6 +149,8 @@ NudgedElasticBand::NudgedElasticBand(
     std::shared_ptr<Potential> potPassed)
     : params{parametersPassed},
       pot{potPassed} {
+  log = spdlog::get("combi");
+  this->status = NEBStatus::INIT;
   numImages = params->nebImages;
   atoms = initialPassed->numberOfAtoms();
   std::vector<Matter> initial_path;
@@ -169,8 +171,6 @@ NudgedElasticBand::NudgedElasticBand(
   extremumEnergy.resize(2 * (numImages + 1));
   extremumCurvature.resize(2 * (numImages + 1));
   numExtrema = 0;
-  this->status = NEBStatus::INIT;
-  log = spdlog::get("combi");
   for (long i = 0; i <= numImages + 1; i++) {
     path[i] = std::make_shared<Matter>(pot, params);
     *path[i] = initial_path[i];

--- a/client/NudgedElasticBand.cpp
+++ b/client/NudgedElasticBand.cpp
@@ -50,9 +50,7 @@ std::vector<fs::path> readFilePaths(const std::string &listFilePath) {
   std::ifstream inputFile(listFilePath);
 
   if (!inputFile.is_open()) {
-    std::cerr << "Error: Could not open path list file: " << listFilePath
-              << std::endl;
-    return paths; // Return empty vector on failure
+    throw std::runtime_error("Error: Could not open path list file: " + listFilePath);
   }
 
   std::string line;

--- a/client/NudgedElasticBand.h
+++ b/client/NudgedElasticBand.h
@@ -2,6 +2,7 @@
 #define NudgedElasticBand_H
 
 #include <cmath>
+#include <filesystem>
 #include <math.h>
 
 #include "Eigen.h"
@@ -92,6 +93,17 @@ namespace helper_functions {
 namespace neb_paths {
 std::vector<Matter> linearPath(const Matter &initImg, const Matter &finalImg,
                                const size_t nimgs);
+std::vector<Matter> filePathInit(const std::vector<std::filesystem::path> &fsrcs,
+                                 const Matter &refImg,
+                                 const size_t nimgs);
+/**
+ * @brief Reads a file where each line contains a path to another file.
+ *
+ * @param listFilePath The path to the file containing the list of file paths.
+ * @return A vector of filesystem paths. Returns an empty vector if the
+ * file cannot be opened.
+ */
+std::vector<std::filesystem::path> readFilePaths(const std::string& listFilePath);
 }
 } // namespace helper_functions
 

--- a/client/Parameters.cpp
+++ b/client/Parameters.cpp
@@ -272,6 +272,7 @@ Parameters::Parameters() {
   nebEnergyWeighted = false;
   nebKSPMin = 0.97;
   nebKSPMax = 9.7;
+  nebIpath = ""s;
 
   // [Dynamics] //
   mdTimeStepInput = 1.0;
@@ -847,6 +848,7 @@ int Parameters::load(FILE *file) {
                                       nebEnergyWeighted);
     nebKSPMin = ini.GetValueF("Nudged Elastic Band", "ew_ksp_min", nebKSPMin);
     nebKSPMax = ini.GetValueF("Nudged Elastic Band", "ew_ksp_max", nebKSPMax);
+    nebIpath = ini.GetValue("Nudged Elastic Band", "initial_path_in", nebIpath);
 
     // [Dynamics] //
 

--- a/client/Parameters.h
+++ b/client/Parameters.h
@@ -357,6 +357,9 @@ public:
   double nebKSPMax;
   bool nebEnergyWeighted;
 
+  // Initial path
+  string nebIpath; // file containing list of .con files for the initial path
+
   // [Molecular Dynamics] //
   double mdTimeStepInput;
   double mdTimeStep;

--- a/eon/config.yaml
+++ b/eon/config.yaml
@@ -233,6 +233,10 @@ Nudged Elastic Band:
             kind: float
             default: 5.0
 
+        initial_path_in:
+            kind: string
+            default: ""
+
 ################################################################################
 
 Distributed Replica:

--- a/eon/config.yaml
+++ b/eon/config.yaml
@@ -203,7 +203,7 @@ Nudged Elastic Band:
 
         max_iterations:
             kind: int
-            default: 5
+            default: 1000
 
         doubly_nudged:
             kind: boolean
@@ -227,11 +227,11 @@ Nudged Elastic Band:
 
         ew_ksp_min:
             kind: float
-            default: 0.5
+            default: 0.972
 
         ew_ksp_max:
             kind: float
-            default: 5.0
+            default: 9.72
 
         initial_path_in:
             kind: string

--- a/eon/schema.py
+++ b/eon/schema.py
@@ -1399,6 +1399,13 @@ class NudgedElasticBandConfig(BaseModel):
     ew_ksp_max: float = Field(
         default=5.0, description="Maximum value for KSP in the energy-weighted method."
     )
+    initial_path_in: str = Field(
+        default="",
+        description="File from which the initial path is read.",
+    )
+    """
+    This file must contain a list of .con files, one per image on the path.
+    """
 
 
 class LanczosConfig(BaseModel):


### PR DESCRIPTION
Basically there's now a path which can be set which in turn needs to have the list of configurations to be used as the initial path.

Needs:
- [x] Release note
- [ ] ~Example (showing `rgpycrumbs` to generate the path)~ TBD after the cookbook recipe

Closes #223.