### PR TITLE
MAINT: Fix license again

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2010--present, eON Development Team
+Copyright (c) 2010--present, eOn Development Team
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2010, EON Development Team
+Copyright (c) 2010--present, eON Development Team
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/client/AtomicGPDimer.cpp
+++ b/client/AtomicGPDimer.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 // An interface to the GPDimer library
 
 #include "AtomicGPDimer.h"

--- a/client/AtomicGPDimer.cpp
+++ b/client/AtomicGPDimer.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 // An interface to the GPDimer library
 

--- a/client/AtomicGPDimer.h
+++ b/client/AtomicGPDimer.h
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #ifndef ATOMICGPDIMER_H
 #define ATOMICGPDIMER_H
 

--- a/client/AtomicGPDimer.h
+++ b/client/AtomicGPDimer.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #ifndef ATOMICGPDIMER_H
 #define ATOMICGPDIMER_H

--- a/client/AtomicGPDimer.h
+++ b/client/AtomicGPDimer.h
@@ -9,9 +9,7 @@
 ** Repo:
 ** https://github.com/TheochemUI/eOn
 */
-#ifndef ATOMICGPDIMER_H
-#define ATOMICGPDIMER_H
-
+#pragma once
 #include "Eigen.h"
 #include "LowestEigenmode.h"
 #include "Matter.h"
@@ -51,5 +49,3 @@ private:
   gpr::Observation init_observations, init_middle_point;
   gpr::Coord orient_init, R_init;
 };
-
-#endif

--- a/client/BaseStructures.h
+++ b/client/BaseStructures.h
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #pragma once
 #include <memory>
 #include <string>

--- a/client/BaseStructures.h
+++ b/client/BaseStructures.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 #include <memory>

--- a/client/BasinHoppingJob.cpp
+++ b/client/BasinHoppingJob.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #include <math.h>
 #include <stdio.h>

--- a/client/BasinHoppingJob.cpp
+++ b/client/BasinHoppingJob.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #include <math.h>

--- a/client/BasinHoppingJob.h
+++ b/client/BasinHoppingJob.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 #include "Job.h"

--- a/client/BasinHoppingJob.h
+++ b/client/BasinHoppingJob.h
@@ -1,7 +1,15 @@
-
-#ifndef BASINHOPPINGJOB_H
-#define BASINHOPPINGJOB_H
-
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 #include "Job.h"
 #include "Matter.h"
 #include "Parameters.h"
@@ -35,5 +43,3 @@ private:
   std::vector<double> uniqueEnergies;
   std::shared_ptr<spdlog::logger> log;
 };
-
-#endif

--- a/client/BasinHoppingSaddleSearch.cpp
+++ b/client/BasinHoppingSaddleSearch.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "BasinHoppingSaddleSearch.h"
 #include "Dimer.h"

--- a/client/BasinHoppingSaddleSearch.cpp
+++ b/client/BasinHoppingSaddleSearch.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "BasinHoppingSaddleSearch.h"
 #include "Dimer.h"
 #include "ImprovedDimer.h"

--- a/client/BasinHoppingSaddleSearch.h
+++ b/client/BasinHoppingSaddleSearch.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 #include "Eigen.h"

--- a/client/BasinHoppingSaddleSearch.h
+++ b/client/BasinHoppingSaddleSearch.h
@@ -1,6 +1,15 @@
-#ifndef BASINHOPPINGSADDLESEARCH_H
-#define BASINHOPPINGSADDLESEARCH_H
-
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 #include "Eigen.h"
 #include "Matter.h"
 #include "MinModeSaddleSearch.h"
@@ -37,5 +46,3 @@ public:
 private:
   std::shared_ptr<spdlog::logger> log;
 };
-
-#endif

--- a/client/BiasedGradientSquaredDescent.cpp
+++ b/client/BiasedGradientSquaredDescent.cpp
@@ -1,4 +1,14 @@
-
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "BiasedGradientSquaredDescent.h"
 #include "Dimer.h"
 #include "HelperFunctions.h"

--- a/client/BiasedGradientSquaredDescent.cpp
+++ b/client/BiasedGradientSquaredDescent.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "BiasedGradientSquaredDescent.h"
 #include "Dimer.h"

--- a/client/BiasedGradientSquaredDescent.h
+++ b/client/BiasedGradientSquaredDescent.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 

--- a/client/BiasedGradientSquaredDescent.h
+++ b/client/BiasedGradientSquaredDescent.h
@@ -1,5 +1,15 @@
-#ifndef _BIASED_GRADIENT_SQUARED_DESCENT_
-#define _BIASED_GRADIENT_SQUARED_DESCENT_
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 
 #include "Eigen.h"
 #include "Matter.h"
@@ -38,5 +48,3 @@ private:
   std::shared_ptr<spdlog::logger> log;
   //        double bgsdAlpha;
 };
-
-#endif

--- a/client/BondBoost.cpp
+++ b/client/BondBoost.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #include "BondBoost.h"
 #include "HelperFunctions.h"

--- a/client/BondBoost.cpp
+++ b/client/BondBoost.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #include "BondBoost.h"

--- a/client/BondBoost.h
+++ b/client/BondBoost.h
@@ -1,8 +1,15 @@
-
-#ifndef BONDBOOST_H
-#define BONDBOOST_H
-
-#include "HelperFunctions.h"
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 #include "Matter.h"
 #include "Parameters.h"
 
@@ -55,5 +62,3 @@ public:
   static const char NONE[];
   static const char BOND_BOOST[];
 };
-
-#endif

--- a/client/BondBoost.h
+++ b/client/BondBoost.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 #include "Matter.h"

--- a/client/Bundling.cpp
+++ b/client/Bundling.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #include "Bundling.h"

--- a/client/Bundling.cpp
+++ b/client/Bundling.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #include "Bundling.h"
 

--- a/client/Bundling.h
+++ b/client/Bundling.h
@@ -1,5 +1,15 @@
-#ifndef BUNDLING_H
-#define BUNDLING_H
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 #include <string>
 #include <vector>
 
@@ -8,4 +18,3 @@ std::vector<std::string> unbundle(int number);
 void bundle(int number, const std::vector<std::string> &filenames,
             std::vector<std::string> *bundledFilenames);
 void deleteUnbundledFiles(const std::vector<std::string> &unbundledFilenames);
-#endif

--- a/client/Bundling.h
+++ b/client/Bundling.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 #include <string>

--- a/client/ClientEON.cpp
+++ b/client/ClientEON.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "BaseStructures.h"
 #include "Bundling.h"
 #include "CommandLine.h"

--- a/client/ClientEON.cpp
+++ b/client/ClientEON.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "BaseStructures.h"
 #include "Bundling.h"

--- a/client/CommandLine.cpp
+++ b/client/CommandLine.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "CommandLine.h"
 #include "Matter.h"
@@ -50,7 +50,7 @@ void commandLine(int argc, char **argv) {
 
   auto params = std::make_shared<Parameters>();
 
-  cxxopts::Options options("eonclient", "The eON client");
+  cxxopts::Options options("eonclient", "The eOn client");
   options.add_options()("v,version", "Print version information")(
       "m,minimize", "Minimization of inputConfile saves to outputConfile")(
       "s,single", "Single point energy of inputConfile")(

--- a/client/CommandLine.cpp
+++ b/client/CommandLine.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "CommandLine.h"
 #include "Matter.h"
 #include "Parameters.h"

--- a/client/CommandLine.h
+++ b/client/CommandLine.h
@@ -1,8 +1,15 @@
-#ifndef COMMANDLINE_H
-#define COMMANDLINE_H
-
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 #include <thirdparty/cxxopts.hpp>
 
 void commandLine(int argc, char **argv);
-
-#endif

--- a/client/CommandLine.h
+++ b/client/CommandLine.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 #include <thirdparty/cxxopts.hpp>

--- a/client/ConjugateGradients.cpp
+++ b/client/ConjugateGradients.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "ConjugateGradients.h"
 

--- a/client/ConjugateGradients.cpp
+++ b/client/ConjugateGradients.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "ConjugateGradients.h"
 
 Eigen::VectorXd ConjugateGradients::getStep() {

--- a/client/ConjugateGradients.h
+++ b/client/ConjugateGradients.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 #include "Eigen.h"

--- a/client/ConjugateGradients.h
+++ b/client/ConjugateGradients.h
@@ -1,6 +1,15 @@
-#ifndef CG_H
-#define CG_H
-
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 #include "Eigen.h"
 #include "HelperFunctions.h"
 #include "Matter.h"
@@ -90,5 +99,3 @@ private:
    */
   int line_search(double a_maxMove);
 };
-
-#endif

--- a/client/Dimer.cpp
+++ b/client/Dimer.cpp
@@ -1,4 +1,16 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "Dimer.h"
+#include "HelperFunctions.h"
 
 using namespace helper_functions;
 

--- a/client/Dimer.cpp
+++ b/client/Dimer.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "Dimer.h"
 #include "HelperFunctions.h"

--- a/client/Dimer.h
+++ b/client/Dimer.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 #include "LowestEigenmode.h"

--- a/client/Dimer.h
+++ b/client/Dimer.h
@@ -1,7 +1,15 @@
-#ifndef DIMER_H
-#define DIMER_H
-
-#include "HelperFunctions.h"
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 #include "LowestEigenmode.h"
 #include "Matter.h"
 #include "Parameters.h"
@@ -43,5 +51,3 @@ private:
       AtomMatrix &forceDiffOrthogonalToDimer); // determine the rotational force
                                                // on the dimer
 };
-
-#endif

--- a/client/Dynamics.cpp
+++ b/client/Dynamics.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "Dynamics.h"
 #include <math.h>

--- a/client/Dynamics.cpp
+++ b/client/Dynamics.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "Dynamics.h"
 #include <math.h>
 

--- a/client/Dynamics.h
+++ b/client/Dynamics.h
@@ -9,8 +9,7 @@
 ** Repo:
 ** https://github.com/TheochemUI/eOn
 */
-#ifndef DYNAMICS_H
-#define DYNAMICS_H
+#pragma once
 
 #include "HelperFunctions.h"
 #include "Matter.h"
@@ -53,5 +52,3 @@ private:
   double vxi1, vxi2, xi1, xi2;
   std::shared_ptr<spdlog::logger> log;
 };
-
-#endif

--- a/client/Dynamics.h
+++ b/client/Dynamics.h
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #ifndef DYNAMICS_H
 #define DYNAMICS_H
 

--- a/client/Dynamics.h
+++ b/client/Dynamics.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #ifndef DYNAMICS_H
 #define DYNAMICS_H

--- a/client/DynamicsJob.cpp
+++ b/client/DynamicsJob.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include <stdio.h>
 #include <string>
 

--- a/client/DynamicsJob.cpp
+++ b/client/DynamicsJob.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include <stdio.h>
 #include <string>

--- a/client/DynamicsJob.h
+++ b/client/DynamicsJob.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 #include "Job.h"

--- a/client/DynamicsJob.h
+++ b/client/DynamicsJob.h
@@ -1,6 +1,15 @@
-#ifndef DYNAMICSJOB_H
-#define DYNAMICSJOB_H
-
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 #include "Job.h"
 #include "Matter.h"
 #include "Parameters.h"
@@ -14,5 +23,3 @@ public:
   std::vector<std::string> run(void);
   std::vector<std::string> returnFiles;
 };
-
-#endif

--- a/client/DynamicsSaddleSearch.cpp
+++ b/client/DynamicsSaddleSearch.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "DynamicsSaddleSearch.h"
 #include "BondBoost.h"

--- a/client/DynamicsSaddleSearch.cpp
+++ b/client/DynamicsSaddleSearch.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "DynamicsSaddleSearch.h"
 #include "BondBoost.h"
 #include "Dimer.h"

--- a/client/DynamicsSaddleSearch.h
+++ b/client/DynamicsSaddleSearch.h
@@ -1,6 +1,15 @@
-#ifndef DYNAMICSSADDLESEARCH_H
-#define DYNAMICSSADDLESEARCH_H
-
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 #include "Eigen.h"
 #include "Matter.h"
 #include "MinModeSaddleSearch.h"
@@ -43,5 +52,3 @@ public:
 private:
   std::shared_ptr<spdlog::logger> log;
 };
-
-#endif

--- a/client/DynamicsSaddleSearch.h
+++ b/client/DynamicsSaddleSearch.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 #include "Eigen.h"

--- a/client/Eigen.h
+++ b/client/Eigen.h
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 2 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #ifndef EIGEN_H
 #define EIGEN_H

--- a/client/Eigen.h
+++ b/client/Eigen.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #ifndef EIGEN_H

--- a/client/Eigen.h
+++ b/client/Eigen.h
@@ -9,9 +9,8 @@
 ** Repo:
 ** https://github.com/TheochemUI/eOn
 */
+#pragma once
 
-#ifndef EIGEN_H
-#define EIGEN_H
 #define EIGEN_DEFAULT_TO_ROW_MAJOR
 // #define EIGEN2_SUPPORT
 #include <Eigen/Dense>
@@ -20,4 +19,3 @@ using namespace Eigen;
 
 typedef Eigen::Matrix<double, Eigen::Dynamic, 3> AtomMatrix;
 typedef Eigen::Matrix<double, 3, 3> RotationMatrix;
-#endif

--- a/client/EnvHelpers.hpp
+++ b/client/EnvHelpers.hpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 #include <string>

--- a/client/EnvHelpers.hpp
+++ b/client/EnvHelpers.hpp
@@ -1,6 +1,15 @@
-#ifndef ENVHELPERS_H_
-#define ENVHELPERS_H_
-
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 #include <string>
 
 namespace helper_functions {
@@ -10,5 +19,3 @@ std::string get_value_from_env_or_param(const char *env_variable,
                                         const std::string &warning_message = "",
                                         const bool is_mandatory = false);
 }
-
-#endif // ENVHELPERS_H_

--- a/client/EpiCenters.cpp
+++ b/client/EpiCenters.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "EpiCenters.h"
 #include "HelperFunctions.h"

--- a/client/EpiCenters.cpp
+++ b/client/EpiCenters.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "EpiCenters.h"
 #include "HelperFunctions.h"
 

--- a/client/EpiCenters.h
+++ b/client/EpiCenters.h
@@ -1,6 +1,15 @@
-#ifndef EPI_CENTERS_H
-#define EPI_CENTERS_H
-
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 #include "Matter.h"
 
 namespace EpiCenters {
@@ -37,4 +46,3 @@ void coordinationLessOrEqual(bool *result, long coordinationMaxVal,
 // determine first minimally coordinated atom
 long minCoordination(const Matter *matter, double neighborCutoff);
 } // namespace EpiCenters
-#endif

--- a/client/EpiCenters.h
+++ b/client/EpiCenters.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 #include "Matter.h"

--- a/client/FIRE.cpp
+++ b/client/FIRE.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "FIRE.h"
 #include "HelperFunctions.h"

--- a/client/FIRE.cpp
+++ b/client/FIRE.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "FIRE.h"
 #include "HelperFunctions.h"
 

--- a/client/FIRE.h
+++ b/client/FIRE.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 #include "Optimizer.h"

--- a/client/FIRE.h
+++ b/client/FIRE.h
@@ -1,7 +1,15 @@
-#ifndef FIRE_H
-#define FIRE_H
-
-#include "Matter.h"
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 #include "Optimizer.h"
 #include "Parameters.h"
 
@@ -47,5 +55,3 @@ private:
   size_t m_iteration;
   shared_ptr<spdlog::logger> m_log;
 };
-
-#endif

--- a/client/FiniteDifferenceJob.cpp
+++ b/client/FiniteDifferenceJob.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "FiniteDifferenceJob.h"
 #include "EpiCenters.h"
 #include "HelperFunctions.h"

--- a/client/FiniteDifferenceJob.cpp
+++ b/client/FiniteDifferenceJob.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "FiniteDifferenceJob.h"
 #include "EpiCenters.h"

--- a/client/FiniteDifferenceJob.h
+++ b/client/FiniteDifferenceJob.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 #include "Job.h"

--- a/client/FiniteDifferenceJob.h
+++ b/client/FiniteDifferenceJob.h
@@ -1,7 +1,15 @@
-#ifndef FINITEDIFFERENCE_H
-#define FINITEDIFFERENCE_H
-
-#include "Eigen.h"
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 #include "Job.h"
 #include "Parameters.h"
 
@@ -12,5 +20,3 @@ public:
   ~FiniteDifferenceJob(void) = default;
   std::vector<std::string> run(void);
 };
-
-#endif

--- a/client/GPRHelpers.cpp
+++ b/client/GPRHelpers.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "GPRHelpers.h"
 

--- a/client/GPRHelpers.cpp
+++ b/client/GPRHelpers.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "GPRHelpers.h"
 
 #include <map>

--- a/client/GPRHelpers.h
+++ b/client/GPRHelpers.h
@@ -1,6 +1,15 @@
-#ifndef GPRHELPERS_H
-#define GPRHELPERS_H
-
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 #include "Matter.h"
 #include "Parameters.h"
 
@@ -36,4 +45,3 @@ gpr::AtomsConfiguration eon_matter_to_atmconf(Matter *matter);
 gpr::Observation eon_matter_to_init_obs(Matter *matter);
 
 } // namespace helper_functions
-#endif /* GPRHELPERS_H */

--- a/client/GPRHelpers.h
+++ b/client/GPRHelpers.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 #include "Matter.h"

--- a/client/GPSurrogateJob.cpp
+++ b/client/GPSurrogateJob.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "GPSurrogateJob.h"
 #include "BaseStructures.h"

--- a/client/GPSurrogateJob.cpp
+++ b/client/GPSurrogateJob.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "GPSurrogateJob.h"
 #include "BaseStructures.h"
 #include "NudgedElasticBand.h"

--- a/client/GPSurrogateJob.h
+++ b/client/GPSurrogateJob.h
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #pragma once
 
 #include "HelperFunctions.h"

--- a/client/GPSurrogateJob.h
+++ b/client/GPSurrogateJob.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 

--- a/client/GlobalOptimization.cpp
+++ b/client/GlobalOptimization.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "GlobalOptimization.h"
 #include <stdio.h>
 

--- a/client/GlobalOptimization.cpp
+++ b/client/GlobalOptimization.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "GlobalOptimization.h"
 #include <stdio.h>

--- a/client/GlobalOptimization.h
+++ b/client/GlobalOptimization.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 #include "Parameters.h"

--- a/client/GlobalOptimization.h
+++ b/client/GlobalOptimization.h
@@ -1,5 +1,15 @@
-#ifndef GLOBALOPTIMIZATION_H
-#define GLOBALOPTIMIZATION_H
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 #include "Parameters.h"
 
 class GlobalOptimization {
@@ -11,5 +21,3 @@ public:
 private:
   Parameters *parameters;
 };
-
-#endif

--- a/client/GlobalOptimizationJob.cpp
+++ b/client/GlobalOptimizationJob.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "GlobalOptimizationJob.h"
 #include "GlobalOptimization.h"
 // #include "MinimizationJob.h"

--- a/client/GlobalOptimizationJob.cpp
+++ b/client/GlobalOptimizationJob.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "GlobalOptimizationJob.h"
 #include "GlobalOptimization.h"

--- a/client/GlobalOptimizationJob.h
+++ b/client/GlobalOptimizationJob.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 #include "Job.h"

--- a/client/GlobalOptimizationJob.h
+++ b/client/GlobalOptimizationJob.h
@@ -1,6 +1,15 @@
-#ifndef GLOBALOPTIMIZATION_HJOB_H
-#define GLOBALOPTIMIZATION_HJOB_H
-
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 #include "Job.h"
 #include "Matter.h"
 #include "Parameters.h"
@@ -66,5 +75,3 @@ private:
   FILE *earrfile;
   std::shared_ptr<spdlog::logger> log;
 };
-
-#endif

--- a/client/HelperFunctions.cpp
+++ b/client/HelperFunctions.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "HelperFunctions.h"
 
 #include <cassert>

--- a/client/HelperFunctions.cpp
+++ b/client/HelperFunctions.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "HelperFunctions.h"
 

--- a/client/HelperFunctions.h
+++ b/client/HelperFunctions.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 #include "Eigen.h"

--- a/client/HelperFunctions.h
+++ b/client/HelperFunctions.h
@@ -1,6 +1,15 @@
-#ifndef HELPER_FUNCTIONS_H
-#define HELPER_FUNCTIONS_H
-
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 #include "Eigen.h"
 #include "Matter.h"
 #include <string>
@@ -87,4 +96,3 @@ bool sortedR(const Matter &m1, const Matter &m2,
 void pushApart(std::shared_ptr<Matter> m1, double minDistance);
 
 } // namespace helper_functions
-#endif

--- a/client/Hessian.cpp
+++ b/client/Hessian.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "Hessian.h"
 #include "HelperFunctions.h"
 Hessian::Hessian(Parameters *params, Matter *matter) {

--- a/client/Hessian.cpp
+++ b/client/Hessian.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "Hessian.h"
 #include "HelperFunctions.h"

--- a/client/Hessian.h
+++ b/client/Hessian.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 #include "Eigen.h"

--- a/client/Hessian.h
+++ b/client/Hessian.h
@@ -1,6 +1,15 @@
-#ifndef HESSIAN_H
-#define HESSIAN_H
-
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 #include "Eigen.h"
 
 #include "Matter.h"
@@ -29,5 +38,3 @@ private:
   bool calculate(void);
   std::shared_ptr<spdlog::logger> log;
 };
-
-#endif

--- a/client/HessianJob.cpp
+++ b/client/HessianJob.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "HessianJob.h"
 #include "Hessian.h"
 #include "Matter.h"

--- a/client/HessianJob.cpp
+++ b/client/HessianJob.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "HessianJob.h"
 #include "Hessian.h"

--- a/client/HessianJob.h
+++ b/client/HessianJob.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 #include "Job.h"

--- a/client/HessianJob.h
+++ b/client/HessianJob.h
@@ -1,6 +1,15 @@
-#ifndef HESSIANJOB_H
-#define HESSIANJOB_H
-
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 #include "Job.h"
 #include "Parameters.h"
 
@@ -11,5 +20,3 @@ public:
   ~HessianJob(void) = default;
   std::vector<std::string> run(void);
 };
-
-#endif

--- a/client/ImprovedDimer.cpp
+++ b/client/ImprovedDimer.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 // An implementation of Johannes Kästner and Paul Sherwood's improved dimer.
 // An attempt to keep to the variable names in their 2008 paper has been made.

--- a/client/ImprovedDimer.cpp
+++ b/client/ImprovedDimer.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 // An implementation of Johannes Kästner and Paul Sherwood's improved dimer.
 // An attempt to keep to the variable names in their 2008 paper has been made.
 

--- a/client/ImprovedDimer.h
+++ b/client/ImprovedDimer.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 #include "Eigen.h"

--- a/client/ImprovedDimer.h
+++ b/client/ImprovedDimer.h
@@ -1,6 +1,15 @@
-#ifndef IMPROVEDDIMER_H
-#define IMPROVEDDIMER_H
-
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 #include "Eigen.h"
 #include "LowestEigenmode.h"
 #include "Matter.h"
@@ -53,5 +62,3 @@ public:
   std::vector<VectorXd> gradients;
   std::vector<VectorXd> positions;
 };
-
-#endif

--- a/client/Job.cpp
+++ b/client/Job.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "Job.h"
 #include "BasinHoppingJob.h"

--- a/client/Job.cpp
+++ b/client/Job.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "Job.h"
 #include "BasinHoppingJob.h"
 #include "DynamicsJob.h"

--- a/client/Job.h
+++ b/client/Job.h
@@ -1,5 +1,15 @@
-#ifndef JOB_H
-#define JOB_H
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 #include "Parameters.h"
 #include "Potential.h"
 #include <string>
@@ -59,4 +69,3 @@ public:
 namespace helper_functions {
 std::unique_ptr<Job> makeJob(std::unique_ptr<Parameters> params);
 } // namespace helper_functions
-#endif

--- a/client/Job.h
+++ b/client/Job.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 #include "Parameters.h"

--- a/client/LBFGS.cpp
+++ b/client/LBFGS.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 // Based on the LBFGS minimizer written in ASE.
 
 #include "LBFGS.h"

--- a/client/LBFGS.cpp
+++ b/client/LBFGS.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 // Based on the LBFGS minimizer written in ASE.
 

--- a/client/LBFGS.h
+++ b/client/LBFGS.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 

--- a/client/LBFGS.h
+++ b/client/LBFGS.h
@@ -1,5 +1,15 @@
-#ifndef LBFGS_H
-#define LBFGS_H
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 
 #include "HelperFunctions.h"
 #include "Matter.h"
@@ -49,5 +59,3 @@ private:
   Eigen::VectorXd m_fPrev;
   std::shared_ptr<spdlog::logger> m_log;
 };
-
-#endif

--- a/client/Lanczos.cpp
+++ b/client/Lanczos.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 // This Lanczos algorithm is implemented as described in this paper:
 // R. A. Olsen, G. J. Kroes, G. Henkelman, A. Arnaldsson, and H. Jónsson,

--- a/client/Lanczos.cpp
+++ b/client/Lanczos.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 // This Lanczos algorithm is implemented as described in this paper:
 // R. A. Olsen, G. J. Kroes, G. Henkelman, A. Arnaldsson, and H. Jónsson,
 // Comparison of methods for finding saddle points without knowledge of the

--- a/client/Lanczos.h
+++ b/client/Lanczos.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 #include "Eigen.h"

--- a/client/Lanczos.h
+++ b/client/Lanczos.h
@@ -1,6 +1,15 @@
-#ifndef LANCZOS_H
-#define LANCZOS_H
-
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 #include "Eigen.h"
 #include "LowestEigenmode.h"
 #include "Matter.h"
@@ -22,5 +31,3 @@ private:
   double lowestEw;
   shared_ptr<spdlog::logger> log;
 };
-
-#endif

--- a/client/LowestEigenmode.cpp
+++ b/client/LowestEigenmode.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "LowestEigenmode.h"
 

--- a/client/LowestEigenmode.cpp
+++ b/client/LowestEigenmode.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "LowestEigenmode.h"
 
 const char LowestEigenmode::MINMODE_DIMER[] = "dimer";

--- a/client/LowestEigenmode.h
+++ b/client/LowestEigenmode.h
@@ -1,5 +1,15 @@
-#ifndef LOWESTEIGENMODE_H
-#define LOWESTEIGENMODE_H
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 
 #include "Eigen.h"
 #include "Matter.h"
@@ -36,5 +46,3 @@ public:
   virtual double getEigenvalue() = 0;
   virtual AtomMatrix getEigenvector() = 0;
 };
-
-#endif

--- a/client/LowestEigenmode.h
+++ b/client/LowestEigenmode.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 

--- a/client/MatrixHelpers.hpp
+++ b/client/MatrixHelpers.hpp
@@ -1,6 +1,15 @@
-#ifndef MATRIXHELPERS_H
-#define MATRIXHELPERS_H
-
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 #include "Matter.h"
 #include "Parameters.h"
 
@@ -18,4 +27,3 @@ bool eigenEquality(const Eigen::MatrixBase<T> &lhs,
   return lhs.isApprox(rhs, threshold);
 }
 } // namespace helper_functions
-#endif /* MATRIXHELPERS_H */

--- a/client/MatrixHelpers.hpp
+++ b/client/MatrixHelpers.hpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 #include "Matter.h"

--- a/client/Matter.cpp
+++ b/client/Matter.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "Matter.h"
 #include "BaseStructures.h"
 #include "BondBoost.h"

--- a/client/Matter.cpp
+++ b/client/Matter.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "Matter.h"
 #include "BaseStructures.h"

--- a/client/Matter.h
+++ b/client/Matter.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 #include "Eigen.h"

--- a/client/Matter.h
+++ b/client/Matter.h
@@ -1,6 +1,15 @@
-#ifndef MATTER_H
-#define MATTER_H
-
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 #include "Eigen.h"
 #include "Parameters.h"
 #include "Potential.h"
@@ -218,5 +227,3 @@ private:
   mutable double energyVariance;
   mutable double potentialEnergy;
 };
-
-#endif

--- a/client/MinModeSaddleSearch.cpp
+++ b/client/MinModeSaddleSearch.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "MinModeSaddleSearch.h"
 #include "ConjugateGradients.h"
 #include "Dimer.h"

--- a/client/MinModeSaddleSearch.cpp
+++ b/client/MinModeSaddleSearch.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "MinModeSaddleSearch.h"
 #include "ConjugateGradients.h"

--- a/client/MinModeSaddleSearch.h
+++ b/client/MinModeSaddleSearch.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 

--- a/client/MinModeSaddleSearch.h
+++ b/client/MinModeSaddleSearch.h
@@ -1,5 +1,15 @@
-#ifndef MIN_MODE_SADDLE_SEARCH_H
-#define MIN_MODE_SADDLE_SEARCH_H
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 
 #include "Eigen.h"
 #include "LowestEigenmode.h"
@@ -58,5 +68,3 @@ private:
   double reactantEnergy;
   shared_ptr<spdlog::logger> log;
 };
-
-#endif

--- a/client/MinimizationJob.cpp
+++ b/client/MinimizationJob.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "MinimizationJob.h"
 #include "BaseStructures.h"
 #include "HelperFunctions.h"

--- a/client/MinimizationJob.cpp
+++ b/client/MinimizationJob.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "MinimizationJob.h"
 #include "BaseStructures.h"

--- a/client/MinimizationJob.h
+++ b/client/MinimizationJob.h
@@ -1,5 +1,15 @@
-#ifndef MINIMAZATIONJOB_H
-#define MINIMAZATIONJOB_H
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 
 #include "Job.h"
 #include "Parameters.h"
@@ -18,5 +28,3 @@ private:
   RunStatus status;
   shared_ptr<spdlog::logger> log;
 };
-
-#endif

--- a/client/MinimizationJob.h
+++ b/client/MinimizationJob.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 

--- a/client/MonteCarlo.cpp
+++ b/client/MonteCarlo.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "MonteCarlo.h"
 

--- a/client/MonteCarlo.cpp
+++ b/client/MonteCarlo.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "MonteCarlo.h"
 
 using namespace helper_functions;

--- a/client/MonteCarlo.h
+++ b/client/MonteCarlo.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 

--- a/client/MonteCarlo.h
+++ b/client/MonteCarlo.h
@@ -1,5 +1,15 @@
-#ifndef MONTECARLO_H
-#define MONTECARLO_H
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 
 #include "HelperFunctions.h"
 #include "Matter.h"
@@ -23,5 +33,3 @@ private:
   std::shared_ptr<Parameters> params;
   shared_ptr<spdlog::logger> log;
 };
-
-#endif

--- a/client/MonteCarloJob.cpp
+++ b/client/MonteCarloJob.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "MonteCarloJob.h"
 #include "HelperFunctions.h"
 #include "Matter.h"

--- a/client/MonteCarloJob.cpp
+++ b/client/MonteCarloJob.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "MonteCarloJob.h"
 #include "HelperFunctions.h"

--- a/client/MonteCarloJob.h
+++ b/client/MonteCarloJob.h
@@ -1,5 +1,15 @@
-#ifndef MONTECARLOJOB_H
-#define MONTECARLOJOB_H
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 
 #include "Job.h"
 #include "Parameters.h"
@@ -16,5 +26,3 @@ public:
 private:
   std::shared_ptr<spdlog::logger> log;
 };
-
-#endif

--- a/client/MonteCarloJob.h
+++ b/client/MonteCarloJob.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 

--- a/client/NudgedElasticBand.cpp
+++ b/client/NudgedElasticBand.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "NudgedElasticBand.h"
 #include "BaseStructures.h"
 #include "ImprovedDimer.h"

--- a/client/NudgedElasticBand.cpp
+++ b/client/NudgedElasticBand.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "NudgedElasticBand.h"
 #include "BaseStructures.h"

--- a/client/NudgedElasticBand.h
+++ b/client/NudgedElasticBand.h
@@ -1,9 +1,17 @@
-#ifndef NudgedElasticBand_H
-#define NudgedElasticBand_H
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 
-#include <cmath>
 #include <filesystem>
-#include <math.h>
 
 #include "Eigen.h"
 
@@ -108,5 +116,3 @@ std::vector<std::filesystem::path>
 readFilePaths(const std::string &listFilePath);
 } // namespace neb_paths
 } // namespace helper_functions
-
-#endif

--- a/client/NudgedElasticBand.h
+++ b/client/NudgedElasticBand.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 

--- a/client/NudgedElasticBandJob.cpp
+++ b/client/NudgedElasticBandJob.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "NudgedElasticBandJob.h"
 #include "ConjugateGradients.h"

--- a/client/NudgedElasticBandJob.cpp
+++ b/client/NudgedElasticBandJob.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "NudgedElasticBandJob.h"
 #include "ConjugateGradients.h"
 #include "Potential.h"

--- a/client/NudgedElasticBandJob.h
+++ b/client/NudgedElasticBandJob.h
@@ -1,5 +1,15 @@
-#ifndef NEBJOB_H
-#define NEBJOB_H
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 
 #include "Job.h"
 #include "Matter.h"
@@ -26,5 +36,3 @@ private:
   size_t fCallsNEB;
   std::shared_ptr<spdlog::logger> m_log;
 };
-
-#endif

--- a/client/NudgedElasticBandJob.h
+++ b/client/NudgedElasticBandJob.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 

--- a/client/ObjectiveFunction.h
+++ b/client/ObjectiveFunction.h
@@ -1,5 +1,15 @@
-#ifndef OBJECTIVE_FUNCTION_H
-#define OBJECTIVE_FUNCTION_H
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 
 #include "Dimer.h"
 #include "ImprovedDimer.h"
@@ -30,5 +40,3 @@ public:
   virtual double getConvergence() = 0;
   virtual VectorXd difference(VectorXd a, VectorXd b) = 0;
 };
-
-#endif

--- a/client/ObjectiveFunction.h
+++ b/client/ObjectiveFunction.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 

--- a/client/Optimizer.cpp
+++ b/client/Optimizer.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "Optimizer.h"
 #include "BaseStructures.h"
 #include "ConjugateGradients.h"

--- a/client/Optimizer.cpp
+++ b/client/Optimizer.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "Optimizer.h"
 #include "BaseStructures.h"

--- a/client/Optimizer.h
+++ b/client/Optimizer.h
@@ -1,5 +1,15 @@
-#ifndef OPTIMIZER_H
-#define OPTIMIZER_H
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 
 #include "Eigen.h"
 #include "ObjectiveFunction.h"
@@ -72,5 +82,3 @@ std::unique_ptr<Optimizer> mkOptim(std::shared_ptr<ObjectiveFunction> a_objf,
                                    OptType a_otype,
                                    std::shared_ptr<Parameters> a_params);
 }
-
-#endif

--- a/client/Optimizer.h
+++ b/client/Optimizer.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 

--- a/client/ParallelReplicaJob.cpp
+++ b/client/ParallelReplicaJob.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include <algorithm>
 #include <cstdlib>

--- a/client/ParallelReplicaJob.cpp
+++ b/client/ParallelReplicaJob.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include <algorithm>
 #include <cstdlib>
 

--- a/client/ParallelReplicaJob.h
+++ b/client/ParallelReplicaJob.h
@@ -1,5 +1,15 @@
-#ifndef PARALLELREPLICAJOB_H
-#define PARALLELREPLICAJOB_H
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 
 #include "Job.h"
 #include "Parameters.h"
@@ -21,5 +31,3 @@ private:
   int refineTransition(std::vector<Matter *> MDSnapshots, bool fake = false);
   std::shared_ptr<spdlog::logger> log;
 };
-
-#endif

--- a/client/ParallelReplicaJob.h
+++ b/client/ParallelReplicaJob.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 

--- a/client/Parameters.cpp
+++ b/client/Parameters.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "Parameters.h"
 #include "BaseStructures.h"

--- a/client/Parameters.cpp
+++ b/client/Parameters.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "Parameters.h"
 #include "BaseStructures.h"
 #include "BondBoost.h"

--- a/client/Parameters.h
+++ b/client/Parameters.h
@@ -1,5 +1,15 @@
-#ifndef PARAMETERS_H
-#define PARAMETERS_H
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 
 #include "BaseStructures.h"
 #include <cstring>
@@ -500,5 +510,3 @@ public:
 private:
   string toLowerCase(string s);
 };
-
-#endif

--- a/client/Parameters.h
+++ b/client/Parameters.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 

--- a/client/PointJob.cpp
+++ b/client/PointJob.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "PointJob.h"
 #include "Matter.h"
 

--- a/client/PointJob.cpp
+++ b/client/PointJob.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "PointJob.h"
 #include "Matter.h"

--- a/client/PointJob.h
+++ b/client/PointJob.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 

--- a/client/PointJob.h
+++ b/client/PointJob.h
@@ -1,5 +1,15 @@
-#ifndef POINTJOB_H
-#define POINTJOB_H
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 
 #include "Job.h"
 #include "Parameters.h"
@@ -16,5 +26,3 @@ public:
 private:
   std::shared_ptr<spdlog::logger> log;
 };
-
-#endif

--- a/client/Potential.cpp
+++ b/client/Potential.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include <csignal>
 #include <limits>

--- a/client/Potential.cpp
+++ b/client/Potential.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include <csignal>
 #include <limits>
 #include <time.h>

--- a/client/Potential.h
+++ b/client/Potential.h
@@ -1,5 +1,15 @@
-#ifndef POTENTIAL_H
-#define POTENTIAL_H
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 
 #include "Eigen.h"
 #include "Parameters.h"
@@ -75,5 +85,3 @@ std::shared_ptr<Potential> makePotential(std::shared_ptr<Parameters> params);
 std::shared_ptr<Potential> makePotential(PotType ptype,
                                          std::shared_ptr<Parameters> params);
 } // namespace helper_functions
-
-#endif

--- a/client/Potential.h
+++ b/client/Potential.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 

--- a/client/Prefactor.cpp
+++ b/client/Prefactor.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "Prefactor.h"
 #include "Hessian.h"

--- a/client/Prefactor.cpp
+++ b/client/Prefactor.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "Prefactor.h"
 #include "Hessian.h"
 

--- a/client/Prefactor.h
+++ b/client/Prefactor.h
@@ -1,6 +1,15 @@
-
-#ifndef PREFACTOR_H
-#define PREFACTOR_H
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 
 #include "Eigen.h"
 #include "Matter.h"
@@ -23,4 +32,3 @@ VectorXi allFreeAtoms(Matter *matter);
 VectorXd removeZeroFreqs(Parameters *parameters, VectorXd freqs);
 void logFreqs(VectorXd freqs, char *name);
 } // namespace Prefactor
-#endif

--- a/client/Prefactor.h
+++ b/client/Prefactor.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 

--- a/client/PrefactorJob.cpp
+++ b/client/PrefactorJob.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "PrefactorJob.h"
 #include "Hessian.h"

--- a/client/PrefactorJob.cpp
+++ b/client/PrefactorJob.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "PrefactorJob.h"
 #include "Hessian.h"
 #include "Matter.h"

--- a/client/PrefactorJob.h
+++ b/client/PrefactorJob.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 

--- a/client/PrefactorJob.h
+++ b/client/PrefactorJob.h
@@ -1,6 +1,15 @@
-
-#ifndef PREFACTORJOB_H
-#define PREFACTORJOB_H
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 
 #include "Job.h"
 #include "Parameters.h"
@@ -16,5 +25,3 @@ public:
   static const char PREFACTOR_SADDLE[];
   static const char PREFACTOR_PRODUCT[];
 };
-
-#endif

--- a/client/ProcessSearchJob.cpp
+++ b/client/ProcessSearchJob.cpp
@@ -1,6 +1,18 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "ProcessSearchJob.h"
 #include "BasinHoppingSaddleSearch.h"
 #include "BiasedGradientSquaredDescent.h"
+#include "HelperFunctions.h"
 #include "DynamicsSaddleSearch.h"
 #include "EpiCenters.h"
 #include "MinModeSaddleSearch.h"

--- a/client/ProcessSearchJob.cpp
+++ b/client/ProcessSearchJob.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "ProcessSearchJob.h"
 #include "BasinHoppingSaddleSearch.h"

--- a/client/ProcessSearchJob.h
+++ b/client/ProcessSearchJob.h
@@ -1,6 +1,15 @@
-
-#ifndef PROCESSSEARCHJOB_H
-#define PROCESSSEARCHJOB_H
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 
 #include "Job.h"
 #include "Matter.h"
@@ -96,5 +105,3 @@ private:
   //! Force calls to find the prefactors
   size_t fCallsPrefactors;
 };
-
-#endif

--- a/client/ProcessSearchJob.h
+++ b/client/ProcessSearchJob.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 

--- a/client/Quickmin.cpp
+++ b/client/Quickmin.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "Quickmin.h"
 #include "HelperFunctions.h"
 

--- a/client/Quickmin.cpp
+++ b/client/Quickmin.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "Quickmin.h"
 #include "HelperFunctions.h"

--- a/client/Quickmin.h
+++ b/client/Quickmin.h
@@ -1,5 +1,15 @@
-#ifndef QUICKMIN_H
-#define QUICKMIN_H
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 
 #include "Matter.h"
 #include "Optimizer.h"
@@ -36,5 +46,3 @@ private:
   size_t m_iteration, m_max_iter;
   shared_ptr<spdlog::logger> m_log;
 };
-
-#endif

--- a/client/Quickmin.h
+++ b/client/Quickmin.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 

--- a/client/ReplicaExchangeJob.cpp
+++ b/client/ReplicaExchangeJob.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "ReplicaExchangeJob.h"
 #include "BaseStructures.h"
 #include "Dynamics.h"

--- a/client/ReplicaExchangeJob.cpp
+++ b/client/ReplicaExchangeJob.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "ReplicaExchangeJob.h"
 #include "BaseStructures.h"

--- a/client/ReplicaExchangeJob.h
+++ b/client/ReplicaExchangeJob.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 

--- a/client/ReplicaExchangeJob.h
+++ b/client/ReplicaExchangeJob.h
@@ -1,5 +1,15 @@
-#ifndef REPLICAEXCHANGEJOB_H
-#define REPLICAEXCHANGEJOB_H
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 
 #include "Dynamics.h"
 #include "Job.h"
@@ -25,5 +35,3 @@ private:
   std::vector<std::string> returnFiles;
   shared_ptr<spdlog::logger> log;
 };
-
-#endif

--- a/client/SaddleSearchJob.cpp
+++ b/client/SaddleSearchJob.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "SaddleSearchJob.h"
 #include "EpiCenters.h"

--- a/client/SaddleSearchJob.cpp
+++ b/client/SaddleSearchJob.cpp
@@ -1,7 +1,18 @@
-
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "SaddleSearchJob.h"
 #include "EpiCenters.h"
 #include "Potential.h"
+#include "HelperFunctions.h"
 
 #include <stdio.h>
 #include <string>

--- a/client/SaddleSearchJob.h
+++ b/client/SaddleSearchJob.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 

--- a/client/SaddleSearchJob.h
+++ b/client/SaddleSearchJob.h
@@ -1,12 +1,21 @@
-//----------------------------------------------------------------------------
-
-#ifndef SADDLESEARCHJOB_H
-#define SADDLESEARCHJOB_H
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 
 #include "Job.h"
 #include "Matter.h"
 #include "MinModeSaddleSearch.h"
 #include "Parameters.h"
+#include "HelperFunctions.h"
 
 /**
  * @file
@@ -70,5 +79,3 @@ private:
 
   std::shared_ptr<spdlog::logger> log;
 };
-
-#endif

--- a/client/SaddleSearchMethod.h
+++ b/client/SaddleSearchMethod.h
@@ -1,5 +1,15 @@
-#ifndef SADDLESEARCHMETHOD_H
-#define SADDLESEARCHMETHOD_H
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 
 #include "Parameters.h"
 #include "Potential.h"
@@ -20,5 +30,3 @@ public:
 
   int status;
 };
-
-#endif

--- a/client/SaddleSearchMethod.h
+++ b/client/SaddleSearchMethod.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 

--- a/client/SafeHyperJob.cpp
+++ b/client/SafeHyperJob.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "SafeHyperJob.h"
 #include "BondBoost.h"

--- a/client/SafeHyperJob.cpp
+++ b/client/SafeHyperJob.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "SafeHyperJob.h"
 #include "BondBoost.h"
 #include "Dynamics.h"

--- a/client/SafeHyperJob.h
+++ b/client/SafeHyperJob.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 

--- a/client/SafeHyperJob.h
+++ b/client/SafeHyperJob.h
@@ -1,5 +1,15 @@
-#ifndef SAFEHYPERJOB_H
-#define SAFEHYPERJOB_H
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 
 #include "Job.h"
 #include "Matter.h"
@@ -48,5 +58,3 @@ private:
 
   std::vector<std::string> returnFiles;
 };
-
-#endif

--- a/client/SteepestDescent.cpp
+++ b/client/SteepestDescent.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 // Based on the SteepestDescent minimizer written in ASE.

--- a/client/SteepestDescent.cpp
+++ b/client/SteepestDescent.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 // Based on the SteepestDescent minimizer written in ASE.
 

--- a/client/SteepestDescent.h
+++ b/client/SteepestDescent.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #ifndef SteepestDescent_H
 #define SteepestDescent_H

--- a/client/SteepestDescent.h
+++ b/client/SteepestDescent.h
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #ifndef SteepestDescent_H
 #define SteepestDescent_H
 

--- a/client/SteepestDescent.h
+++ b/client/SteepestDescent.h
@@ -9,8 +9,7 @@
 ** Repo:
 ** https://github.com/TheochemUI/eOn
 */
-#ifndef SteepestDescent_H
-#define SteepestDescent_H
+#pragma once
 
 #include "Eigen.h"
 #include "HelperFunctions.h"
@@ -44,5 +43,3 @@ private:
   Eigen::VectorXd m_rPrev;
   Eigen::VectorXd m_fPrev;
 };
-
-#endif

--- a/client/StringHelpers.hpp
+++ b/client/StringHelpers.hpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 

--- a/client/StringHelpers.hpp
+++ b/client/StringHelpers.hpp
@@ -1,5 +1,15 @@
-#ifndef STRINGHELPERS_H
-#define STRINGHELPERS_H
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 
 #include <optional>
 #include <regex>
@@ -33,4 +43,3 @@ std::vector<std::string> get_split_strings(const std::string &line);
  */
 bool isNumber(const std::string &token);
 } // namespace helper_functions
-#endif /* STRINGHELPERS_H */

--- a/client/StructureComparisonJob.cpp
+++ b/client/StructureComparisonJob.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "StructureComparisonJob.h"
 #include "HelperFunctions.h"
 #include "Matter.h"

--- a/client/StructureComparisonJob.cpp
+++ b/client/StructureComparisonJob.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "StructureComparisonJob.h"
 #include "HelperFunctions.h"

--- a/client/StructureComparisonJob.h
+++ b/client/StructureComparisonJob.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 

--- a/client/StructureComparisonJob.h
+++ b/client/StructureComparisonJob.h
@@ -1,6 +1,15 @@
-
-#ifndef STRUCTURECOMPARISONJOB_H
-#define STRUCTURECOMPARISONJOB_H
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 
 #include "Job.h"
 #include "Parameters.h"
@@ -12,5 +21,3 @@ public:
   ~StructureComparisonJob(void) = default;
   std::vector<std::string> run(void);
 };
-
-#endif

--- a/client/SurrogatePotential.cpp
+++ b/client/SurrogatePotential.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "SurrogatePotential.h"
 
 std::tuple<double, AtomMatrix, double>

--- a/client/SurrogatePotential.cpp
+++ b/client/SurrogatePotential.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "SurrogatePotential.h"
 

--- a/client/SurrogatePotential.h
+++ b/client/SurrogatePotential.h
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #pragma once
 
 #include "Potential.h"

--- a/client/SurrogatePotential.h
+++ b/client/SurrogatePotential.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 

--- a/client/TADJob.cpp
+++ b/client/TADJob.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include <cstdlib>
 

--- a/client/TADJob.cpp
+++ b/client/TADJob.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include <cstdlib>
 
 #include "BaseStructures.h"

--- a/client/TADJob.h
+++ b/client/TADJob.h
@@ -1,6 +1,15 @@
-
-#ifndef TADJOB_H
-#define TADJOB_H
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 
 #include "Job.h"
 #include "MinModeSaddleSearch.h"
@@ -51,5 +60,3 @@ private:
 
   std::vector<std::string> returnFiles;
 };
-
-#endif

--- a/client/TADJob.h
+++ b/client/TADJob.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 

--- a/client/TestJob.cpp
+++ b/client/TestJob.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "TestJob.h"
 #include "Matter.h"
 #include "MinModeSaddleSearch.h"

--- a/client/TestJob.cpp
+++ b/client/TestJob.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "TestJob.h"
 #include "Matter.h"

--- a/client/TestJob.h
+++ b/client/TestJob.h
@@ -1,6 +1,15 @@
-
-#ifndef TESTJOB_H
-#define TESTJOB_H
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#pragma once
 
 #include "ConjugateGradients.h"
 #include "Job.h"
@@ -21,5 +30,3 @@ private:
   double getEnergyDiff(string potTag, double refEnergy);
   double getForceDiff(string potTag, double refForce);
 };
-
-#endif

--- a/client/TestJob.h
+++ b/client/TestJob.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 

--- a/client/archive/include/archive.h
+++ b/client/archive/include/archive.h
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 /*-
  * Copyright (c) 2003-2007 Tim Kientzle
  * All rights reserved.

--- a/client/archive/include/archive.h
+++ b/client/archive/include/archive.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 /*-
  * Copyright (c) 2003-2007 Tim Kientzle

--- a/client/archive/include/archive.h
+++ b/client/archive/include/archive.h
@@ -1,14 +1,3 @@
-/*
-** This file is part of eOn.
-**
-** SPDX-License-Identifier: BSD-3-Clause
-**
-** Copyright (c) 2010--present, eOn Development Team
-** All rights reserved.
-**
-** Repo:
-** https://github.com/TheochemUI/eOn
-*/
 /*-
  * Copyright (c) 2003-2007 Tim Kientzle
  * All rights reserved.

--- a/client/archive/include/archive_entry.h
+++ b/client/archive/include/archive_entry.h
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 /*-
  * Copyright (c) 2003-2008 Tim Kientzle
  * All rights reserved.

--- a/client/archive/include/archive_entry.h
+++ b/client/archive/include/archive_entry.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 /*-
  * Copyright (c) 2003-2008 Tim Kientzle

--- a/client/fpe_handler.cpp
+++ b/client/fpe_handler.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "fpe_handler.h"
 
 #include <cfenv>

--- a/client/fpe_handler.cpp
+++ b/client/fpe_handler.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "fpe_handler.h"
 

--- a/client/fpe_handler.h
+++ b/client/fpe_handler.h
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #pragma once
 
 #include <fenv.h>

--- a/client/fpe_handler.h
+++ b/client/fpe_handler.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 

--- a/client/gtests/ApproveMatter.cpp
+++ b/client/gtests/ApproveMatter.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "ApprovalTests.hpp"
 #include "Matter.h"

--- a/client/gtests/ApproveMatter.cpp
+++ b/client/gtests/ApproveMatter.cpp
@@ -1,0 +1,155 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#include "ApprovalTests.hpp"
+#include "Matter.h"
+#include "catch2/catch_amalgamated.hpp"
+#include <iomanip>
+#include <iostream>
+#include <string>
+
+std::string toSpaceSeparatedString(const Eigen::VectorXd &vec) {
+  std::ostringstream oss;
+  for (int i = 0; i < vec.size(); ++i) {
+    oss << vec[i];
+    if (i < vec.size() - 1) {
+      oss << " ";
+    }
+  }
+  return oss.str();
+}
+
+double perAtomNormConst(const Matter &matter) {
+  return const_cast<Matter &>(matter).perAtomNorm(matter);
+}
+
+double distanceToConst(const Matter &matter) {
+  return const_cast<Matter &>(matter).distanceTo(matter);
+}
+
+double getPotentialEnergyConst(const Matter &matter) {
+  return const_cast<Matter &>(matter).getPotentialEnergy();
+}
+
+double maxForceConst(const Matter &matter) {
+  return const_cast<Matter &>(matter).maxForce();
+}
+
+auto getForcesConst(const Matter &matter) {
+  return const_cast<Matter &>(matter).getForces();
+}
+
+auto getForcesVConst(const Matter &matter) {
+  return const_cast<Matter &>(matter).getForcesV();
+}
+
+auto getEnergyVarianceConst(const Matter &matter) {
+  return const_cast<Matter &>(matter).getEnergyVariance();
+}
+
+auto getMechanicalEnergyConst(const Matter &matter) {
+  return const_cast<Matter &>(matter).getMechanicalEnergy();
+}
+
+auto getForcesFreeConst(const Matter &matter) {
+  return const_cast<Matter &>(matter).getForcesFree();
+}
+
+auto getForcesFreeVConst(const Matter &matter) {
+  return const_cast<Matter &>(matter).getForcesFreeV();
+}
+
+auto getBiasForcesConst(const Matter &matter) {
+  return const_cast<Matter &>(matter).getBiasForces();
+}
+
+std::ostream &operator<<(std::ostream &os, const Matter &matter) {
+  os << std::setprecision(8);
+  os << "Matter has: " << std::endl;
+
+  // Methods without parameters
+  os << "Number of atoms: \n" << matter.numberOfAtoms() << std::endl;
+  os << "Cell: \n" << matter.getCell() << std::endl;
+  os << "Potential calls: \n" << matter.getPotentialCalls() << std::endl;
+  os << "Positions: \n" << matter.getPositions() << std::endl;
+  os << "Positions (Vector): \n"
+     << toSpaceSeparatedString(matter.getPositionsV()) << std::endl;
+  os << "Positions (Free): \n" << matter.getPositionsFree() << std::endl;
+  os << "Positions (Free Vector): \n"
+     << toSpaceSeparatedString(matter.getPositionsFreeV()) << std::endl;
+  os << "Velocities: \n" << matter.getVelocities() << std::endl;
+  // TODO(rg): These have no initializers
+  // os << "Potential: \n" << (matter.getPotential() ? "Exists" : \n"None") <<
+  // std::endl; os << "Bias Forces: \n" << getBiasForcesConst(matter) <<
+  // std::endl;
+  os << "Forces: \n" << getForcesConst(matter) << std::endl;
+  os << "Forces (Vector): \n"
+     << toSpaceSeparatedString(getForcesVConst(matter)) << std::endl;
+  os << "Forces (Free): \n" << getForcesFreeConst(matter) << std::endl;
+  os << "Forces (Free Vector): \n"
+     << toSpaceSeparatedString(getForcesFreeVConst(matter)) << std::endl;
+  os << "Masses: \n" << matter.getMasses() << std::endl;
+  os << "Atomic Numbers: \n" << matter.getAtomicNrs() << std::endl;
+  os << "Fixed Atoms: \n" << matter.getFixed(3) << std::endl;
+  os << "Energy Variance: \n" << getEnergyVarianceConst(matter) << std::endl;
+  os << "Potential Energy: \n" << getPotentialEnergyConst(matter) << std::endl;
+  os << "Kinetic Energy: \n" << matter.getKineticEnergy() << std::endl;
+  os << "Mechanical Energy: \n"
+     << getMechanicalEnergyConst(matter) << std::endl;
+  os << "Number of Free Atoms: \n" << matter.numberOfFreeAtoms() << std::endl;
+  os << "Number of Fixed Atoms: \n" << matter.numberOfFixedAtoms() << std::endl;
+  // TODO(rg): This is weirdly broken
+  // os << "Force Calls: \n" << matter.getForceCalls() << std::endl;
+  os << "Maximum Force: \n" << maxForceConst(matter) << std::endl;
+  os << "Free (Matrix): \n" << matter.getFree() << std::endl;
+  os << "Free (Vector): \n"
+     << toSpaceSeparatedString(matter.getFreeV()) << std::endl;
+
+  // Methods with parameters
+  os << "Distance to self: \n" << distanceToConst(matter) << std::endl;
+  os << "Per atom norm with self: \n" << perAtomNormConst(matter) << std::endl;
+  os << "Position of atom 0, axis 0: \n"
+     << matter.getPosition(0, 0) << std::endl;
+  os << "Mass of atom 0: \n" << matter.getMass(0) << std::endl;
+  os << "Atomic number of atom 0: \n" << matter.getAtomicNr(0) << std::endl;
+  os << "Is atom 0 fixed: \n" << matter.getFixed(0) << std::endl;
+  os << "Distance between atoms 0 and 1: \n"
+     << matter.distance(0, 1) << std::endl;
+  os << "P-distance between atoms 0 and 1, axis 0: \n"
+     << matter.pdistance(0, 1, 0) << std::endl;
+  os << "Distance between same atom in two configurations: \n"
+     << matter.distance(matter, 0) << std::endl;
+
+  AtomMatrix placeholderMatrix = Eigen::MatrixXd::Zero(0, 3);
+  Eigen::VectorXd placeholderVector = Eigen::VectorXd::Zero(0);
+  os << "PBC Matrix: \n" << matter.pbc(placeholderMatrix) << std::endl;
+  os << "PBC Vector: \n" << matter.pbcV(placeholderVector) << std::endl;
+
+  return os;
+}
+
+std::vector<Matter> getMatter() {
+  // Return test data for Matter
+  // TODO(rg): Add more objects
+  auto params = std::make_shared<Parameters>();
+  auto pot_default = helper_functions::makePotential(PotType::LJ, params);
+  auto m1 = Matter(pot_default, params);
+  std::string confile("pos.con"); // Sulfolene
+  m1.con2matter(confile);
+  for (size_t idx{0}; idx < 3; idx++) {
+    m1.setFixed(idx, true);
+  }
+  return {m1};
+}
+
+TEST_CASE("VerifyMatter") {
+  ApprovalTests::Approvals::verifyAll("matter", getMatter());
+}

--- a/client/gtests/ApproveParams.cpp
+++ b/client/gtests/ApproveParams.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "ApprovalTests.hpp"
 #include "Parameters.h"
 #include "catch2/catch_amalgamated.hpp"

--- a/client/gtests/ApproveParams.cpp
+++ b/client/gtests/ApproveParams.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "ApprovalTests.hpp"
 #include "Parameters.h"

--- a/client/gtests/AtomsConfigurationTest.cpp
+++ b/client/gtests/AtomsConfigurationTest.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 /*
  * AtomsConfigurationTest.cpp

--- a/client/gtests/AtomsConfigurationTest.cpp
+++ b/client/gtests/AtomsConfigurationTest.cpp
@@ -1,4 +1,15 @@
 /*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+/*
  * AtomsConfigurationTest.cpp
  *
  *  Created on: 04 Feb 2021

--- a/client/gtests/AtomsConfigurationTest.h
+++ b/client/gtests/AtomsConfigurationTest.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #ifndef ATOMSCONFIGURATIONTEST_H
 #define ATOMSCONFIGURATIONTEST_H

--- a/client/gtests/AtomsConfigurationTest.h
+++ b/client/gtests/AtomsConfigurationTest.h
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #ifndef ATOMSCONFIGURATIONTEST_H
 #define ATOMSCONFIGURATIONTEST_H
 

--- a/client/gtests/GPRDimerTest.cpp
+++ b/client/gtests/GPRDimerTest.cpp
@@ -1,4 +1,15 @@
 /*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+/*
  * GPRDimerTest.cpp
  *
  *  Created on: 07 Feb 2021

--- a/client/gtests/GPRDimerTest.cpp
+++ b/client/gtests/GPRDimerTest.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 /*
  * GPRDimerTest.cpp

--- a/client/gtests/GPRDimerTest.h
+++ b/client/gtests/GPRDimerTest.h
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #ifndef GPRDIMERTEST_H
 #define GPRDIMERTEST_H
 

--- a/client/gtests/GPRDimerTest.h
+++ b/client/gtests/GPRDimerTest.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #ifndef GPRDIMERTEST_H
 #define GPRDIMERTEST_H

--- a/client/gtests/ImpDimerTest.cpp
+++ b/client/gtests/ImpDimerTest.cpp
@@ -1,4 +1,15 @@
 /*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+/*
  * ImpDimerTest.cpp
  *
  *  Created on: 07 Feb 2021

--- a/client/gtests/ImpDimerTest.cpp
+++ b/client/gtests/ImpDimerTest.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 /*
  * ImpDimerTest.cpp

--- a/client/gtests/ImpDimerTest.h
+++ b/client/gtests/ImpDimerTest.h
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #ifndef IMPDIMERTEST_H
 #define IMPDIMERTEST_H
 

--- a/client/gtests/ImpDimerTest.h
+++ b/client/gtests/ImpDimerTest.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #ifndef IMPDIMERTEST_H
 #define IMPDIMERTEST_H

--- a/client/gtests/MatterTest.cpp
+++ b/client/gtests/MatterTest.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "Matter.h"
 #include "Parameters.h"

--- a/client/gtests/MatterTest.cpp
+++ b/client/gtests/MatterTest.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "Matter.h"
 #include "Parameters.h"
 #include "catch2/catch_amalgamated.hpp"

--- a/client/gtests/NEBTest.cpp
+++ b/client/gtests/NEBTest.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 /*
  * Test.cpp

--- a/client/gtests/NEBTest.cpp
+++ b/client/gtests/NEBTest.cpp
@@ -1,4 +1,15 @@
 /*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+/*
  * Test.cpp
  *
  *  Created on: 23 Feb 2022

--- a/client/gtests/NEBTest.h
+++ b/client/gtests/NEBTest.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #ifndef NEBTEST_H
 #define NEBTEST_H

--- a/client/gtests/NEBTest.h
+++ b/client/gtests/NEBTest.h
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #ifndef NEBTEST_H
 #define NEBTEST_H
 

--- a/client/gtests/ObsTest.cpp
+++ b/client/gtests/ObsTest.cpp
@@ -1,4 +1,15 @@
 /*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+/*
  * ObsTest.cpp
  *
  *  Created on: 05 Feb 2021

--- a/client/gtests/ObsTest.cpp
+++ b/client/gtests/ObsTest.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 /*
  * ObsTest.cpp

--- a/client/gtests/ObsTest.h
+++ b/client/gtests/ObsTest.h
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #ifndef OBSTEST_H
 #define OBSTEST_H
 

--- a/client/gtests/ObsTest.h
+++ b/client/gtests/ObsTest.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #ifndef OBSTEST_H
 #define OBSTEST_H

--- a/client/gtests/PotTest.cpp
+++ b/client/gtests/PotTest.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "../MatrixHelpers.hpp"
 #include "Matter.h"

--- a/client/gtests/PotTest.cpp
+++ b/client/gtests/PotTest.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "../MatrixHelpers.hpp"
 #include "Matter.h"
 #include "catch2/catch_amalgamated.hpp"

--- a/client/gtests/StringHelpersTest.cpp
+++ b/client/gtests/StringHelpersTest.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 /*
  * StringHelpersTest.cpp

--- a/client/gtests/StringHelpersTest.cpp
+++ b/client/gtests/StringHelpersTest.cpp
@@ -1,4 +1,15 @@
 /*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+/*
  * StringHelpersTest.cpp
  *
  *  Created on: 23 Feb 2022

--- a/client/gtests/StringHelpersTest.h
+++ b/client/gtests/StringHelpersTest.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #ifndef STRINGHELPERSTEST_H
 #define STRINGHELPERSTEST_H

--- a/client/gtests/StringHelpersTest.h
+++ b/client/gtests/StringHelpersTest.h
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #ifndef STRINGHELPERSTEST_H
 #define STRINGHELPERSTEST_H
 

--- a/client/gtests/TestMain.cpp
+++ b/client/gtests/TestMain.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #define APPROVALS_CATCH2_V3
 #include "ApprovalTests.hpp"
 

--- a/client/gtests/TestMain.cpp
+++ b/client/gtests/TestMain.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #define APPROVALS_CATCH2_V3
 #include "ApprovalTests.hpp"

--- a/client/gtests/catch2_v3_starter_test.cpp
+++ b/client/gtests/catch2_v3_starter_test.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "ApprovalTests.hpp"
 #include "catch2/catch_amalgamated.hpp"
 

--- a/client/gtests/catch2_v3_starter_test.cpp
+++ b/client/gtests/catch2_v3_starter_test.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "ApprovalTests.hpp"
 #include "catch2/catch_amalgamated.hpp"

--- a/client/gtests/cuh2Test.cpp
+++ b/client/gtests/cuh2Test.cpp
@@ -1,4 +1,15 @@
 /*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+/*
  * CuH2Test.cpp
  *
  *  Created on: 15 Nov 2022

--- a/client/gtests/cuh2Test.cpp
+++ b/client/gtests/cuh2Test.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 /*
  * CuH2Test.cpp

--- a/client/gtests/cuh2Test.h
+++ b/client/gtests/cuh2Test.h
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #ifndef CUH2TEST_H
 #define CUH2TEST_H
 

--- a/client/gtests/cuh2Test.h
+++ b/client/gtests/cuh2Test.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #ifndef CUH2TEST_H
 #define CUH2TEST_H

--- a/client/helpers/Create.hpp
+++ b/client/helpers/Create.hpp
@@ -9,6 +9,7 @@
 ** Repo:
 ** https://github.com/TheochemUI/eOn
 */
+#pragma once
 #include "../SurrogatePotential.h"
 
 #ifdef WITH_CATLEARN

--- a/client/helpers/Create.hpp
+++ b/client/helpers/Create.hpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "../SurrogatePotential.h"
 
 #ifdef WITH_CATLEARN

--- a/client/helpers/Create.hpp
+++ b/client/helpers/Create.hpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "../SurrogatePotential.h"
 

--- a/client/potentials/AMS/AMS.cpp
+++ b/client/potentials/AMS/AMS.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #include "AMS.h"

--- a/client/potentials/AMS/AMS.cpp
+++ b/client/potentials/AMS/AMS.cpp
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #include "AMS.h"
 #include <iostream>

--- a/client/potentials/AMS/AMS.h
+++ b/client/potentials/AMS/AMS.h
@@ -9,9 +9,7 @@
 ** Repo:
 ** https://github.com/TheochemUI/eOn
 */
-
-#ifndef AMS_POT
-#define AMS_POT
+#pragma once
 
 #include "../../Matter.h"
 #include "../../Potential.h"
@@ -78,5 +76,3 @@ private:
   std::string readFile(std::filesystem::path path);
   void recieveFromSystem(long N, double *F, double *U);
 };
-
-#endif

--- a/client/potentials/AMS/AMS.h
+++ b/client/potentials/AMS/AMS.h
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #ifndef AMS_POT
 #define AMS_POT

--- a/client/potentials/AMS/AMS.h
+++ b/client/potentials/AMS/AMS.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #ifndef AMS_POT

--- a/client/potentials/AMS_IO/AMS_IO.cpp
+++ b/client/potentials/AMS_IO/AMS_IO.cpp
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #include "AMS_IO.h"
 #include <iostream>

--- a/client/potentials/AMS_IO/AMS_IO.cpp
+++ b/client/potentials/AMS_IO/AMS_IO.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #include "AMS_IO.h"

--- a/client/potentials/AMS_IO/AMS_IO.h
+++ b/client/potentials/AMS_IO/AMS_IO.h
@@ -9,9 +9,7 @@
 ** Repo:
 ** https://github.com/TheochemUI/eOn
 */
-
-#ifndef AMS_IO_POT
-#define AMS_IO_POT
+#pragma once
 
 #include "../../Matter.h"
 #include "../../Potential.h"
@@ -35,5 +33,3 @@ private:
   const char *forcefield;
   const char *xc;
 };
-
-#endif

--- a/client/potentials/AMS_IO/AMS_IO.h
+++ b/client/potentials/AMS_IO/AMS_IO.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #ifndef AMS_IO_POT

--- a/client/potentials/AMS_IO/AMS_IO.h
+++ b/client/potentials/AMS_IO/AMS_IO.h
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #ifndef AMS_IO_POT
 #define AMS_IO_POT

--- a/client/potentials/ASE/ASE.cpp
+++ b/client/potentials/ASE/ASE.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #include "ASE.h"

--- a/client/potentials/ASE/ASE.cpp
+++ b/client/potentials/ASE/ASE.cpp
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #include "ASE.h"
 #include "../../fpe_handler.h"

--- a/client/potentials/ASE/ASE.h
+++ b/client/potentials/ASE/ASE.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #ifndef ASE_POTENTIAL

--- a/client/potentials/ASE/ASE.h
+++ b/client/potentials/ASE/ASE.h
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #ifndef ASE_POTENTIAL
 #define ASE_POTENTIAL

--- a/client/potentials/ASE/ASE.h
+++ b/client/potentials/ASE/ASE.h
@@ -9,9 +9,7 @@
 ** Repo:
 ** https://github.com/TheochemUI/eOn
 */
-
-#ifndef ASE_POTENTIAL
-#define ASE_POTENTIAL
+#pragma once
 
 #include "../../Potential.h"
 #include <pybind11/embed.h>
@@ -37,4 +35,3 @@ public:
   void force(long nAtoms, const double *R, const int *atomicNrs, double *F,
              double *U, double *variance, const double *box) override;
 };
-#endif

--- a/client/potentials/ASE_NWCHEM/ASE_NWCHEM.h
+++ b/client/potentials/ASE_NWCHEM/ASE_NWCHEM.h
@@ -1,13 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
-
+/*
+** This file is part of eOn.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eOn Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eOn
+*/
 #pragma once
 #define PYBIND11_DETAILED_ERROR_MESSAGES
 

--- a/client/potentials/ASE_ORCA/ASE_ORCA.cpp
+++ b/client/potentials/ASE_ORCA/ASE_ORCA.cpp
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #include "ASE_ORCA.h"
 #include "../../EnvHelpers.hpp"

--- a/client/potentials/ASE_ORCA/ASE_ORCA.cpp
+++ b/client/potentials/ASE_ORCA/ASE_ORCA.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #include "ASE_ORCA.h"

--- a/client/potentials/ASE_ORCA/ASE_ORCA.h
+++ b/client/potentials/ASE_ORCA/ASE_ORCA.h
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #pragma once
 #define PYBIND11_DETAILED_ERROR_MESSAGES

--- a/client/potentials/ASE_ORCA/ASE_ORCA.h
+++ b/client/potentials/ASE_ORCA/ASE_ORCA.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #pragma once

--- a/client/potentials/ASE_ORCA/ASE_ORCA.h
+++ b/client/potentials/ASE_ORCA/ASE_ORCA.h
@@ -9,7 +9,6 @@
 ** Repo:
 ** https://github.com/TheochemUI/eOn
 */
-
 #pragma once
 #define PYBIND11_DETAILED_ERROR_MESSAGES
 

--- a/client/potentials/Aluminum/Aluminum.cpp
+++ b/client/potentials/Aluminum/Aluminum.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 //-----------------------------------------------------------------------------------
 #include "Aluminum.h"

--- a/client/potentials/Aluminum/Aluminum.cpp
+++ b/client/potentials/Aluminum/Aluminum.cpp
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 //-----------------------------------------------------------------------------------
 #include "Aluminum.h"
 #include <assert.h>

--- a/client/potentials/Aluminum/Aluminum.h
+++ b/client/potentials/Aluminum/Aluminum.h
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 //-----------------------------------------------------------------------------------
 #ifndef ALUMINUM_POTENTIAL
 #define ALUMINUM_POTENTIAL

--- a/client/potentials/Aluminum/Aluminum.h
+++ b/client/potentials/Aluminum/Aluminum.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 //-----------------------------------------------------------------------------------
 #ifndef ALUMINUM_POTENTIAL

--- a/client/potentials/Aluminum/Aluminum.h
+++ b/client/potentials/Aluminum/Aluminum.h
@@ -10,8 +10,7 @@
 ** https://github.com/TheochemUI/eOn
 */
 //-----------------------------------------------------------------------------------
-#ifndef ALUMINUM_POTENTIAL
-#define ALUMINUM_POTENTIAL
+#pragma once
 
 #include "../../Potential.h"
 
@@ -44,4 +43,3 @@ public:
   void force(long N, const double *R, const int *atomicNrs, double *F,
              double *U, double *variance, const double *box) override;
 };
-#endif

--- a/client/potentials/Aluminum/dfrhoDblexp.f
+++ b/client/potentials/Aluminum/dfrhoDblexp.f
@@ -1,3 +1,13 @@
+C This file is part of eON.
+C
+C SPDX-License-Identifier: BSD-3-Clause
+C
+C Copyright (c) 2010--present, eON Development Team
+C All rights reserved.
+C
+C Repo:
+C https://github.com/TheochemUI/eON
+
 c  Dblexp:  June 92
 c  Generalized to arbitrary order   Feb 92
 c  This routine evaluates teh derivative of the embedding function with respect

--- a/client/potentials/Aluminum/dfrhoDblexp.f
+++ b/client/potentials/Aluminum/dfrhoDblexp.f
@@ -1,12 +1,12 @@
-C This file is part of eON.
+C This file is part of eOn.
 C
 C SPDX-License-Identifier: BSD-3-Clause
 C
-C Copyright (c) 2010--present, eON Development Team
+C Copyright (c) 2010--present, eOn Development Team
 C All rights reserved.
 C
 C Repo:
-C https://github.com/TheochemUI/eON
+C https://github.com/TheochemUI/eOn
 
 c  Dblexp:  June 92
 c  Generalized to arbitrary order   Feb 92

--- a/client/potentials/Aluminum/embedenergy.f
+++ b/client/potentials/Aluminum/embedenergy.f
@@ -1,3 +1,13 @@
+C This file is part of eON.
+C
+C SPDX-License-Identifier: BSD-3-Clause
+C
+C Copyright (c) 2010--present, eON Development Team
+C All rights reserved.
+C
+C Repo:
+C https://github.com/TheochemUI/eON
+
 c  the case of exactly two components is hardwired into this routine(!!!)
 C  This subroutine calculate the total embedding energy of the system and the
 c  contribution of the embedding energy to the virial.

--- a/client/potentials/Aluminum/embedenergy.f
+++ b/client/potentials/Aluminum/embedenergy.f
@@ -1,12 +1,12 @@
-C This file is part of eON.
+C This file is part of eOn.
 C
 C SPDX-License-Identifier: BSD-3-Clause
 C
-C Copyright (c) 2010--present, eON Development Team
+C Copyright (c) 2010--present, eOn Development Team
 C All rights reserved.
 C
 C Repo:
-C https://github.com/TheochemUI/eON
+C https://github.com/TheochemUI/eOn
 
 c  the case of exactly two components is hardwired into this routine(!!!)
 C  This subroutine calculate the total embedding energy of the system and the

--- a/client/potentials/Aluminum/fofrhoDblexp.f
+++ b/client/potentials/Aluminum/fofrhoDblexp.f
@@ -1,3 +1,13 @@
+C This file is part of eON.
+C
+C SPDX-License-Identifier: BSD-3-Clause
+C
+C Copyright (c) 2010--present, eON Development Team
+C All rights reserved.
+C
+C Repo:
+C https://github.com/TheochemUI/eON
+
 c   Dblexp:    June 92
 c  This routine calculates FOFRHO
 c  Generalized to arbitrary order

--- a/client/potentials/Aluminum/fofrhoDblexp.f
+++ b/client/potentials/Aluminum/fofrhoDblexp.f
@@ -1,12 +1,12 @@
-C This file is part of eON.
+C This file is part of eOn.
 C
 C SPDX-License-Identifier: BSD-3-Clause
 C
-C Copyright (c) 2010--present, eON Development Team
+C Copyright (c) 2010--present, eOn Development Team
 C All rights reserved.
 C
 C Repo:
-C https://github.com/TheochemUI/eON
+C https://github.com/TheochemUI/eOn
 
 c   Dblexp:    June 92
 c  This routine calculates FOFRHO

--- a/client/potentials/Aluminum/forces.f
+++ b/client/potentials/Aluminum/forces.f
@@ -1,3 +1,13 @@
+C This file is part of eON.
+C
+C SPDX-License-Identifier: BSD-3-Clause
+C
+C Copyright (c) 2010--present, eON Development Team
+C All rights reserved.
+C
+C Repo:
+C https://github.com/TheochemUI/eON
+
 c   version e93:   add gregs SPF routine for chain relaxation
 c   EAM version b91:   add FPI forces and potential by calling FPIforce
 c

--- a/client/potentials/Aluminum/forces.f
+++ b/client/potentials/Aluminum/forces.f
@@ -1,12 +1,12 @@
-C This file is part of eON.
+C This file is part of eOn.
 C
 C SPDX-License-Identifier: BSD-3-Clause
 C
-C Copyright (c) 2010--present, eON Development Team
+C Copyright (c) 2010--present, eOn Development Team
 C All rights reserved.
 C
 C Repo:
-C https://github.com/TheochemUI/eON
+C https://github.com/TheochemUI/eOn
 
 c   version e93:   add gregs SPF routine for chain relaxation
 c   EAM version b91:   add FPI forces and potential by calling FPIforce

--- a/client/potentials/Aluminum/gagafeDblexp.f
+++ b/client/potentials/Aluminum/gagafeDblexp.f
@@ -1,3 +1,13 @@
+C This file is part of eON.
+C
+C SPDX-License-Identifier: BSD-3-Clause
+C
+C Copyright (c) 2010--present, eON Development Team
+C All rights reserved.
+C
+C Repo:
+C https://github.com/TheochemUI/eON
+
 c   EAM version e:
 c   EAM version d:    Greg found bug in interactions between FPI chains.
 c   EAM version c:    tags 100-199 for fixed-endpoint FPI

--- a/client/potentials/Aluminum/gagafeDblexp.f
+++ b/client/potentials/Aluminum/gagafeDblexp.f
@@ -1,12 +1,12 @@
-C This file is part of eON.
+C This file is part of eOn.
 C
 C SPDX-License-Identifier: BSD-3-Clause
 C
-C Copyright (c) 2010--present, eON Development Team
+C Copyright (c) 2010--present, eOn Development Team
 C All rights reserved.
 C
 C Repo:
-C https://github.com/TheochemUI/eON
+C https://github.com/TheochemUI/eOn
 
 c   EAM version e:
 c   EAM version d:    Greg found bug in interactions between FPI chains.

--- a/client/potentials/Aluminum/potinit.f
+++ b/client/potentials/Aluminum/potinit.f
@@ -1,3 +1,13 @@
+C This file is part of eON.
+C
+C SPDX-License-Identifier: BSD-3-Clause
+C
+C Copyright (c) 2010--present, eON Development Team
+C All rights reserved.
+C
+C Repo:
+C https://github.com/TheochemUI/eON
+
 c   version e93:   add gregs SPF routine for chain relaxation
 c   EAM version b91:   add FPI forces and potential by calling FPIforce
 c

--- a/client/potentials/Aluminum/potinit.f
+++ b/client/potentials/Aluminum/potinit.f
@@ -1,12 +1,12 @@
-C This file is part of eON.
+C This file is part of eOn.
 C
 C SPDX-License-Identifier: BSD-3-Clause
 C
-C Copyright (c) 2010--present, eON Development Team
+C Copyright (c) 2010--present, eOn Development Team
 C All rights reserved.
 C
 C Repo:
-C https://github.com/TheochemUI/eON
+C https://github.com/TheochemUI/eOn
 
 c   version e93:   add gregs SPF routine for chain relaxation
 c   EAM version b91:   add FPI forces and potential by calling FPIforce

--- a/client/potentials/Aluminum/sumembforce.f
+++ b/client/potentials/Aluminum/sumembforce.f
@@ -1,12 +1,12 @@
-C This file is part of eON.
+C This file is part of eOn.
 C
 C SPDX-License-Identifier: BSD-3-Clause
 C
-C Copyright (c) 2010--present, eON Development Team
+C Copyright (c) 2010--present, eOn Development Team
 C All rights reserved.
 C
 C Repo:
-C https://github.com/TheochemUI/eON
+C https://github.com/TheochemUI/eOn
 
       SUBROUTINE SUMFORCE(ipot,FA1,FA2)
 

--- a/client/potentials/Aluminum/sumembforce.f
+++ b/client/potentials/Aluminum/sumembforce.f
@@ -1,3 +1,13 @@
+C This file is part of eON.
+C
+C SPDX-License-Identifier: BSD-3-Clause
+C
+C Copyright (c) 2010--present, eON Development Team
+C All rights reserved.
+C
+C Repo:
+C https://github.com/TheochemUI/eON
+
       SUBROUTINE SUMFORCE(ipot,FA1,FA2)
 
       implicit real*8 (a-h,o-z)

--- a/client/potentials/CatLearnPot/CatLearnPot.cpp
+++ b/client/potentials/CatLearnPot/CatLearnPot.cpp
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #include "CatLearnPot.h"
 #include "Eigen/src/Core/Matrix.h"

--- a/client/potentials/CatLearnPot/CatLearnPot.cpp
+++ b/client/potentials/CatLearnPot/CatLearnPot.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #include "CatLearnPot.h"

--- a/client/potentials/CatLearnPot/CatLearnPot.h
+++ b/client/potentials/CatLearnPot/CatLearnPot.h
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #ifndef CATLEARNPOT_INTERFACE
 #define CATLEARNPOT_INTERFACE

--- a/client/potentials/CatLearnPot/CatLearnPot.h
+++ b/client/potentials/CatLearnPot/CatLearnPot.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #ifndef CATLEARNPOT_INTERFACE

--- a/client/potentials/CatLearnPot/CatLearnPot.h
+++ b/client/potentials/CatLearnPot/CatLearnPot.h
@@ -9,9 +9,7 @@
 ** Repo:
 ** https://github.com/TheochemUI/eOn
 */
-
-#ifndef CATLEARNPOT_INTERFACE
-#define CATLEARNPOT_INTERFACE
+#pragma once
 
 #define PYBIND11_DETAILED_ERROR_MESSAGES
 
@@ -40,4 +38,3 @@ public:
   Eigen::MatrixXd
       variance; // XXX: This is a hacky way to populate and use this variable
 };
-#endif

--- a/client/potentials/CuH2/CuH2.cpp
+++ b/client/potentials/CuH2/CuH2.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #include "CuH2.h"

--- a/client/potentials/CuH2/CuH2.cpp
+++ b/client/potentials/CuH2/CuH2.cpp
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #include "CuH2.h"
 #include <set>

--- a/client/potentials/CuH2/CuH2.h
+++ b/client/potentials/CuH2/CuH2.h
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #ifndef CUH2_INTERFACE
 #define CUH2_INTERFACE

--- a/client/potentials/CuH2/CuH2.h
+++ b/client/potentials/CuH2/CuH2.h
@@ -9,9 +9,7 @@
 ** Repo:
 ** https://github.com/TheochemUI/eOn
 */
-
-#ifndef CUH2_INTERFACE
-#define CUH2_INTERFACE
+#pragma once
 
 #include "../../Potential.h"
 
@@ -32,4 +30,3 @@ public:
   void force(long N, const double *R, const int *atomicNrs, double *F,
              double *U, double *variance, const double *box) override;
 };
-#endif

--- a/client/potentials/CuH2/CuH2.h
+++ b/client/potentials/CuH2/CuH2.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #ifndef CUH2_INTERFACE

--- a/client/potentials/CuH2/eam_isoc.f90
+++ b/client/potentials/CuH2/eam_isoc.f90
@@ -1,12 +1,12 @@
-! This file is part of eON.
+! This file is part of eOn.
 !
 ! SPDX-License-Identifier: BSD-3-Clause
 !
-! Copyright (c) 2010--present, eON Development Team
+! Copyright (c) 2010--present, eOn Development Team
 ! All rights reserved.
 !
 ! Repo:
-! https://github.com/TheochemUI/eON
+! https://github.com/TheochemUI/eOn
   module eam_wrap
     use iso_c_binding, only: c_double, c_int
     use iso_fortran_env, only: real64

--- a/client/potentials/CuH2/eam_isoc.f90
+++ b/client/potentials/CuH2/eam_isoc.f90
@@ -1,3 +1,12 @@
+! This file is part of eON.
+!
+! SPDX-License-Identifier: BSD-3-Clause
+!
+! Copyright (c) 2010--present, eON Development Team
+! All rights reserved.
+!
+! Repo:
+! https://github.com/TheochemUI/eON
   module eam_wrap
     use iso_c_binding, only: c_double, c_int
     use iso_fortran_env, only: real64

--- a/client/potentials/CuH2/eamroutines.f90
+++ b/client/potentials/CuH2/eamroutines.f90
@@ -1,3 +1,13 @@
+! This file is part of eON.
+!
+! SPDX-License-Identifier: BSD-3-Clause
+!
+! Copyright (c) 2010--present, eON Development Team
+! All rights reserved.
+!
+! Repo:
+! https://github.com/TheochemUI/eON
+
       SUBROUTINE force_eam(natms,ndim,box,R,F,U)
 
         IMPLICIT NONE

--- a/client/potentials/CuH2/eamroutines.f90
+++ b/client/potentials/CuH2/eamroutines.f90
@@ -1,12 +1,12 @@
-! This file is part of eON.
+! This file is part of eOn.
 !
 ! SPDX-License-Identifier: BSD-3-Clause
 !
-! Copyright (c) 2010--present, eON Development Team
+! Copyright (c) 2010--present, eOn Development Team
 ! All rights reserved.
 !
 ! Repo:
-! https://github.com/TheochemUI/eON
+! https://github.com/TheochemUI/eOn
 
       SUBROUTINE force_eam(natms,ndim,box,R,F,U)
 

--- a/client/potentials/CuH2/main.f90
+++ b/client/potentials/CuH2/main.f90
@@ -1,12 +1,12 @@
-! This file is part of eON.
+! This file is part of eOn.
 !
 ! SPDX-License-Identifier: BSD-3-Clause
 !
-! Copyright (c) 2010--present, eON Development Team
+! Copyright (c) 2010--present, eOn Development Team
 ! All rights reserved.
 !
 ! Repo:
-! https://github.com/TheochemUI/eON
+! https://github.com/TheochemUI/eOn
 
       program readcon
 ! This program has been edited for matlab

--- a/client/potentials/CuH2/main.f90
+++ b/client/potentials/CuH2/main.f90
@@ -1,3 +1,12 @@
+! This file is part of eON.
+!
+! SPDX-License-Identifier: BSD-3-Clause
+!
+! Copyright (c) 2010--present, eON Development Team
+! All rights reserved.
+!
+! Repo:
+! https://github.com/TheochemUI/eON
 
       program readcon
 ! This program has been edited for matlab

--- a/client/potentials/EAM/EAM.cpp
+++ b/client/potentials/EAM/EAM.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include <float.h>
 #include <limits.h>
 #include <math.h>

--- a/client/potentials/EAM/EAM.cpp
+++ b/client/potentials/EAM/EAM.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include <float.h>
 #include <limits.h>

--- a/client/potentials/EAM/EAM.h
+++ b/client/potentials/EAM/EAM.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include <iostream>
 #include <math.h>

--- a/client/potentials/EAM/EAM.h
+++ b/client/potentials/EAM/EAM.h
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include <iostream>
 #include <math.h>
 

--- a/client/potentials/EAM/EAM.h
+++ b/client/potentials/EAM/EAM.h
@@ -9,6 +9,8 @@
 ** Repo:
 ** https://github.com/TheochemUI/eOn
 */
+#pragma once
+
 #include <iostream>
 #include <math.h>
 

--- a/client/potentials/EAM/Parameters.h
+++ b/client/potentials/EAM/Parameters.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #define NPARAMS 3
 

--- a/client/potentials/EAM/Parameters.h
+++ b/client/potentials/EAM/Parameters.h
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #define NPARAMS 3
 
 const EAM::element_parameters EAM::el_params[NPARAMS] = {

--- a/client/potentials/EAM/Parameters.h
+++ b/client/potentials/EAM/Parameters.h
@@ -9,6 +9,7 @@
 ** Repo:
 ** https://github.com/TheochemUI/eOn
 */
+#pragma once
 #define NPARAMS 3
 
 const EAM::element_parameters EAM::el_params[NPARAMS] = {

--- a/client/potentials/EAM/test.cpp
+++ b/client/potentials/EAM/test.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include <stdio.h>
 

--- a/client/potentials/EAM/test.cpp
+++ b/client/potentials/EAM/test.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include <stdio.h>
 
 #include "EAM.h"

--- a/client/potentials/EDIP/EDIP.cpp
+++ b/client/potentials/EDIP/EDIP.cpp
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #include "EDIP.h"
 

--- a/client/potentials/EDIP/EDIP.cpp
+++ b/client/potentials/EDIP/EDIP.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #include "EDIP.h"

--- a/client/potentials/EDIP/EDIP.h
+++ b/client/potentials/EDIP/EDIP.h
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #ifndef EDIP_POTENTIAL
 #define EDIP_POTENTIAL

--- a/client/potentials/EDIP/EDIP.h
+++ b/client/potentials/EDIP/EDIP.h
@@ -9,9 +9,7 @@
 ** Repo:
 ** https://github.com/TheochemUI/eOn
 */
-
-#ifndef EDIP_POTENTIAL
-#define EDIP_POTENTIAL
+#pragma once
 
 #include "../../Potential.h"
 
@@ -42,4 +40,3 @@ public:
   void force(long N, const double *R, const int *atomicNrs, double *F,
              double *U, double *variance, const double *box) override;
 };
-#endif

--- a/client/potentials/EDIP/EDIP.h
+++ b/client/potentials/EDIP/EDIP.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #ifndef EDIP_POTENTIAL

--- a/client/potentials/EDIP/edipFortran.f90
+++ b/client/potentials/EDIP/edipFortran.f90
@@ -1,3 +1,13 @@
+! This file is part of eOn.
+!
+! SPDX-License-Identifier: BSD-3-Clause
+!
+! Copyright (c) 2010--present, eOn Development Team
+! All rights reserved.
+!
+! Repo:
+! https://github.com/TheochemUI/eOn
+
 !  SUBROUTINE potinit()
 !    IMPLICIT NONE
 !  RETURN

--- a/client/potentials/EMT/AlH/EMT_parms.h
+++ b/client/potentials/EMT/AlH/EMT_parms.h
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 // all information for the EMT potential
 
 #ifndef EMT_PARMS_H

--- a/client/potentials/EMT/AlH/EMT_parms.h
+++ b/client/potentials/EMT/AlH/EMT_parms.h
@@ -9,10 +9,8 @@
 ** Repo:
 ** https://github.com/TheochemUI/eOn
 */
+#pragma once
 // all information for the EMT potential
-
-#ifndef EMT_PARMS_H
-#define EMT_PARMS_H
 
 // the number of different spicies that will be used in simulation
 // int const EMT_NumType = 1;
@@ -32,5 +30,3 @@ int const EMT_NumAtomPerType[] = {900, 1};
 // eventually will be deposited!
 // int const EMT_AtomType[] = {29};
 int const EMT_AtomType[] = {13, 1};
-
-#endif

--- a/client/potentials/EMT/AlH/EMT_parms.h
+++ b/client/potentials/EMT/AlH/EMT_parms.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 // all information for the EMT potential
 

--- a/client/potentials/EMT/Cu/EMT_parms.h
+++ b/client/potentials/EMT/Cu/EMT_parms.h
@@ -9,10 +9,8 @@
 ** Repo:
 ** https://github.com/TheochemUI/eOn
 */
+#pragma once
 // all information for the EMT potential
-
-#ifndef EMT_PARMS_H
-#define EMT_PARMS_H
 
 // the number of different spicies that will be used in simulation
 int const EMT_NumType = 1;
@@ -32,5 +30,3 @@ int const EMT_NumAtomPerType[] = {1300};
 // eventually will be deposited!
 int const EMT_AtomType[] = {29};
 // int const EMT_AtomType[] = {12,1};
-
-#endif

--- a/client/potentials/EMT/Cu/EMT_parms.h
+++ b/client/potentials/EMT/Cu/EMT_parms.h
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 // all information for the EMT potential
 
 #ifndef EMT_PARMS_H

--- a/client/potentials/EMT/Cu/EMT_parms.h
+++ b/client/potentials/EMT/Cu/EMT_parms.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 // all information for the EMT potential
 

--- a/client/potentials/EMT/EffectiveMediumTheory.cpp
+++ b/client/potentials/EMT/EffectiveMediumTheory.cpp
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #include "EffectiveMediumTheory.h"
 #include <string.h>

--- a/client/potentials/EMT/EffectiveMediumTheory.cpp
+++ b/client/potentials/EMT/EffectiveMediumTheory.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #include "EffectiveMediumTheory.h"

--- a/client/potentials/EMT/EffectiveMediumTheory.h
+++ b/client/potentials/EMT/EffectiveMediumTheory.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 // serves as an interface between emt potentials provided by CamposASE and

--- a/client/potentials/EMT/EffectiveMediumTheory.h
+++ b/client/potentials/EMT/EffectiveMediumTheory.h
@@ -9,12 +9,10 @@
 ** Repo:
 ** https://github.com/TheochemUI/eOn
 */
+#pragma once
 
 // serves as an interface between emt potentials provided by CamposASE and
 // dynamics provided by EON
-
-#ifndef EFFECTIVE_MEDIUM_THEORY
-#define EFFECTIVE_MEDIUM_THEORY
 
 #include "Asap/Atoms.h"
 #include "Asap/EMT.h"
@@ -62,5 +60,3 @@ public:
   void force(long N, const double *R, const int *atomicNrs, double *F,
              double *U, double *variance, const double *box);
 };
-
-#endif

--- a/client/potentials/EMT/EffectiveMediumTheory.h
+++ b/client/potentials/EMT/EffectiveMediumTheory.h
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 // serves as an interface between emt potentials provided by CamposASE and
 // dynamics provided by EON

--- a/client/potentials/ExtPot/ExtPot.cpp
+++ b/client/potentials/ExtPot/ExtPot.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #include "ExtPot.h"

--- a/client/potentials/ExtPot/ExtPot.cpp
+++ b/client/potentials/ExtPot/ExtPot.cpp
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #include "ExtPot.h"
 #include <iostream>

--- a/client/potentials/ExtPot/ExtPot.h
+++ b/client/potentials/ExtPot/ExtPot.h
@@ -9,9 +9,7 @@
 ** Repo:
 ** https://github.com/TheochemUI/eOn
 */
-
-#ifndef EXT_POT
-#define EXT_POT
+#pragma once
 
 #include "../../Potential.h"
 
@@ -32,4 +30,3 @@ private:
   const char *eon_extpot_path;
 };
 
-#endif

--- a/client/potentials/ExtPot/ExtPot.h
+++ b/client/potentials/ExtPot/ExtPot.h
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #ifndef EXT_POT
 #define EXT_POT

--- a/client/potentials/ExtPot/ExtPot.h
+++ b/client/potentials/ExtPot/ExtPot.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #ifndef EXT_POT

--- a/client/potentials/FeHe/FeHe.cpp
+++ b/client/potentials/FeHe/FeHe.cpp
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 //-----------------------------------------------------------------------------------
 #include "FeHe.h"
 #include <assert.h>

--- a/client/potentials/FeHe/FeHe.cpp
+++ b/client/potentials/FeHe/FeHe.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 //-----------------------------------------------------------------------------------
 #include "FeHe.h"

--- a/client/potentials/FeHe/FeHe.h
+++ b/client/potentials/FeHe/FeHe.h
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 //-----------------------------------------------------------------------------------
 #ifndef FEHE_POTENTIAL
 #define FEHE_POTENTIAL

--- a/client/potentials/FeHe/FeHe.h
+++ b/client/potentials/FeHe/FeHe.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 //-----------------------------------------------------------------------------------
 #ifndef FEHE_POTENTIAL

--- a/client/potentials/FeHe/FeHe.h
+++ b/client/potentials/FeHe/FeHe.h
@@ -9,9 +9,7 @@
 ** Repo:
 ** https://github.com/TheochemUI/eOn
 */
-//-----------------------------------------------------------------------------------
-#ifndef FEHE_POTENTIAL
-#define FEHE_POTENTIAL
+#pragma once
 
 #include "../../Potential.h"
 
@@ -52,4 +50,3 @@ public:
   void force(long N, const double *R, const int *atomicNrs, double *F,
              double *U, double *variance, const double *box) override;
 };
-#endif

--- a/client/potentials/FeHe/feforce.f
+++ b/client/potentials/FeHe/feforce.f
@@ -1,3 +1,13 @@
+C This file is part of eON.
+C
+C SPDX-License-Identifier: BSD-3-Clause
+C
+C Copyright (c) 2010--present, eON Development Team
+C All rights reserved.
+C
+C Repo:
+C https://github.com/TheochemUI/eON
+C
 !force
       subroutine FEFORCE(nm,x0,y0,z0,ispec,fx,fy,fz,pe,ax,ay,az)
           implicit  real*8 ( a-h,o-z )

--- a/client/potentials/FeHe/feforce.f
+++ b/client/potentials/FeHe/feforce.f
@@ -1,12 +1,12 @@
-C This file is part of eON.
+C This file is part of eOn.
 C
 C SPDX-License-Identifier: BSD-3-Clause
 C
-C Copyright (c) 2010--present, eON Development Team
+C Copyright (c) 2010--present, eOn Development Team
 C All rights reserved.
 C
 C Repo:
-C https://github.com/TheochemUI/eON
+C https://github.com/TheochemUI/eOn
 C
 !force
       subroutine FEFORCE(nm,x0,y0,z0,ispec,fx,fy,fz,pe,ax,ay,az)

--- a/client/potentials/GPRPotential/GPRPotential.cpp
+++ b/client/potentials/GPRPotential/GPRPotential.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #include "GPRPotential.h"

--- a/client/potentials/GPRPotential/GPRPotential.cpp
+++ b/client/potentials/GPRPotential/GPRPotential.cpp
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #include "GPRPotential.h"
 #include "../../subprojects/gprdimer/gpr/auxiliary/AdditionalFunctionality.h"

--- a/client/potentials/GPRPotential/GPRPotential.h
+++ b/client/potentials/GPRPotential/GPRPotential.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #ifndef GPRPOT_INTERFACE

--- a/client/potentials/GPRPotential/GPRPotential.h
+++ b/client/potentials/GPRPotential/GPRPotential.h
@@ -9,9 +9,7 @@
 ** Repo:
 ** https://github.com/TheochemUI/eOn
 */
-
-#ifndef GPRPOT_INTERFACE
-#define GPRPOT_INTERFACE
+#pragma once
 
 #include "../../Potential.h"
 #include "../../subprojects/gpr_optim/gpr/ml/GaussianProcessRegression.h"
@@ -36,4 +34,3 @@ public:
   void force(long N, const double *R, const int *atomicNrs, double *F,
              double *U, double *variance, const double *box);
 };
-#endif

--- a/client/potentials/GPRPotential/GPRPotential.h
+++ b/client/potentials/GPRPotential/GPRPotential.h
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #ifndef GPRPOT_INTERFACE
 #define GPRPOT_INTERFACE

--- a/client/potentials/IMD/IMD.cpp
+++ b/client/potentials/IMD/IMD.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #include <cstdio>

--- a/client/potentials/IMD/IMD.cpp
+++ b/client/potentials/IMD/IMD.cpp
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #include <cstdio>
 #include <errno.h>

--- a/client/potentials/IMD/IMD.h
+++ b/client/potentials/IMD/IMD.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #ifndef IMD_POTENTIAL

--- a/client/potentials/IMD/IMD.h
+++ b/client/potentials/IMD/IMD.h
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #ifndef IMD_POTENTIAL
 #define IMD_POTENTIAL

--- a/client/potentials/IMD/IMD.h
+++ b/client/potentials/IMD/IMD.h
@@ -9,9 +9,7 @@
 ** Repo:
 ** https://github.com/TheochemUI/eOn
 */
-
-#ifndef IMD_POTENTIAL
-#define IMD_POTENTIAL
+#pragma once
 
 #include "../../Potential.h"
 
@@ -35,4 +33,3 @@ private:
   //        static pid_t vaspPID;
 };
 
-#endif

--- a/client/potentials/IMD/filesForIMD/imd_cg.c
+++ b/client/potentials/IMD/filesForIMD/imd_cg.c
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 /******************************************************************************
  *

--- a/client/potentials/IMD/filesForIMD/imd_cg.c
+++ b/client/potentials/IMD/filesForIMD/imd_cg.c
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 /******************************************************************************
  *
  * IMD -- The ITAP Molecular Dynamics Program

--- a/client/potentials/LAMMPS/LAMMPSPot.cpp
+++ b/client/potentials/LAMMPS/LAMMPSPot.cpp
@@ -1,4 +1,16 @@
-#include "LAMMPSPot.h"
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+#include "LAMMPS.h"
+#include "library.h"
 #include <map>
 #include <string.h>
 #include <sys/stat.h>

--- a/client/potentials/LAMMPS/LAMMPSPot.cpp
+++ b/client/potentials/LAMMPS/LAMMPSPot.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "LAMMPS.h"
 #include "library.h"

--- a/client/potentials/LAMMPS/LAMMPSPot.h
+++ b/client/potentials/LAMMPS/LAMMPSPot.h
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 // serves as an interface between LAMMPS potentials maintained by SANDIA
 
 #pragma once

--- a/client/potentials/LAMMPS/LAMMPSPot.h
+++ b/client/potentials/LAMMPS/LAMMPSPot.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 // serves as an interface between LAMMPS potentials maintained by SANDIA
 

--- a/client/potentials/LJ/LJ.cpp
+++ b/client/potentials/LJ/LJ.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #include "LJ.h"

--- a/client/potentials/LJ/LJ.cpp
+++ b/client/potentials/LJ/LJ.cpp
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #include "LJ.h"
 

--- a/client/potentials/LJ/LJ.h
+++ b/client/potentials/LJ/LJ.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #ifndef LENNARD_JONES

--- a/client/potentials/LJ/LJ.h
+++ b/client/potentials/LJ/LJ.h
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #ifndef LENNARD_JONES
 #define LENNARD_JONES

--- a/client/potentials/LJ/LJ.h
+++ b/client/potentials/LJ/LJ.h
@@ -9,9 +9,7 @@
 ** Repo:
 ** https://github.com/TheochemUI/eOn
 */
-
-#ifndef LENNARD_JONES
-#define LENNARD_JONES
+#pragma once
 
 #include <iostream>
 #include <math.h>
@@ -44,4 +42,3 @@ public:
 
   void setParameters(double r0Recieved, double u0Recieved, double psiRecieved);
 };
-#endif

--- a/client/potentials/LJCluster/LJCluster.cpp
+++ b/client/potentials/LJCluster/LJCluster.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #include "LJCluster.h"

--- a/client/potentials/LJCluster/LJCluster.cpp
+++ b/client/potentials/LJCluster/LJCluster.cpp
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #include "LJCluster.h"
 

--- a/client/potentials/LJCluster/LJCluster.h
+++ b/client/potentials/LJCluster/LJCluster.h
@@ -9,9 +9,7 @@
 ** Repo:
 ** https://github.com/TheochemUI/eOn
 */
-
-#ifndef LENNARD_JONES_CLUSTER_H
-#define LENNARD_JONES_CLUSTER_H
+#pragma once
 
 #include <iostream>
 #include <math.h>
@@ -46,4 +44,3 @@ public:
              double *U, double *variance, const double *box) override;
   void setParameters(double r0Recieved, double u0Recieved, double psiRecieved);
 };
-#endif

--- a/client/potentials/LJCluster/LJCluster.h
+++ b/client/potentials/LJCluster/LJCluster.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #ifndef LENNARD_JONES_CLUSTER_H

--- a/client/potentials/LJCluster/LJCluster.h
+++ b/client/potentials/LJCluster/LJCluster.h
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #ifndef LENNARD_JONES_CLUSTER_H
 #define LENNARD_JONES_CLUSTER_H

--- a/client/potentials/Lenosky/Lenosky.cpp
+++ b/client/potentials/Lenosky/Lenosky.cpp
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #include "Lenosky.h"
 

--- a/client/potentials/Lenosky/Lenosky.cpp
+++ b/client/potentials/Lenosky/Lenosky.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #include "Lenosky.h"

--- a/client/potentials/Lenosky/Lenosky.h
+++ b/client/potentials/Lenosky/Lenosky.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #ifndef LENOSKY_POTENTIAL

--- a/client/potentials/Lenosky/Lenosky.h
+++ b/client/potentials/Lenosky/Lenosky.h
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #ifndef LENOSKY_POTENTIAL
 #define LENOSKY_POTENTIAL

--- a/client/potentials/Lenosky/Lenosky.h
+++ b/client/potentials/Lenosky/Lenosky.h
@@ -9,9 +9,7 @@
 ** Repo:
 ** https://github.com/TheochemUI/eOn
 */
-
-#ifndef LENOSKY_POTENTIAL
-#define LENOSKY_POTENTIAL
+#pragma once
 
 #include "../../Potential.h"
 
@@ -41,4 +39,3 @@ public:
   void force(long N, const double *R, const int *atomicNrs, double *F,
              double *U, double *variance, const double *box) override;
 };
-#endif

--- a/client/potentials/Lenosky/lenoskyFortran.f90
+++ b/client/potentials/Lenosky/lenoskyFortran.f90
@@ -1,12 +1,12 @@
-!    ! This file is part of eON.
+!    ! This file is part of eOn.
 !
 ! SPDX-License-Identifier: BSD-3-Clause
 !
-! Copyright (c) 2010--present, eON Development Team
+! Copyright (c) 2010--present, eOn Development Team
 ! All rights reserved.
 !
 ! Repo:
-! https://github.com/TheochemUI/eON
+! https://github.com/TheochemUI/eOn
 
 !     Last change:  AA    6 Jun 2002    6:54 pm
 !

--- a/client/potentials/Lenosky/lenoskyFortran.f90
+++ b/client/potentials/Lenosky/lenoskyFortran.f90
@@ -1,3 +1,13 @@
+!    ! This file is part of eON.
+!
+! SPDX-License-Identifier: BSD-3-Clause
+!
+! Copyright (c) 2010--present, eON Development Team
+! All rights reserved.
+!
+! Repo:
+! https://github.com/TheochemUI/eON
+
 !     Last change:  AA    6 Jun 2002    6:54 pm
 !
 !  SUBROUTINE potinit()

--- a/client/potentials/MPIPot/MPIPot.cpp
+++ b/client/potentials/MPIPot/MPIPot.cpp
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #include "MPIPot.h"
 #include <mpi.h>

--- a/client/potentials/MPIPot/MPIPot.cpp
+++ b/client/potentials/MPIPot/MPIPot.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #include "MPIPot.h"

--- a/client/potentials/MPIPot/MPIPot.h
+++ b/client/potentials/MPIPot/MPIPot.h
@@ -9,9 +9,7 @@
 ** Repo:
 ** https://github.com/TheochemUI/eOn
 */
-
-#ifndef __MPI_POTENTIAL__
-#define __MPI_POTENTIAL__
+#pragma once
 
 #include "../../Parameters.h"
 #include "../../Potential.h"
@@ -31,4 +29,3 @@ private:
   double poll_period;
 };
 
-#endif

--- a/client/potentials/MPIPot/MPIPot.h
+++ b/client/potentials/MPIPot/MPIPot.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #ifndef __MPI_POTENTIAL__

--- a/client/potentials/MPIPot/MPIPot.h
+++ b/client/potentials/MPIPot/MPIPot.h
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #ifndef __MPI_POTENTIAL__
 #define __MPI_POTENTIAL__

--- a/client/potentials/Metatomic/MetatomicPotential.h
+++ b/client/potentials/Metatomic/MetatomicPotential.h
@@ -1,5 +1,15 @@
-#ifndef METATOMIC_POTENTIAL_H
-#define METATOMIC_POTENTIAL_H
+/*
+** This file is part of eOn.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eOn Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eOn
+*/
+#pragma once
 
 #include "../../Potential.h"
 
@@ -104,5 +114,3 @@ public:
                double *forces, double *energy, double *variance,
                const double *box) override;
 };
-
-#endif // METATOMIC_POTENTIAL_H

--- a/client/potentials/Morse/Morse.cpp
+++ b/client/potentials/Morse/Morse.cpp
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #include "Morse.h"
 #include <cassert>

--- a/client/potentials/Morse/Morse.cpp
+++ b/client/potentials/Morse/Morse.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #include "Morse.h"

--- a/client/potentials/Morse/Morse.h
+++ b/client/potentials/Morse/Morse.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #ifndef MORSE

--- a/client/potentials/Morse/Morse.h
+++ b/client/potentials/Morse/Morse.h
@@ -9,9 +9,8 @@
 ** Repo:
 ** https://github.com/TheochemUI/eOn
 */
+#pragma once
 
-#ifndef MORSE
-#define MORSE
 /** @file
       @brief Morse potential for platinum
       @author Anonymous (possibly A. Pedersen or G. Henkelman), revision: Jean
@@ -46,4 +45,3 @@ private:
   double cutoff_;
   double energyCutoff_;
 };
-#endif

--- a/client/potentials/Morse/Morse.h
+++ b/client/potentials/Morse/Morse.h
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #ifndef MORSE
 #define MORSE

--- a/client/potentials/NewPot/NewPot.cpp
+++ b/client/potentials/NewPot/NewPot.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #include "NewPot.h"

--- a/client/potentials/NewPot/NewPot.cpp
+++ b/client/potentials/NewPot/NewPot.cpp
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #include "NewPot.h"
 

--- a/client/potentials/NewPot/NewPot.h
+++ b/client/potentials/NewPot/NewPot.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #ifndef NEWPOT_INTERFACE

--- a/client/potentials/NewPot/NewPot.h
+++ b/client/potentials/NewPot/NewPot.h
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #ifndef NEWPOT_INTERFACE
 #define NEWPOT_INTERFACE

--- a/client/potentials/NewPot/NewPot.h
+++ b/client/potentials/NewPot/NewPot.h
@@ -9,9 +9,7 @@
 ** Repo:
 ** https://github.com/TheochemUI/eOn
 */
-
-#ifndef NEWPOT_INTERFACE
-#define NEWPOT_INTERFACE
+#pragma once
 
 #include "../../Potential.h"
 
@@ -34,4 +32,3 @@ public:
   void force(long N, const double *R, const int *atomicNrs, double *F,
              double *U, double *variance, const double *box) override;
 };
-#endif

--- a/client/potentials/PyAMFF/PyAMFF.cpp
+++ b/client/potentials/PyAMFF/PyAMFF.cpp
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "PyAMFF.h"
 #include <iostream>
 #include <set>

--- a/client/potentials/PyAMFF/PyAMFF.cpp
+++ b/client/potentials/PyAMFF/PyAMFF.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "PyAMFF.h"
 #include <iostream>

--- a/client/potentials/PyAMFF/PyAMFF.h
+++ b/client/potentials/PyAMFF/PyAMFF.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #ifndef PYAMFF_POTENTIAL

--- a/client/potentials/PyAMFF/PyAMFF.h
+++ b/client/potentials/PyAMFF/PyAMFF.h
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #ifndef PYAMFF_POTENTIAL
 #define PYAMFF_POTENTIAL

--- a/client/potentials/PyAMFF/PyAMFF.h
+++ b/client/potentials/PyAMFF/PyAMFF.h
@@ -9,9 +9,7 @@
 ** Repo:
 ** https://github.com/TheochemUI/eOn
 */
-
-#ifndef PYAMFF_POTENTIAL
-#define PYAMFF_POTENTIAL
+#pragma once
 
 #include "../../Potential.h"
 
@@ -32,4 +30,3 @@ public:
              double *U, double *variance, const double *box);
   bool new_pyamff;
 };
-#endif

--- a/client/potentials/QSC/Parameters.h
+++ b/client/potentials/QSC/Parameters.h
@@ -9,6 +9,7 @@
 ** Repo:
 ** https://github.com/TheochemUI/eOn
 */
+#pragma once
 const QSC::qsc_parameters QSC::qsc_default_params[] = {
   //{ Z,    n,   m,   epsilon,       c,      a}
     {28, 10.0, 5.0, 7.3767e-3,  84.745, 3.5157}, // Ni

--- a/client/potentials/QSC/Parameters.h
+++ b/client/potentials/QSC/Parameters.h
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 const QSC::qsc_parameters QSC::qsc_default_params[] = {
   //{ Z,    n,   m,   epsilon,       c,      a}
     {28, 10.0, 5.0, 7.3767e-3,  84.745, 3.5157}, // Ni

--- a/client/potentials/QSC/Parameters.h
+++ b/client/potentials/QSC/Parameters.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 const QSC::qsc_parameters QSC::qsc_default_params[] = {
   //{ Z,    n,   m,   epsilon,       c,      a}

--- a/client/potentials/QSC/QSC.cpp
+++ b/client/potentials/QSC/QSC.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "stdio.h"
 #include <cassert>

--- a/client/potentials/QSC/QSC.cpp
+++ b/client/potentials/QSC/QSC.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "stdio.h"
 #include <cassert>
 #include <math.h>

--- a/client/potentials/QSC/QSC.h
+++ b/client/potentials/QSC/QSC.h
@@ -9,6 +9,7 @@
 ** Repo:
 ** https://github.com/TheochemUI/eOn
 */
+#pragma once
 #include <vector>
 
 #ifndef QSC_STANDALONE

--- a/client/potentials/QSC/QSC.h
+++ b/client/potentials/QSC/QSC.h
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include <vector>
 
 #ifndef QSC_STANDALONE

--- a/client/potentials/QSC/QSC.h
+++ b/client/potentials/QSC/QSC.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include <vector>
 

--- a/client/potentials/SW/SW.cpp
+++ b/client/potentials/SW/SW.cpp
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #include "SW.h"
 

--- a/client/potentials/SW/SW.cpp
+++ b/client/potentials/SW/SW.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #include "SW.h"

--- a/client/potentials/SW/SW.h
+++ b/client/potentials/SW/SW.h
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #ifndef SW_POTENTIAL
 #define SW_POTENTIAL

--- a/client/potentials/SW/SW.h
+++ b/client/potentials/SW/SW.h
@@ -9,9 +9,7 @@
 ** Repo:
 ** https://github.com/TheochemUI/eOn
 */
-
-#ifndef SW_POTENTIAL
-#define SW_POTENTIAL
+#pragma once
 
 #include "../../Potential.h"
 
@@ -45,4 +43,3 @@ public:
   void force(long N, const double *R, const int *atomicNrs, double *F,
              double *U, double *variance, const double *box);
 };
-#endif

--- a/client/potentials/SW/SW.h
+++ b/client/potentials/SW/SW.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #ifndef SW_POTENTIAL

--- a/client/potentials/SW/SWFortran.f90
+++ b/client/potentials/SW/SWFortran.f90
@@ -1,3 +1,13 @@
+! This file is part of eOn.
+!
+! SPDX-License-Identifier: BSD-3-Clause
+!
+! Copyright (c) 2010--present, eOn Development Team
+! All rights reserved.
+!
+! Repo:
+! https://github.com/TheochemUI/eOn
+
 !     Last change:  AA    3 Apr 2002    2:31 pm
 !-----------------------------------------------------------------------------------!
 

--- a/client/potentials/SocketNWChem/SocketNWChemPot.h
+++ b/client/potentials/SocketNWChem/SocketNWChemPot.h
@@ -1,5 +1,15 @@
-#ifndef SOCKET_NWCHEM_POT_H
-#define SOCKET_NWCHEM_POT_H
+/*
+** This file is part of eOn.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eOn Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eOn
+*/
+#pragma once
 
 #include "../../Potential.h"
 #include <memory>
@@ -82,5 +92,3 @@ private:
   static constexpr double BOHR_IN_ANGSTROM = 0.529177210903;
   static constexpr double HARTREE_IN_EV = 27.211386245988;
 };
-
-#endif // SOCKET_NWCHEM_POT_H

--- a/client/potentials/Tersoff/Tersoff.cpp
+++ b/client/potentials/Tersoff/Tersoff.cpp
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #include "Tersoff.h"
 

--- a/client/potentials/Tersoff/Tersoff.cpp
+++ b/client/potentials/Tersoff/Tersoff.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #include "Tersoff.h"

--- a/client/potentials/Tersoff/Tersoff.h
+++ b/client/potentials/Tersoff/Tersoff.h
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #ifndef TERSOFF_POTENTIAL
 #define TERSOFF_POTENTIAL

--- a/client/potentials/Tersoff/Tersoff.h
+++ b/client/potentials/Tersoff/Tersoff.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #ifndef TERSOFF_POTENTIAL

--- a/client/potentials/Tersoff/Tersoff.h
+++ b/client/potentials/Tersoff/Tersoff.h
@@ -9,9 +9,7 @@
 ** Repo:
 ** https://github.com/TheochemUI/eOn
 */
-
-#ifndef TERSOFF_POTENTIAL
-#define TERSOFF_POTENTIAL
+#pragma once
 
 #include "../../Potential.h"
 
@@ -43,4 +41,3 @@ public:
   void force(long N, const double *R, const int *atomicNrs, double *F,
              double *U, double *variance, const double *box);
 };
-#endif

--- a/client/potentials/Tersoff/tersoffFortran.f90
+++ b/client/potentials/Tersoff/tersoffFortran.f90
@@ -1,3 +1,13 @@
+! This file is part of eOn.
+!
+! SPDX-License-Identifier: BSD-3-Clause
+!
+! Copyright (c) 2010--present, eOn Development Team
+! All rights reserved.
+!
+! Repo:
+! https://github.com/TheochemUI/eOn
+
 !   for version EAMf of the MD code, Feb 1995.  (Modified by Graeme)
 !   for EAM version E     Feb 1994
 !   Tersoff potential:   Sept 14. 1993   based on EAMd version

--- a/client/potentials/VASP/VASP.cpp
+++ b/client/potentials/VASP/VASP.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #include <cstdio>

--- a/client/potentials/VASP/VASP.cpp
+++ b/client/potentials/VASP/VASP.cpp
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #include <cstdio>
 #include <errno.h>

--- a/client/potentials/VASP/VASP.h
+++ b/client/potentials/VASP/VASP.h
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #ifndef VASP_POTENTIAL
 #define VASP_POTENTIAL

--- a/client/potentials/VASP/VASP.h
+++ b/client/potentials/VASP/VASP.h
@@ -9,9 +9,7 @@
 ** Repo:
 ** https://github.com/TheochemUI/eOn
 */
-
-#ifndef VASP_POTENTIAL
-#define VASP_POTENTIAL
+#pragma once
 
 #include "../../Potential.h"
 
@@ -55,4 +53,3 @@ private:
   static pid_t vaspPID;
 };
 
-#endif

--- a/client/potentials/VASP/VASP.h
+++ b/client/potentials/VASP/VASP.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #ifndef VASP_POTENTIAL

--- a/client/potentials/Water/Water.cpp
+++ b/client/potentials/Water/Water.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "Water.hpp"
 

--- a/client/potentials/Water/Water.cpp
+++ b/client/potentials/Water/Water.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "Water.hpp"
 
 void Tip4p::force(long N, const double *R, const int *atomicNrs, double *F,

--- a/client/potentials/Water/Water.hpp
+++ b/client/potentials/Water/Water.hpp
@@ -9,6 +9,7 @@
 ** Repo:
 ** https://github.com/TheochemUI/eOn
 */
+#pragma once
 /** @file
 Wrapper for Eon
 @author Jean-Claude C. Berthet
@@ -16,8 +17,6 @@ Wrapper for Eon
 University of Iceland
 */
 
-#ifndef WATER_FOR_EON_HPP
-#define WATER_FOR_EON_HPP
 #include "../../Potential.h"
 #include "spce_ccl.hpp"
 #include "tip4p_ccl.hpp"
@@ -47,5 +46,3 @@ public:
   void force(long N, const double *R, const int *atomicNrs, double *F,
              double *U, double *variance, const double *box) override;
 };
-
-#endif

--- a/client/potentials/Water/Water.hpp
+++ b/client/potentials/Water/Water.hpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 /** @file
 Wrapper for Eon

--- a/client/potentials/Water/Water.hpp
+++ b/client/potentials/Water/Water.hpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 /** @file
 Wrapper for Eon
 @author Jean-Claude C. Berthet

--- a/client/potentials/Water/ccl.cpp
+++ b/client/potentials/Water/ccl.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 /** @file
 Potential CCL Table II for intramolecular interactions in water.
 @author Jean-Claude C. Berthet

--- a/client/potentials/Water/ccl.cpp
+++ b/client/potentials/Water/ccl.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 /** @file
 Potential CCL Table II for intramolecular interactions in water.

--- a/client/potentials/Water/ccl.hpp
+++ b/client/potentials/Water/ccl.hpp
@@ -10,8 +10,6 @@
 ** https://github.com/TheochemUI/eOn
 */
 #pragma once
-#ifndef FORCEFIELDS_CCL_HPP
-#define FORCEFIELDS_CCL_HPP
 #include "potential_base.hpp"
 
 /** @file
@@ -106,4 +104,3 @@ private:
   void theta_4(Dtheta const &s3, double &energy, double &d3);
 };
 } // namespace forcefields
-#endif

--- a/client/potentials/Water/ccl.hpp
+++ b/client/potentials/Water/ccl.hpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #pragma once
 #ifndef FORCEFIELDS_CCL_HPP
 #define FORCEFIELDS_CCL_HPP

--- a/client/potentials/Water/ccl.hpp
+++ b/client/potentials/Water/ccl.hpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 #ifndef FORCEFIELDS_CCL_HPP

--- a/client/potentials/Water/potential_base.cpp
+++ b/client/potentials/Water/potential_base.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 /** @file
 Basic  tools to write potentials.
 @author Jean-Claude C. Berthet

--- a/client/potentials/Water/potential_base.cpp
+++ b/client/potentials/Water/potential_base.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 /** @file
 Basic  tools to write potentials.

--- a/client/potentials/Water/potential_base.hpp
+++ b/client/potentials/Water/potential_base.hpp
@@ -10,8 +10,6 @@
 ** https://github.com/TheochemUI/eOn
 */
 #pragma once
-#ifndef FORCEFIELDS_POTENTIAL_BASE_HPP
-#define FORCEFIELDS_POTENTIAL_BASE_HPP
 
 #include <cassert>
 #include <cmath>
@@ -247,5 +245,3 @@ void forcefields::PotentialBase::normalise(double v[]) {
   double const n = norm(v);
   divide(v, n);
 }
-
-#endif

--- a/client/potentials/Water/potential_base.hpp
+++ b/client/potentials/Water/potential_base.hpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 #ifndef FORCEFIELDS_POTENTIAL_BASE_HPP

--- a/client/potentials/Water/potential_base.hpp
+++ b/client/potentials/Water/potential_base.hpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #pragma once
 #ifndef FORCEFIELDS_POTENTIAL_BASE_HPP
 #define FORCEFIELDS_POTENTIAL_BASE_HPP

--- a/client/potentials/Water/spce_ccl.cpp
+++ b/client/potentials/Water/spce_ccl.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 /** @file
 SPC/E potential for water.

--- a/client/potentials/Water/spce_ccl.cpp
+++ b/client/potentials/Water/spce_ccl.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 /** @file
 SPC/E potential for water.
 @author Jean-Claude C. Berthet

--- a/client/potentials/Water/spce_ccl.hpp
+++ b/client/potentials/Water/spce_ccl.hpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #pragma once
 #ifndef FORCEFIELDS_SPCE_CCL_HPP
 #define FORCEFIELDS_SPCE_CCL_HPP

--- a/client/potentials/Water/spce_ccl.hpp
+++ b/client/potentials/Water/spce_ccl.hpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 #ifndef FORCEFIELDS_SPCE_CCL_HPP

--- a/client/potentials/Water/spce_ccl.hpp
+++ b/client/potentials/Water/spce_ccl.hpp
@@ -10,8 +10,6 @@
 ** https://github.com/TheochemUI/eOn
 */
 #pragma once
-#ifndef FORCEFIELDS_SPCE_CCL_HPP
-#define FORCEFIELDS_SPCE_CCL_HPP
 #include "ccl.hpp"
 /** @file
 SPC/E potential for water.
@@ -202,4 +200,3 @@ private:
                        bool const (*const xo)[O] = 0);
 };
 } // namespace forcefields
-#endif

--- a/client/potentials/Water/tip4p_ccl.cpp
+++ b/client/potentials/Water/tip4p_ccl.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 /** @file
 TIP4P potential for water
 @author Jean-Claude C. Berthet

--- a/client/potentials/Water/tip4p_ccl.cpp
+++ b/client/potentials/Water/tip4p_ccl.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 /** @file
 TIP4P potential for water

--- a/client/potentials/Water/tip4p_ccl.hpp
+++ b/client/potentials/Water/tip4p_ccl.hpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 #ifndef FORCEFIELDS_TIP4P_CCL_HPP

--- a/client/potentials/Water/tip4p_ccl.hpp
+++ b/client/potentials/Water/tip4p_ccl.hpp
@@ -10,8 +10,6 @@
 ** https://github.com/TheochemUI/eOn
 */
 #pragma once
-#ifndef FORCEFIELDS_TIP4P_CCL_HPP
-#define FORCEFIELDS_TIP4P_CCL_HPP
 #include "ccl.hpp"
 
 /** @file
@@ -49,4 +47,3 @@ private:
   void lennardJonesWithCutoff(Water &w1, Water &w2, double &U);
 };
 } // namespace forcefields
-#endif

--- a/client/potentials/Water/tip4p_ccl.hpp
+++ b/client/potentials/Water/tip4p_ccl.hpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #pragma once
 #ifndef FORCEFIELDS_TIP4P_CCL_HPP
 #define FORCEFIELDS_TIP4P_CCL_HPP

--- a/client/potentials/Water/tip4p_unit_system.hpp
+++ b/client/potentials/Water/tip4p_unit_system.hpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 #ifndef FORCEFIELDS_UNIT_SYSTEM_HPP

--- a/client/potentials/Water/tip4p_unit_system.hpp
+++ b/client/potentials/Water/tip4p_unit_system.hpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #pragma once
 #ifndef FORCEFIELDS_UNIT_SYSTEM_HPP
 #define FORCEFIELDS_UNIT_SYSTEM_HPP

--- a/client/potentials/Water/tip4p_unit_system.hpp
+++ b/client/potentials/Water/tip4p_unit_system.hpp
@@ -10,8 +10,6 @@
 ** https://github.com/TheochemUI/eOn
 */
 #pragma once
-#ifndef FORCEFIELDS_UNIT_SYSTEM_HPP
-#define FORCEFIELDS_UNIT_SYSTEM_HPP
 
 /** @file
 Physical constants, unit conversion.
@@ -282,5 +280,3 @@ const double ONE_OVER_4_PI_EPSILON0 =
     one_over_4_pi_epsilon0 * METRE * JOULE / COULOMB / COULOMB;
 } // namespace unit_system
 } // namespace forcefields
-
-#endif

--- a/client/potentials/Water_H/Tip4p_H.cpp
+++ b/client/potentials/Water_H/Tip4p_H.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 // the add H must be the last atom

--- a/client/potentials/Water_H/Tip4p_H.cpp
+++ b/client/potentials/Water_H/Tip4p_H.cpp
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 // the add H must be the last atom
 #include "Tip4p_H.h"

--- a/client/potentials/Water_H/Tip4p_H.h
+++ b/client/potentials/Water_H/Tip4p_H.h
@@ -9,9 +9,7 @@
 ** Repo:
 ** https://github.com/TheochemUI/eOn
 */
-
-#ifndef TIP4_H_POTENTIAL
-#define TIP4_H_POTENTIAL
+#pragma once
 
 #include "../../Potential.h"
 #include "../Water/Water.hpp"
@@ -51,4 +49,3 @@ public:
 private:
   std::shared_ptr<Tip4p> tip4p_pot;
 };
-#endif

--- a/client/potentials/Water_H/Tip4p_H.h
+++ b/client/potentials/Water_H/Tip4p_H.h
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #ifndef TIP4_H_POTENTIAL
 #define TIP4_H_POTENTIAL

--- a/client/potentials/Water_H/Tip4p_H.h
+++ b/client/potentials/Water_H/Tip4p_H.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #ifndef TIP4_H_POTENTIAL

--- a/client/potentials/Water_Pt/Tip4p_Pt.cpp
+++ b/client/potentials/Water_Pt/Tip4p_Pt.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "Tip4p_Pt.hpp"
 
 void Tip4p_Pt::force(long N, const double *R, const int *atomicNrs, double *F,

--- a/client/potentials/Water_Pt/Tip4p_Pt.cpp
+++ b/client/potentials/Water_Pt/Tip4p_Pt.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "Tip4p_Pt.hpp"
 

--- a/client/potentials/Water_Pt/Tip4p_Pt.hpp
+++ b/client/potentials/Water_Pt/Tip4p_Pt.hpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 /** @file
 Wrapper for Eon

--- a/client/potentials/Water_Pt/Tip4p_Pt.hpp
+++ b/client/potentials/Water_Pt/Tip4p_Pt.hpp
@@ -9,6 +9,7 @@
 ** Repo:
 ** https://github.com/TheochemUI/eOn
 */
+#pragma once
 /** @file
 Wrapper for Eon
 @author Jean-Claude C. Berthet
@@ -16,8 +17,6 @@ Wrapper for Eon
 University of Iceland
 */
 
-#ifndef TIP4P_PT
-#define TIP4P_PT
 #include "../../Potential.h"
 #include "zhu_philpott.hpp"
 
@@ -34,5 +33,3 @@ public:
   void force(long N, const double *R, const int *atomicNrs, double *F,
              double *U, double *variance, const double *box);
 };
-
-#endif

--- a/client/potentials/Water_Pt/Tip4p_Pt.hpp
+++ b/client/potentials/Water_Pt/Tip4p_Pt.hpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 /** @file
 Wrapper for Eon
 @author Jean-Claude C. Berthet

--- a/client/potentials/Water_Pt/zhu_philpott.cpp
+++ b/client/potentials/Water_Pt/zhu_philpott.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 /** @file
 Potential for water and Platinum
 @author Jean-Claude C. Berthet

--- a/client/potentials/Water_Pt/zhu_philpott.cpp
+++ b/client/potentials/Water_Pt/zhu_philpott.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 /** @file
 Potential for water and Platinum

--- a/client/potentials/Water_Pt/zhu_philpott.hpp
+++ b/client/potentials/Water_Pt/zhu_philpott.hpp
@@ -9,15 +9,13 @@
 ** Repo:
 ** https://github.com/TheochemUI/eOn
 */
+#pragma once
 /** @file
 Potential for water and Platinum
 @author Jean-Claude C. Berthet
 @date 2007
 University of Iceland
 */
-#pragma once
-#ifndef FORCEFIELDS_ZHU_PHILPOTT_HPP
-#define FORCEFIELDS_ZHU_PHILPOTT_HPP
 #include "../Water/spce_ccl.hpp"
 #include "zhu_philpott_parameters.hpp"
 
@@ -72,5 +70,3 @@ private:
 template class ZhuPhilpott<zhu_philpott_parameters::Standard>;
 template class ZhuPhilpott<zhu_philpott_parameters::Iceland>;
 } // namespace forcefields
-
-#endif

--- a/client/potentials/Water_Pt/zhu_philpott.hpp
+++ b/client/potentials/Water_Pt/zhu_philpott.hpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 /** @file
 Potential for water and Platinum
 @author Jean-Claude C. Berthet

--- a/client/potentials/Water_Pt/zhu_philpott.hpp
+++ b/client/potentials/Water_Pt/zhu_philpott.hpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 /** @file
 Potential for water and Platinum

--- a/client/potentials/Water_Pt/zhu_philpott_parameters.cpp
+++ b/client/potentials/Water_Pt/zhu_philpott_parameters.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 /** @file
 Parameters for potential ZhuPhilpott.

--- a/client/potentials/Water_Pt/zhu_philpott_parameters.cpp
+++ b/client/potentials/Water_Pt/zhu_philpott_parameters.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 /** @file
 Parameters for potential ZhuPhilpott.
 @author Jean-Claude C. Berthet

--- a/client/potentials/Water_Pt/zhu_philpott_parameters.hpp
+++ b/client/potentials/Water_Pt/zhu_philpott_parameters.hpp
@@ -9,6 +9,7 @@
 ** Repo:
 ** https://github.com/TheochemUI/eOn
 */
+#pragma once
 /** @file
 Parameters for potential ZhuPhilpott.
 @author Jean-Claude C. Berthet
@@ -16,9 +17,6 @@ Parameters for potential ZhuPhilpott.
 University of Iceland
 @see zhu_philpott.hpp
 */
-#pragma once
-#ifndef FORCEFIELDS_ZHU_PHILPOTT_PARAMETERS_HPP
-#define FORCEFIELDS_ZHU_PHILPOTT_PARAMETERS_HPP
 
 namespace forcefields {
 /// Parameters for ZhuPhilpott.
@@ -62,4 +60,3 @@ struct Iceland {
 };
 } // namespace zhu_philpott_parameters
 } // namespace forcefields
-#endif

--- a/client/potentials/Water_Pt/zhu_philpott_parameters.hpp
+++ b/client/potentials/Water_Pt/zhu_philpott_parameters.hpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 /** @file
 Parameters for potential ZhuPhilpott.

--- a/client/potentials/Water_Pt/zhu_philpott_parameters.hpp
+++ b/client/potentials/Water_Pt/zhu_philpott_parameters.hpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 /** @file
 Parameters for potential ZhuPhilpott.
 @author Jean-Claude C. Berthet

--- a/client/potentials/XTBPot/XTBPot.cpp
+++ b/client/potentials/XTBPot/XTBPot.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #include "XTBPot.h"

--- a/client/potentials/XTBPot/XTBPot.cpp
+++ b/client/potentials/XTBPot/XTBPot.cpp
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #include "XTBPot.h"
 #include <cstddef>

--- a/client/potentials/XTBPot/XTBPot.h
+++ b/client/potentials/XTBPot/XTBPot.h
@@ -9,7 +9,6 @@
 ** Repo:
 ** https://github.com/TheochemUI/eOn
 */
-
 #pragma once
 
 #include "../../Potential.h"

--- a/client/potentials/XTBPot/XTBPot.h
+++ b/client/potentials/XTBPot/XTBPot.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #pragma once

--- a/client/potentials/XTBPot/XTBPot.h
+++ b/client/potentials/XTBPot/XTBPot.h
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #pragma once
 

--- a/client/potentials/XTBPot/units.hpp
+++ b/client/potentials/XTBPot/units.hpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #pragma once
 /** @file
 Physical constants, unit conversion.

--- a/client/potentials/XTBPot/units.hpp
+++ b/client/potentials/XTBPot/units.hpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #pragma once
 /** @file

--- a/client/potentials/XTBPot/xtb.h
+++ b/client/potentials/XTBPot/xtb.h
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 /* This file is part of xtb.
  *
  * Copyright (C) 2019-2020  Sebastian Ehlert

--- a/client/potentials/XTBPot/xtb.h
+++ b/client/potentials/XTBPot/xtb.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 /* This file is part of xtb.
  *

--- a/client/potentials/XTBPot/xtb.h
+++ b/client/potentials/XTBPot/xtb.h
@@ -1,14 +1,3 @@
-/*
-** This file is part of eOn.
-**
-** SPDX-License-Identifier: BSD-3-Clause
-**
-** Copyright (c) 2010--present, eOn Development Team
-** All rights reserved.
-**
-** Repo:
-** https://github.com/TheochemUI/eOn
-*/
 /* This file is part of xtb.
  *
  * Copyright (C) 2019-2020  Sebastian Ehlert

--- a/client/potentials/ZBL/ZBLPot.h
+++ b/client/potentials/ZBL/ZBLPot.h
@@ -1,5 +1,15 @@
-#ifndef ZBLPOT_H
-#define ZBLPOT_H
+/*
+** This file is part of eOn.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eOn Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eOn
+*/
+#pragma once
 
 #include "../../Potential.h"
 #include <map>
@@ -77,5 +87,3 @@ private:
   // Conversion factor in LAMMPS 'metal' units (eV*Angstrom)
   static constexpr double QQR2E = 14.399645;
 };
-
-#endif // ZBLPOT_H

--- a/client/testWriteR.cpp
+++ b/client/testWriteR.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "Matter.h"
 #include "Parameters.h"

--- a/client/testWriteR.cpp
+++ b/client/testWriteR.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "Matter.h"
 #include "Parameters.h"
 #include <cstdlib>

--- a/client/testpot.cpp
+++ b/client/testpot.cpp
@@ -1,3 +1,14 @@
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 #include "Matter.h"
 #include "Parameters.h"
 #include "Potential.h"

--- a/client/testpot.cpp
+++ b/client/testpot.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 #include "Matter.h"
 #include "Parameters.h"

--- a/client/unittests/utHelperFunctions.cpp
+++ b/client/unittests/utHelperFunctions.cpp
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-//// eOn is free software: you can redistribute it and/or modify
-//// it under the terms of the GNU General Public License as published by
-//// the Free Software Foundation, either version 3 of the License, or
-//// (at your option) any later version.
-////
-//// A copy of the GNU General Public License is available at
-//// http://www.gnu.org/licenses/
-////-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #include "utHelperFunctions.h"
 

--- a/client/unittests/utHelperFunctions.cpp
+++ b/client/unittests/utHelperFunctions.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #include "utHelperFunctions.h"

--- a/client/unittests/utHelperFunctions.h
+++ b/client/unittests/utHelperFunctions.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #ifndef UT_HELPER_FUNCTIONS_H

--- a/client/unittests/utHelperFunctions.h
+++ b/client/unittests/utHelperFunctions.h
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-// eOn is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// A copy of the GNU General Public License is available at
-// http://www.gnu.org/licenses/
-//-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #ifndef UT_HELPER_FUNCTIONS_H
 #define UT_HELPER_FUNCTIONS_H

--- a/client/unittests/utMainTest.cpp
+++ b/client/unittests/utMainTest.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #include "utObjectiveTest.h"

--- a/client/unittests/utMainTest.cpp
+++ b/client/unittests/utMainTest.cpp
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-//// eOn is free software: you can redistribute it and/or modify
-//// it under the terms of the GNU General Public License as published by
-//// the Free Software Foundation, either version 3 of the License, or
-//// (at your option) any later version.
-////
-//// A copy of the GNU General Public License is available at
-//// http://www.gnu.org/licenses/
-////-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #include "utObjectiveTest.h"
 #include <iostream>

--- a/client/unittests/utObjectiveTest.cpp
+++ b/client/unittests/utObjectiveTest.cpp
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #include "utObjectiveTest.h"

--- a/client/unittests/utObjectiveTest.cpp
+++ b/client/unittests/utObjectiveTest.cpp
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-//// eOn is free software: you can redistribute it and/or modify
-//// it under the terms of the GNU General Public License as published by
-//// the Free Software Foundation, either version 3 of the License, or
-//// (at your option) any later version.
-////
-//// A copy of the GNU General Public License is available at
-//// http://www.gnu.org/licenses/
-////-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #include "utObjectiveTest.h"
 #include <fstream>

--- a/client/unittests/utObjectiveTest.h
+++ b/client/unittests/utObjectiveTest.h
@@ -1,12 +1,14 @@
-//-----------------------------------------------------------------------------------
-//// eOn is free software: you can redistribute it and/or modify
-//// it under the terms of the GNU General Public License as published by
-//// the Free Software Foundation, either version 3 of the License, or
-//// (at your option) any later version.
-////
-//// A copy of the GNU General Public License is available at
-//// http://www.gnu.org/licenses/
-////-----------------------------------------------------------------------------------
+/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
 
 #ifndef OBJECTIVE_TEST_H
 #define OBJECTIVE_TEST_H

--- a/client/unittests/utObjectiveTest.h
+++ b/client/unittests/utObjectiveTest.h
@@ -1,13 +1,13 @@
 /*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 
 #ifndef OBJECTIVE_TEST_H

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,7 +6,7 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = "eON"
+project = "eOn"
 copyright = "2024, Henkelmann Group, Jonsson Group, Rohit Goswami"
 author = "Rohit Goswami"
 release = "2.0.0"
@@ -54,7 +54,7 @@ exclude_patterns = []
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 html_theme = "sphinx_book_theme"
-html_title = "eON"
+html_title = "eOn"
 html_static_path = ["_static"]
 
 html_theme_options = {

--- a/docs/source/devdocs/design/client/index.md
+++ b/docs/source/devdocs/design/client/index.md
@@ -1,0 +1,10 @@
+# Client design
+
+Guidelines and rationale for the `C++` core of eOn.
+
+```{toctree}
+:maxdepth: 2
+:caption: Components
+
+types
+```

--- a/docs/source/devdocs/design/client/types.md
+++ b/docs/source/devdocs/design/client/types.md
@@ -1,0 +1,17 @@
+# Type system
+
+`eOn` was written to use `Eigen` as the matrix multiplication library.
+*However*, we define `EIGEN_DEFAULT_TO_ROW_MAJOR` which makes the Eigen
+constructs of `eOn` not directly interoperable with those from other libraries.
+
+```{versionchanged} 2.x
+Generic type interfaces were setup, to eventually transition away from the preprocessor macro.
+```
+
+## Header conventions
+
+```{versionchanged} 2.x
+```
+
+- `include-what-you-use`
+- `pragma once` is preferred over setting `ifdef`s

--- a/docs/source/devdocs/docbuild.md
+++ b/docs/source/devdocs/docbuild.md
@@ -1,6 +1,6 @@
 # Working with the documentation
 
-`eON` is a relatively complex project, with both `C++` and `Python` sources,
+`eOn` is a relatively complex project, with both `C++` and `Python` sources,
 along with a large set of options.
 
 ```{versionchanged} 2.1_TBA

--- a/docs/source/devdocs/index.md
+++ b/docs/source/devdocs/index.md
@@ -1,6 +1,6 @@
 # Development Documentation
 
-For all changes to `eON`, the best way to get in touch with the developers is to
+For all changes to `eOn`, the best way to get in touch with the developers is to
 open an issue on the Github repository.
 
 Pull requests and documentation contributions are all highly appreciated.

--- a/docs/source/devdocs/svn-migration.md
+++ b/docs/source/devdocs/svn-migration.md
@@ -63,7 +63,7 @@ Since the SVN source has no tags or branches, there are no cleanup tasks
 required.
 
 ```{note}
-`eON` used to use CVS for managing history, which was not imported when the switch to SVN took place, so rememeber to rebase a dummy commit co-authored by contributors before 2010!
+`eOn` used to use CVS for managing history, which was not imported when the switch to SVN took place, so rememeber to rebase a dummy commit co-authored by contributors before 2010!
 ```
 
 Since we already have `svn` as a branch and even tags, it is a bit of a pain to

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -1,4 +1,4 @@
-# eON: Long Timescale Dynamics Software
+# eOn: Long Timescale Dynamics Software
 
 The EON software package contains a set of algorithms used primarily to model
 the evolution of atomic scale systems over long time scales. Standard molecular
@@ -14,7 +14,7 @@ hyperdyamics, adaptive kinetic Monte Carlo, and basin hopping.
 
 ## Supported systems
 
-eON can handle both molecular systems (e.g. gas-phase reactions) and extended
+eOn can handle both molecular systems (e.g. gas-phase reactions) and extended
 (surface) systems, with robust periodic image boundary support.
 
 ```{figure} fig/esys_trans.png
@@ -23,7 +23,7 @@ alt: Collection of systems which can be modeled
 class: full-width
 align: center
 ---
-An overview of some systems modelled with eON
+An overview of some systems modelled with eOn
 ```
 
 However, the systems which are best modelled using EON are those in which the
@@ -47,12 +47,12 @@ island forms after `65720` transitions in a time scale of a `ms` at `300K`.
 
 # Interatomic Interactions
 
-There are a variety of empirical potentials included with `eON`. You can also
-use the potentials built into the LAMMPS library. `eON` also provides an
+There are a variety of empirical potentials included with `eOn`. You can also
+use the potentials built into the LAMMPS library. `eOn` also provides an
 interace to the VASP and GPAW density functional theory codes.
 
 ```{versionadded} 2.0
-`eON` now supports additional potentials
+`eOn` now supports additional potentials
 * via an embeded Python interpreter, all the potentials accessible from the atomic simulation environment, ASE.
 * via native Fortran-C interface, different forms of the tight binding `XTB` potentials
 * via an I/O and server-client interface, potentials from the Amsterdam Modeling Suite (AMS)

--- a/docs/source/install/ase.md
+++ b/docs/source/install/ase.md
@@ -1,6 +1,6 @@
 # ASE Interface
 
-In order to build eON client with the ability to use ASE calculators as a
+In order to build eOn client with the ability to use ASE calculators as a
 potential, the appropriate option must be setup when using `meson` which is
 `-Dwith_python=True -Dwith_ase=True`. 
 

--- a/docs/source/install/index.md
+++ b/docs/source/install/index.md
@@ -97,6 +97,7 @@ svn
 License](https://opensource.org/license/BSD-3-Clause).
 
 ## Vendored
+
 Some libraries[^2] are distributed along with `eOn`, namely:
 
 - `mcamc` which contains `libqd` :: BSD-3-Clause license

--- a/docs/source/install/svn.md
+++ b/docs/source/install/svn.md
@@ -1,7 +1,7 @@
 # Subversion
 
 ```{deprecated} 2.0
-These instructions are for obtaining older versions of `eON`.
+These instructions are for obtaining older versions of `eOn`.
 ```
 
 A read-only copy of the code can be anonymously checked out of the subversion
@@ -22,4 +22,4 @@ This will fetch a copy of the latest code to a local directory named eon.
 
 For more information on subversion read its [online documentation](http://svnbook.red-bean.com/en/1.5/index.html).
 
-The `eON` code can also be download directly in `tar` format [from here](http://theory.cm.utexas.edu/code/eon.tgz).
+The `eOn` code can also be download directly in `tar` format [from here](http://theory.cm.utexas.edu/code/eon.tgz).

--- a/docs/source/team.md
+++ b/docs/source/team.md
@@ -1,7 +1,7 @@
-# eON Team
+# eOn Team
 
-The EON software is primarily a collaboration between the Henkelman and Jónsson
-research groups.
+The `eOn` software is primarily a collaboration between the Henkelman and
+Jónsson research groups.
 
 ## Contributors
 
@@ -43,7 +43,7 @@ With contributions from a number of other developers:
 
 ## License history
 
-`eON` was originally licensed under the GNU GPL v3 until 2017.  In 2017, the
-license was changed to GNU GPL v2.  Since 2020, eON is licensed under the BSD
+`eOn` was originally licensed under the GNU GPL v3 until 2017.  In 2017, the
+license was changed to GNU GPL v2.  Since 2020, eOn is licensed under the BSD
 3-Clause License. Some more context is at
-[gh-140](https://github.com/TheochemUI/eON/issues/140).
+[gh-140](https://github.com/TheochemUI/eOn/issues/140).

--- a/docs/source/team.md
+++ b/docs/source/team.md
@@ -40,3 +40,10 @@ With contributions from a number of other developers:
 - Raymond Smith (UT)
 - Erik Edelmann (Finland)
 - Jutta Rogal (Bochum)
+
+## License history
+
+`eON` was originally licensed under the GNU GPL v3 until 2017.  In 2017, the
+license was changed to GNU GPL v2.  Since 2020, eON is licensed under the BSD
+3-Clause License. Some more context is at
+[gh-140](https://github.com/TheochemUI/eON/issues/140).

--- a/docs/source/tutorials/CECAM_LTS_MAP_2024/index.md
+++ b/docs/source/tutorials/CECAM_LTS_MAP_2024/index.md
@@ -3,7 +3,7 @@
 For the CECAM event at SISSA, titled ["Long time multi-scale simulations of
 activated events: from theory to
 practice"](https://www.cecam.org/workshop-details/long-time-multi-scale-simulations-of-activated-events-from-theory-to-practice-1317),
-or CECAM-LTS-MAP-2024[^1], tutorial materials for `eON v2` were prepared and
+or CECAM-LTS-MAP-2024[^1], tutorial materials for `eOn v2` were prepared and
 presented by (alphabetically):
 - Akksay Singh
 - Rohit Goswami

--- a/docs/source/tutorials/CECAM_LTS_MAP_2024/troubleshooting.md
+++ b/docs/source/tutorials/CECAM_LTS_MAP_2024/troubleshooting.md
@@ -1,11 +1,11 @@
 # Virtualbox Troublshooting
 
 ```{warning}
-It is **highly** recommended to run `eON` locally, since hypervision virtualization incurs a **significant** slowdown.
+It is **highly** recommended to run `eOn` locally, since hypervision virtualization incurs a **significant** slowdown.
 ```
 
 The virtual machine used for the CECAM-LTS-MAP 2024 event has an older version
-of `eON` which must be removed.
+of `eOn` which must be removed.
 
 To do so:
 

--- a/docs/source/tutorials/index.md
+++ b/docs/source/tutorials/index.md
@@ -1,6 +1,6 @@
 # Tutorials
 
-We provide several full tutorials which demonstrate the usage of `eON` (both
+We provide several full tutorials which demonstrate the usage of `eOn` (both
 server and client).
 
 ```{toctree}

--- a/docs/source/user_guide/basin_hopping.md
+++ b/docs/source/user_guide/basin_hopping.md
@@ -14,7 +14,7 @@ At each basin hopping step the client will print out:
 
 ## Notes
 
-- `eON` defaults to letting displacements occur from minimized structures as per
+- `eOn` defaults to letting displacements occur from minimized structures as per
   the method of {cite:t}`bh-whiteInvestigationTwoApproaches1998`, which is
   controlled by {any}`siginificant_structure
   <eon.schema.BasinHoppingConfig.significant_structure>`

--- a/docs/source/user_guide/communicator.md
+++ b/docs/source/user_guide/communicator.md
@@ -1,15 +1,15 @@
 # Communicator
 
-`eON` has a server client architecture for running its calculations. The
+`eOn` has a server client architecture for running its calculations. The
 simulation data is stored on the server and clients are sent jobs and return the
-results. Each time `eON` is run it first checks to see if any results have come
+results. Each time `eOn` is run it first checks to see if any results have come
 back from clients and processes them accordingly and then submits more jobs if
-needed. In `eON` there are several different ways to run jobs. One can run them
+needed. In `eOn` there are several different ways to run jobs. One can run them
 locally on the server, via MPI,  or using a job queuing system such as
 [SGE](http://www.oracle.com/us/products/tools/oracle-grid-engine-075549.html).
 
 ```{note}
-As of version 2.0 onwards, we recommend using dedicated workflow management tools (like [AiiDA](https://www.aiida.net/) or [Snakemake](https://snakemake.readthedocs.io/) or [Fireworks](https://materialsproject.github.io/fireworks)) instead of using `eON` to generate submission scripts.
+As of version 2.0 onwards, we recommend using dedicated workflow management tools (like [AiiDA](https://www.aiida.net/) or [Snakemake](https://snakemake.readthedocs.io/) or [Fireworks](https://materialsproject.github.io/fireworks)) instead of using `eOn` to generate submission scripts.
 ```
 
 ## Configuration

--- a/docs/source/user_guide/index.md
+++ b/docs/source/user_guide/index.md
@@ -2,15 +2,15 @@
 
 Here we collect a brief introduction to each algorithm, with curated references
 for more information along with the  configuration settings as implemented
-within `eON`.
+within `eOn`.
 
 Each of the sections and methods may be included in the configuration file with the appropriate section header.
 
 ## Overview
 
-The `eON` program can run the following methods or tasks to explore the
+The `eOn` program can run the following methods or tasks to explore the
 configuration space of molecular systems and to accelerate the simulation of
-their dynamics over long times. To run `eON`, a configuration file must be generated
+their dynamics over long times. To run `eOn`, a configuration file must be generated
 using the options specified in the documentation. Each section header is denoted
 by square brackets, and is followed by the key/value pairs. For example, to set
 the *job_type* key of the *[Main]* section to the value *process_search*, your
@@ -33,7 +33,7 @@ optimizations and comparisons.
 
 ````{margin}
 ```{note}
-As of version 2.0 onwards, we recommend using dedicated workflow management tools (like [AiiDA](https://www.aiida.net/) or [Snakemake](https://snakemake.readthedocs.io/) or [Fireworks](https://materialsproject.github.io/fireworks)) instead of using `eON` to generate submission scripts.
+As of version 2.0 onwards, we recommend using dedicated workflow management tools (like [AiiDA](https://www.aiida.net/) or [Snakemake](https://snakemake.readthedocs.io/) or [Fireworks](https://materialsproject.github.io/fireworks)) instead of using `eOn` to generate submission scripts.
 ```
 ````
 

--- a/docs/source/user_guide/lammps_pot.md
+++ b/docs/source/user_guide/lammps_pot.md
@@ -30,7 +30,7 @@ meson install -C bbdir
 ```
 
 ```{note}
-With this setup, there is no need to explicitly let `eON` know about other libraries, since they are all installed together in the environment.
+With this setup, there is no need to explicitly let `eOn` know about other libraries, since they are all installed together in the environment.
 
 For backwards compatibility, we also support copying in `liblammps.so` into `potentials/LAMMPS/liblammps.so`.
 ```

--- a/docs/source/user_guide/main.md
+++ b/docs/source/user_guide/main.md
@@ -90,7 +90,7 @@ Communicator
 : which detail methods by which the code can be run in parallel.
 
 Potential
-: which configures interatomic potentials, both bundled with `eON` and interfaced
+: which configures interatomic potentials, both bundled with `eOn` and interfaced
 
 Optimizer
 : which has options related to the generic step interface for optimization of atomic structures

--- a/docs/source/user_guide/neb.md
+++ b/docs/source/user_guide/neb.md
@@ -28,7 +28,7 @@ set as per the <project:optimizer.md> document.
 ```
 
 ```{note}
-`eON`, like many other codes after {cite:t}`neb-sheppardOptimizationMethodsFinding2008` uses one optimizer instance for moving the whole band of images.
+`eOn`, like many other codes after {cite:t}`neb-sheppardOptimizationMethodsFinding2008` uses one optimizer instance for moving the whole band of images.
 ```
 
 ```{versionadded} 3.0_TBA

--- a/docs/source/user_guide/optimizer.md
+++ b/docs/source/user_guide/optimizer.md
@@ -1,10 +1,10 @@
 # Optimizer
 
 ```{note}
-All the optimizers in `eON` **do not** use a line search to determine steepest descent!!
+All the optimizers in `eOn` **do not** use a line search to determine steepest descent!!
 ```
 
-There are several other ways in which the `eON` implementations differ from a
+There are several other ways in which the `eOn` implementations differ from a
 standard optimizer software suite[^1] . Some prominent reasons are:
 - They are meant to be used with the <project:neb.md> which does not
   have well defined closed form energy surface

--- a/docs/source/user_guide/potential.md
+++ b/docs/source/user_guide/potential.md
@@ -1,6 +1,6 @@
 # Potential
 
-`eON` supports a large number of potentials, some vendored within the executable
+`eOn` supports a large number of potentials, some vendored within the executable
 and libraries and others via interfaces.
 
 ```{note}

--- a/docs/source/user_guide/recycling.md
+++ b/docs/source/user_guide/recycling.md
@@ -1,6 +1,6 @@
 # Recycling
 
-As reported in {cite:t}`recyc-xuAdaptiveKineticMonte2008`, `eON` implements a
+As reported in {cite:t}`recyc-xuAdaptiveKineticMonte2008`, `eOn` implements a
 method of saddle point recycling that can significantly reduce the computational
 cost of the aKMC algorithm.
 

--- a/eon/akmcstatelist.py
+++ b/eon/akmcstatelist.py
@@ -1,3 +1,14 @@
+#
+# This file is part of eOn.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright (c) 2010--present, eOn Development Team
+# All rights reserved.
+#
+# Repo:
+# https://github.com/TheochemUI/eOn
+#
 """ The statelist module. """
 
 from eon.config import config

--- a/eon/schema.py
+++ b/eon/schema.py
@@ -349,7 +349,7 @@ class CommunicatorConfig(BaseModel):
         description="Number of jobs per bundle.",
     )
     """
-    In ``eON``, a job is defined as a task that the ``eonclient`` executes, such
+    In ``eOn``, a job is defined as a task that the ``eonclient`` executes, such
     as a process search or a parallel replica run. Sometimes it makes sense to
     run more than one of the same type of job at a time.
 
@@ -381,7 +381,7 @@ class CommunicatorConfig(BaseModel):
         description="Path to the eon client binary.",
     )
     """
-    If only a name and not a path is given, ``eON`` looks for the binary in the
+    If only a name and not a path is given, ``eOn`` looks for the binary in the
     same directory as the configuration file. If not found there, it searches
     through the directories in the ``$PATH`` environment variable.
     """
@@ -402,7 +402,7 @@ class CommunicatorConfig(BaseModel):
         description="Name of the script that returns the job IDs of all the running and queued jobs for the cluster communicator.",
     )
     """
-    This may return more than just ``eON`` jobs.
+    This may return more than just ``eOn`` jobs.
     """
     cancel_job: str = Field(
         default="cancel_job.sh",
@@ -417,11 +417,11 @@ class CommunicatorConfig(BaseModel):
     )
     """
     It takes two command line arguments. The first is the name of the job. This
-    is not required for ``eON`` use, but is highly recommended so that users can
+    is not required for ``eOn`` use, but is highly recommended so that users can
     identify which job is which. The second argument is the working directory.
-    This is the path where the ``eON`` client should be executed. All of the
+    This is the path where the ``eOn`` client should be executed. All of the
     needed client files will be placed in this directory. The script must return
-    the job id of the submitted job. This is how ``eON`` internally keeps track
+    the job id of the submitted job. This is how ``eOn`` internally keeps track
     of jobs.
     """
 

--- a/scripts/upd_license.py
+++ b/scripts/upd_license.py
@@ -18,33 +18,40 @@ new_license = """/*
 */
 """
 
-
 def find_license(top_lines):
     _eonpat = re.compile(r"(.*eOn is free)")
     _gnupat = re.compile(r"(GNU General Public)")
-    if _eonpat.search(top_lines) and _gnupat.search(top_lines):
-        return True
-    else:
-        return False
+    return _eonpat.search(top_lines) and _gnupat.search(top_lines)
 
+def has_any_license(top_lines):
+    license_patterns = [
+        re.compile(r"(SPDX-License-Identifier:)"),
+        re.compile(r"(GNU General Public License)"),
+        re.compile(r"(BSD 3-Clause License)"),
+    ]
+    return any(pat.search(top_lines) for pat in license_patterns)
 
 def replace_license(file_path):
     with file_path.open("r", encoding="utf-8") as file:
         lines = file.readlines()
 
-    if find_license('\n'.join(lines[:10])):
-        # Replace the first 10 lines with the new license
-        new_content = new_license + "".join(lines[9:])
+    top_lines = '\n'.join(lines[:10])
 
-        # Write the new content back to the file
-        with file_path.open("w") as f:
-            f.write(new_content)
+    if find_license(top_lines):
+        # Replace the first 10 lines with the new license
+        new_content = new_license + "".join(lines[10:])
         print(f"Replaced license in {file_path}")
+    elif not has_any_license(top_lines):
+        new_content = new_license + "".join(lines)
+        print(f"Prepended license in {file_path}")
     else:
+        new_content = "".join(lines)
         print(f"No match found in {file_path}")
 
+    with file_path.open("w", encoding="utf-8") as f:
+        f.write(new_content)
 
-ignore_if = ["Asap", "mcamc", ".venv"]
+ignore_if = ["Asap", "mcamc", ".venv", "thirdparty", "tools"]
 for file_path in directory.rglob("*"):
     if file_path.suffix in file_extensions:
         if not any(x in str(file_path) for x in ignore_if):

--- a/scripts/upd_license.py
+++ b/scripts/upd_license.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+import re
+
+directory = Path(".")
+
+file_extensions = {".h", ".hpp", ".c", ".cpp"}
+
+new_license = """/*
+** This file is part of eON.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eON Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eON
+*/
+"""
+
+
+def find_license(top_lines):
+    _eonpat = re.compile(r"(.*eOn is free)")
+    _gnupat = re.compile(r"(GNU General Public)")
+    if _eonpat.search(top_lines) and _gnupat.search(top_lines):
+        return True
+    else:
+        return False
+
+
+def replace_license(file_path):
+    with file_path.open("r", encoding="utf-8") as file:
+        lines = file.readlines()
+
+    if find_license('\n'.join(lines[:10])):
+        # Replace the first 10 lines with the new license
+        new_content = new_license + "".join(lines[9:])
+
+        # Write the new content back to the file
+        with file_path.open("w") as f:
+            f.write(new_content)
+        print(f"Replaced license in {file_path}")
+    else:
+        print(f"No match found in {file_path}")
+
+
+ignore_if = ["Asap", "mcamc", ".venv"]
+for file_path in directory.rglob("*"):
+    if file_path.suffix in file_extensions:
+        if not any(x in str(file_path) for x in ignore_if):
+            replace_license(file_path)
+
+print("License replacement completed.")

--- a/scripts/upd_license.py
+++ b/scripts/upd_license.py
@@ -6,15 +6,15 @@ directory = Path(".")
 file_extensions = {".h", ".hpp", ".c", ".cpp"}
 
 new_license = """/*
-** This file is part of eON.
+** This file is part of eOn.
 **
 ** SPDX-License-Identifier: BSD-3-Clause
 **
-** Copyright (c) 2010--present, eON Development Team
+** Copyright (c) 2010--present, eOn Development Team
 ** All rights reserved.
 **
 ** Repo:
-** https://github.com/TheochemUI/eON
+** https://github.com/TheochemUI/eOn
 */
 """
 


### PR DESCRIPTION
For the final 2.x release. Port of https://github.com/TheochemUI/eOn/pull/148 to `main`.

See #140 for more details.