### PR TITLE
ENH: Implement an MMF-NEB-CI (RO-NEB-CI)

### DIFF
--- a/client/Parameters.cpp
+++ b/client/Parameters.cpp
@@ -276,6 +276,10 @@ Parameters::Parameters() {
   nebKSPMax = 9.7;
   nebIpath = ""s;
   nebMinimEP = true;
+  nebciAfter = 0.0;
+  nebciWithMMF = false;
+  nebciMMFAfter = 0.5;
+  nebciMMFnSteps = 10;
 
   // [Dynamics] //
   mdTimeStepInput = 1.0;
@@ -856,6 +860,11 @@ int Parameters::load(FILE *file) {
     nebKSPMax = ini.GetValueF("Nudged Elastic Band", "ew_ksp_max", nebKSPMax);
     nebIpath = ini.GetValue("Nudged Elastic Band", "initial_path_in", nebIpath);
     nebMinimEP = ini.GetValueB("Nudged Elastic Band", "minimize_endpoints", nebMinimEP);
+    nebciAfter = ini.GetValueF("Nudged Elastic Band", "ci_after", nebciAfter);
+    nebciWithMMF = ini.GetValueB("Nudged Elastic Band", "ci_mmf", nebciWithMMF);
+    nebciMMFAfter = ini.GetValueF("Nudged Elastic Band", "ci_mmf_after", nebciMMFAfter);
+    nebciMMFnSteps = ini.GetValueL("Nudged Elastic Band", "ci_mmf_nsteps",
+                                     nebciMMFnSteps);
 
     // [Dynamics] //
 

--- a/client/Parameters.cpp
+++ b/client/Parameters.cpp
@@ -690,10 +690,13 @@ int Parameters::load(FILE *file) {
       // Case sensitive!!
       // TODO: This should be handled in clienteon so you can still call
       // eonclient for single point calculations easily
-      metatomic_options.model_path = ini.GetValue("Metatomic", "model_path", "");
+      metatomic_options.model_path =
+          ini.GetValue("Metatomic", "model_path", "");
       metatomic_options.device = ini.GetValue("Metatomic", "device", "cpu");
-      metatomic_options.length_unit = ini.GetValue("Metatomic", "length_unit", "angstrom");
-      metatomic_options.extensions_directory = ini.GetValue("Metatomic", "extensions_directory", "");
+      metatomic_options.length_unit =
+          ini.GetValue("Metatomic", "length_unit", "angstrom");
+      metatomic_options.extensions_directory =
+          ini.GetValue("Metatomic", "extensions_directory", "");
       metatomic_options.check_consistency =
           ini.GetValueB("Metatomic", "check_consistency", false);
     }

--- a/client/Parameters.cpp
+++ b/client/Parameters.cpp
@@ -276,7 +276,7 @@ Parameters::Parameters() {
   nebKSPMax = 9.7;
   nebIpath = ""s;
   nebMinimEP = true;
-  nebciAfter = 0.0;
+  nebciAfter = std::numeric_limits<double>::infinity();
   nebciWithMMF = false;
   nebciMMFAfter = 0.5;
   nebciMMFnSteps = 10;
@@ -500,8 +500,7 @@ int Parameters::load(FILE *file) {
     writeMoviesInterval =
         ini.GetValueL("Debug", "write_movies_interval", writeMoviesInterval);
     estNEBeig = ini.GetValueB("Debug", "estimate_neb_eigenvalues", estNEBeig);
-    nebMMF = toLowerCase(
-        ini.GetValue("Debug", "neb_mmf_estimator", nebMMF));
+    nebMMF = toLowerCase(ini.GetValue("Debug", "neb_mmf_estimator", nebMMF));
 
     // [Structure Comparison] //
 
@@ -859,12 +858,14 @@ int Parameters::load(FILE *file) {
     nebKSPMin = ini.GetValueF("Nudged Elastic Band", "ew_ksp_min", nebKSPMin);
     nebKSPMax = ini.GetValueF("Nudged Elastic Band", "ew_ksp_max", nebKSPMax);
     nebIpath = ini.GetValue("Nudged Elastic Band", "initial_path_in", nebIpath);
-    nebMinimEP = ini.GetValueB("Nudged Elastic Band", "minimize_endpoints", nebMinimEP);
+    nebMinimEP =
+        ini.GetValueB("Nudged Elastic Band", "minimize_endpoints", nebMinimEP);
     nebciAfter = ini.GetValueF("Nudged Elastic Band", "ci_after", nebciAfter);
     nebciWithMMF = ini.GetValueB("Nudged Elastic Band", "ci_mmf", nebciWithMMF);
-    nebciMMFAfter = ini.GetValueF("Nudged Elastic Band", "ci_mmf_after", nebciMMFAfter);
-    nebciMMFnSteps = ini.GetValueL("Nudged Elastic Band", "ci_mmf_nsteps",
-                                     nebciMMFnSteps);
+    nebciMMFAfter =
+        ini.GetValueF("Nudged Elastic Band", "ci_mmf_after", nebciMMFAfter);
+    nebciMMFnSteps =
+        ini.GetValueL("Nudged Elastic Band", "ci_mmf_nsteps", nebciMMFnSteps);
 
     // [Dynamics] //
 

--- a/client/Parameters.h
+++ b/client/Parameters.h
@@ -352,15 +352,20 @@ public:
   bool nebElasticBand;
   double nebConvergedForce; // force convergence criterion required for an
                             // optimization
+  double nebciAfter; // force convergence before ci-neb is used
   // For energy weighted
   double nebKSPMin;
   double nebKSPMax;
   bool nebEnergyWeighted;
 
+  // For hybrid dimer-NEB
+  bool nebciWithMMF;
+  double nebciMMFAfter;
+  long nebciMMFnSteps;
+
   // Initial path
   string nebIpath; // file containing list of .con files for the initial path
-  // Minimize endpoints This is almost always a good idea, not the default to
-  // keep with older timings
+  // Minimize endpoints
   bool nebMinimEP;
 
   // [Molecular Dynamics] //

--- a/eon/config.yaml
+++ b/eon/config.yaml
@@ -191,11 +191,15 @@ Nudged Elastic Band:
 
         climbing_image_method:
             kind: boolean
-            default: False
+            default: true
+
+        climbing_image_converged_only:
+            kind: boolean
+            default: true
 
         old_tangent:
             kind: boolean
-            default: False
+            default: false
 
         opt_method:
             kind: string

--- a/eon/config.yaml
+++ b/eon/config.yaml
@@ -241,6 +241,22 @@ Nudged Elastic Band:
             kind: boolean
             default: true
 
+        ci_after:
+            kind: float
+            default: 0
+
+        ci_mmf:
+            kind: boolean
+            default: false
+
+        ci_mmf_after:
+            kind: float
+            default: 0.5
+
+        ci_mmf_nsteps:
+            kind: int
+            default: 10
+
 ################################################################################
 
 Distributed Replica:

--- a/eon/config.yaml
+++ b/eon/config.yaml
@@ -247,7 +247,7 @@ Nudged Elastic Band:
 
         ci_after:
             kind: float
-            default: 0
+            default: 100000000 # infinity actually
 
         ci_mmf:
             kind: boolean

--- a/eon/schema.py
+++ b/eon/schema.py
@@ -1418,6 +1418,22 @@ class NudgedElasticBandConfig(BaseModel):
         default=True,
         description="Minimize the reactant and product before the NEB.",
     )
+    ci_after: float = Field(
+        default=0,
+        description="Convergence before the CI is turned on.",
+    )
+    ci_mmf: bool = Field(
+        default=False,
+        description="Use an MMF method for a few steps at the CI.",
+    )
+    ci_mmf_after: float = Field(
+        default=0.5,
+        description="Convergence before the CI is turned on.",
+    )
+    ci_mmf_nsteps: int = Field(
+        default=10,
+        description="Number of steps for which the MMF is run at the CI image.",
+    )
 
 
 class LanczosConfig(BaseModel):

--- a/eon/schema.py
+++ b/eon/schema.py
@@ -7,6 +7,7 @@ from pydantic import (
 )
 from typing import Optional, Any, Union
 from typing_extensions import Literal
+import math
 import random
 
 
@@ -1419,7 +1420,7 @@ class NudgedElasticBandConfig(BaseModel):
         description="Minimize the reactant and product before the NEB.",
     )
     ci_after: float = Field(
-        default=0,
+        default=math.inf,
         description="Convergence before the CI is turned on.",
     )
     ci_mmf: bool = Field(


### PR DESCRIPTION
Also known as Rohit's obvious fix for NEB CI (RO-NEB-CI). Closes #222.

This PR introduces a hybrid optimization scheme that enhances the standard Climbing Image Nudged Elastic Band (CI-NEB) method. Once the NEB path is sufficiently relaxed (i.e., the force on the climbing image drops below a threshold), the optimization of the climbing image is handed over to a local MinModeSaddleSearch (MMF) for a few steps. This leverages the global path-finding strength of NEB with the local saddle point finding efficiency of MMF.

## Why.
Standard CI-NEB can sometimes be inefficient at precisely locating the saddle point, especially on flat or complex potential energy surfaces. By switching to a dedicated saddle point optimizer like the Dimer or Lanczos method once in the vicinity of the transition state, this hybrid approach can achieve convergence faster and more reliably.

## Usage
To use the new hybrid method, enable `climbing_image_method` and the new `ci_mmf` flag in your `config.ini` file.

```ini
[Nudged Elastic Band]
images = 10
climbing_image_method = true
converged_force = 0.01

# --- New Hybrid Method Settings ---
# Enable the MMF refinement for the climbing image
ci_mmf = true

# Switch to MMF once the NEB force is below 0.05 eV/A
ci_mmf_after = 0.05

# Run the MMF saddle search for 20 steps
ci_mmf_nsteps = 20

[Saddle Search]
# Specify which method the MMF search should use
min_mode_method = dimer
```