### PR TITLE
docs: add dictionary-style config examples using `rgpycrumbs`

### DIFF
--- a/docs/source/tutorials/dict_config.md
+++ b/docs/source/tutorials/dict_config.md
@@ -1,0 +1,252 @@
+---
+myst:
+  html_meta:
+    "description": "Tutorial on using Python dictionaries to generate eOn configuration files programmatically, as an alternative to hand-written config.ini files."
+    "keywords": "eOn dictionary config, Python configuration, write_eon_config, rgpycrumbs, programmatic setup"
+---
+
+# Dictionary-Style Configuration
+
+eOn reads its parameters from a `config.ini` file in INI format. While writing
+these files by hand works well for one-off runs, programmatic workflows benefit
+from generating the configuration from Python dictionaries. The
+{func}`~rgpycrumbs.eon.helpers.write_eon_config` function in
+[rgpycrumbs](https://github.com/HaoZeke/rgpycrumbs) handles this conversion.
+
+All configuration options are documented in {mod}`eon.schema`, which is the
+single source of truth for parameter names, types, defaults, and allowed values.
+The user guide pages (e.g. {doc}`/user_guide/main`, {doc}`/user_guide/neb`)
+render these Pydantic models directly.
+
+## Installation
+
+`rgpycrumbs` is available on PyPI:
+
+```bash
+pip install rgpycrumbs
+# or
+uv add rgpycrumbs
+```
+
+## Basic Usage
+
+A dictionary maps INI section names to their key-value pairs. The section names
+match the headers in `config.ini` (and the headings in the user guide). For
+example, an AKMC run on a Pt heptamer:
+
+```python
+from pathlib import Path
+from rgpycrumbs.eon.helpers import write_eon_config
+
+settings = {
+    "Main": {
+        "job": "akmc",
+        "temperature": 300,
+    },
+    "Potential": {
+        "potential": "morse_pt",
+    },
+    "Optimizer": {
+        "converged_force": 0.001,
+        "max_iterations": 1000,
+    },
+    "AKMC": {
+        "confidence": 0.95,
+    },
+    "Process Search": {
+        "minimize_first": True,
+    },
+    "Communicator": {
+        "type": "local",
+        "number_of_CPUs": 2,
+        "num_jobs": 2,
+    },
+    "Saddle Search": {
+        "displace_least_coordinated_weight": 1.0,
+        "displace_radius": 3.3,
+        "displace_magnitude": 0.1,
+        "min_mode_method": "dimer",
+        "max_energy": 10.0,
+    },
+}
+
+write_eon_config(Path("."), settings)
+```
+
+This writes a `config.ini` in the current directory. You can then run
+`python -m eon.server` (or `eonclient` directly) as usual.
+
+```{tip}
+Pass a directory path and `write_eon_config` creates `config.ini` inside it.
+Pass a full file path to control the output name.
+```
+
+## Why Dictionaries?
+
+Compared to editing INI files by hand, the dictionary approach provides:
+
+- **Reproducibility**: the script *is* the configuration, checked into version
+  control alongside the structure files.
+- **Parameterization**: loop over temperatures, spring constants, or image
+  counts without duplicating INI files.
+- **Validation reference**: option names and types are defined in
+  {mod}`eon.schema`. Typos that would silently fall back to defaults in an INI
+  file become obvious when compared against the schema documentation.
+- **Notebook integration**: generate and run eOn configurations within Jupyter
+  notebooks. The
+  [atomistic cookbook](https://atomistic-cookbook.org/examples/eon-pet-neb/eon-pet-neb.html)
+  has a worked NEB example using this approach.
+
+## Examples by Job Type
+
+Each example directory under `examples/` now contains both a `config.ini` and
+a Python equivalent (`run_*.py`). The scripts are self-contained and can be
+executed with:
+
+```bash
+cd examples/akmc-pt
+python run_akmc_pt.py      # generates config.ini
+python -m eon.server       # runs the simulation
+```
+
+### AKMC
+
+:::::{tab-set}
+
+::::{tab-item} Dictionary (Python)
+```{literalinclude} ../../../examples/akmc-pt/run_akmc_pt.py
+:language: python
+```
+::::
+
+::::{tab-item} INI
+```{literalinclude} ../../../examples/akmc-pt/config.ini
+:language: ini
+```
+::::
+
+:::::
+
+### NEB
+
+:::::{tab-set}
+
+::::{tab-item} Dictionary (Python)
+```{literalinclude} ../../../examples/neb-al/run_neb_al.py
+:language: python
+```
+::::
+
+::::{tab-item} INI
+```{literalinclude} ../../../examples/neb-al/config.ini
+:language: ini
+```
+::::
+
+:::::
+
+For advanced NEB options (climbing image, energy-weighted springs, IDPP
+initialization, off-path CI with MMF), see
+`examples/neb-al/run_neb_advanced.py`.
+
+### Basin Hopping
+
+:::::{tab-set}
+
+::::{tab-item} Dictionary (Python)
+```{literalinclude} ../../../examples/basin-hopping/run_basin_hopping.py
+:language: python
+```
+::::
+
+::::{tab-item} INI
+```{literalinclude} ../../../examples/basin-hopping/config.ini
+:language: ini
+```
+::::
+
+:::::
+
+### Parallel Replica Dynamics
+
+:::::{tab-set}
+
+::::{tab-item} Dictionary (Python)
+```{literalinclude} ../../../examples/parallel-replica/run_parrep.py
+:language: python
+```
+::::
+
+::::{tab-item} INI
+```{literalinclude} ../../../examples/parallel-replica/config.ini
+:language: ini
+```
+::::
+
+:::::
+
+### AKMC with Displacement Script
+
+The Cu vacancy example shows how dictionary config works alongside a
+displacement script (`ptmdisp.py`). The script path is just another string
+parameter:
+
+```python
+"Saddle Search": {
+    "displace_atom_kmc_state_script": "ptmdisp.py",
+    "displace_all_listed": True,
+    # ...
+},
+```
+
+See `examples/akmc-cu-vacancy/run_akmc_cu.py` for the full configuration and
+{doc}`displacement_scripts` for details on writing displacement scripts.
+
+## Parameter Sweeps
+
+The dictionary approach makes parameter sweeps straightforward:
+
+```python
+from pathlib import Path
+from rgpycrumbs.eon.helpers import write_eon_config
+
+base = {
+    "Main": {"job": "nudged_elastic_band"},
+    "Potential": {"potential": "eam_al"},
+    "Optimizer": {
+        "opt_method": "lbfgs",
+        "max_move": 0.1,
+        "converged_force": 0.001,
+        "max_iterations": 1000,
+    },
+}
+
+for n_images in [5, 7, 11, 15]:
+    run_dir = Path(f"neb_{n_images}img")
+    run_dir.mkdir(exist_ok=True)
+    settings = {
+        **base,
+        "Nudged Elastic Band": {
+            "images": n_images,
+            "spring": 5.0,
+        },
+    }
+    write_eon_config(run_dir, settings)
+```
+
+## Schema Reference
+
+The authoritative documentation for every configuration option lives in the
+Pydantic models in {mod}`eon.schema`. The user guide pages render these models
+automatically:
+
+- {doc}`/user_guide/main` -- general simulation parameters
+- {doc}`/user_guide/akmc` -- adaptive kinetic Monte Carlo
+- {doc}`/user_guide/neb` -- nudged elastic band
+- {doc}`/user_guide/saddle_search` -- saddle search methods
+- {doc}`/user_guide/optimizer` -- optimization algorithms
+- {doc}`/user_guide/potential` -- interatomic potentials
+- {doc}`/user_guide/dynamics` -- molecular dynamics
+- {doc}`/user_guide/parallel_replica` -- parallel replica dynamics
+- {doc}`/user_guide/basin_hopping` -- basin hopping
+- {doc}`/user_guide/communicator` -- job communicators

--- a/docs/source/tutorials/index.md
+++ b/docs/source/tutorials/index.md
@@ -18,6 +18,7 @@ server and client).
 akmc
 parrep
 displacement_scripts
+dict_config
 CECAM_LTS_MAP_2024/index
 ```
 

--- a/examples/akmc-al/run_akmc_al.py
+++ b/examples/akmc-al/run_akmc_al.py
@@ -1,0 +1,55 @@
+"""AKMC simulation of Al with dictionary-style configuration.
+
+Equivalent to the config.ini in this directory, but uses
+``write_eon_config`` from rgpycrumbs to generate the INI file
+programmatically. All option names match the fields documented in
+``eon.schema`` (the Pydantic models are the single source of truth).
+"""
+
+from pathlib import Path
+
+from rgpycrumbs.eon.helpers import write_eon_config
+
+settings = {
+    "Main": {
+        "job": "akmc",
+        "temperature": 300,
+        "random_seed": 42,
+    },
+    "Potential": {
+        "potential": "eam_al",
+    },
+    "Optimizer": {
+        "opt_method": "lbfgs",
+        "converged_force": 1e-4,
+        "max_iterations": 1000,
+    },
+    "AKMC": {
+        "confidence": 0.95,
+    },
+    "Process Search": {
+        "minimize_first": True,
+    },
+    "Prefactor": {
+        "default_value": 1e12,
+    },
+    "Communicator": {
+        "type": "local",
+        "number_of_cpus": 2,
+        "num_jobs": 8,
+    },
+    "Lanczos": {
+        "tolerance": 0.05,
+    },
+    "Saddle Search": {
+        "min_mode_method": "lanczos",
+        "displace_radius": 5.0,
+        "displace_magnitude": 0.2,
+        "max_energy": 10.0,
+        "displace_listed_atom_weight": 1.0,
+        "displace_atom_list": -1,
+    },
+}
+
+if __name__ == "__main__":
+    write_eon_config(Path("."), settings)

--- a/examples/akmc-cu-vacancy/run_akmc_cu.py
+++ b/examples/akmc-cu-vacancy/run_akmc_cu.py
@@ -1,0 +1,77 @@
+"""AKMC simulation of Cu vacancy with dictionary-style configuration.
+
+Equivalent to the config.ini in this directory. Demonstrates the use of
+a displacement script (ptmdisp.py) for targeted saddle searches around
+the vacancy site, identified via polyhedral template matching.
+"""
+
+from pathlib import Path
+
+from rgpycrumbs.eon.helpers import write_eon_config
+
+settings = {
+    "Main": {
+        "job": "akmc",
+        "temperature": 300,
+        "random_seed": 757783492,
+        "finite_difference": 0.01,
+    },
+    "Communicator": {
+        "type": "local",
+        "num_jobs": 4,
+        "number_of_cpus": 4,
+    },
+    "AKMC": {
+        "confidence": 0.005,
+        "confidence_scheme": "new",
+        "thermally_accessible_window": 100.0,
+    },
+    "Optimizer": {
+        "max_iterations": 1000,
+        "opt_method": "lbfgs",
+        "converged_force": 0.01,
+        "lbfgs_memory": 25,
+        "lbfgs_inverse_curvature": 0.01,
+        "lbfgs_auto_scale": True,
+        "convergence_metric": "norm",
+        "max_move": 0.05,
+    },
+    "Dimer": {
+        "opt_method": "cg",
+        "improved": True,
+        "rotations_max": 20,
+        "converged_angle": 1.0,
+        "remove_rotation": False,
+    },
+    "Potential": {
+        "potential": "emt",
+    },
+    "Process Search": {
+        "minimize_first": True,
+    },
+    "Saddle Search": {
+        "method": "min_mode",
+        "min_mode_method": "dimer",
+        "max_energy": 300,
+        "displace_listed_atom_weight": 1.0,
+        "displace_radius": 3.0,
+        "displace_magnitude": 0.01,
+        "displace_atom_kmc_state_script": "ptmdisp.py",
+        "displace_all_listed": True,
+        "remove_rotation": False,
+    },
+    "Structure Comparison": {
+        "distance_difference": 0.1,
+        "energy_difference": 0.08,
+        "neighbor_cutoff": 3.0,
+    },
+    "Debug": {
+        "write_movies": True,
+    },
+    "Prefactor": {
+        "default_value": 1e13,
+    },
+}
+
+if __name__ == "__main__":
+    write_eon_config(Path("."), settings)

--- a/examples/akmc-pt/run_akmc_pt.py
+++ b/examples/akmc-pt/run_akmc_pt.py
@@ -1,0 +1,45 @@
+"""AKMC simulation of Pt heptamer with dictionary-style configuration.
+
+Equivalent to the config.ini in this directory. Uses the dimer method
+for saddle searches with displacement biased towards the least
+coordinated atom.
+"""
+
+from pathlib import Path
+
+from rgpycrumbs.eon.helpers import write_eon_config
+
+settings = {
+    "Main": {
+        "job": "akmc",
+        "temperature": 300,
+    },
+    "Potential": {
+        "potential": "morse_pt",
+    },
+    "Optimizer": {
+        "converged_force": 0.001,
+        "max_iterations": 1000,
+    },
+    "AKMC": {
+        "confidence": 0.95,
+    },
+    "Process Search": {
+        "minimize_first": True,
+    },
+    "Communicator": {
+        "type": "local",
+        "number_of_CPUs": 2,
+        "num_jobs": 2,
+    },
+    "Saddle Search": {
+        "displace_least_coordinated_weight": 1.0,
+        "displace_radius": 3.3,
+        "displace_magnitude": 0.1,
+        "min_mode_method": "dimer",
+        "max_energy": 10.0,
+    },
+}
+
+if __name__ == "__main__":
+    write_eon_config(Path("."), settings)

--- a/examples/basin-hopping/run_basin_hopping.py
+++ b/examples/basin-hopping/run_basin_hopping.py
@@ -1,0 +1,37 @@
+"""Basin hopping global optimization with dictionary-style configuration.
+
+Equivalent to the config.ini in this directory. Searches for the global
+minimum of a Lennard-Jones cluster at 2000 K using Gaussian-distributed
+displacements.
+"""
+
+from pathlib import Path
+
+from rgpycrumbs.eon.helpers import write_eon_config
+
+settings = {
+    "Main": {
+        "job": "basin_hopping",
+        "temperature": 2000,
+    },
+    "Communicator": {
+        "type": "local",
+    },
+    "Potential": {
+        "potential": "lj",
+    },
+    "Basin Hopping": {
+        "steps": 100,
+        "displacement": 0.25,
+        "significant_structure": True,
+        "displacement_distribution": "gaussian",
+    },
+    "Optimizer": {
+        "opt_method": "cg",
+        "converged_force": 0.01,
+        "max_iterations": 10000,
+    },
+}
+
+if __name__ == "__main__":
+    write_eon_config(Path("."), settings)

--- a/examples/neb-al/run_neb_advanced.py
+++ b/examples/neb-al/run_neb_advanced.py
@@ -1,0 +1,49 @@
+"""Advanced NEB with climbing image and energy-weighted springs.
+
+Demonstrates the full set of NEB options available via dictionary
+configuration. This extends the basic NEB example with:
+
+- Climbing image method for accurate saddle point location
+- Energy-weighted springs for better resolution near the barrier
+- IDPP initialization for a smoother initial path
+- Off-path climbing image (MMF) for dimer-like refinement at the saddle
+
+See ``eon.schema.NudgedElasticBandConfig`` for all available fields.
+"""
+
+from pathlib import Path
+
+from rgpycrumbs.eon.helpers import write_eon_config
+
+N_IMAGES = 10
+
+settings = {
+    "Main": {
+        "job": "nudged_elastic_band",
+    },
+    "Potential": {
+        "potential": "eam_al",
+    },
+    "Nudged Elastic Band": {
+        "images": N_IMAGES,
+        "spring": 5.0,
+        "climbing_image_method": True,
+        "energy_weighted": True,
+        "ew_ksp_min": 0.972,
+        "ew_ksp_max": 9.72,
+        "initializer": "idpp",
+        # Off-path climbing image with dimer-like refinement
+        "ci_mmf": True,
+        "ci_mmf_after": 0.5,
+        "ci_mmf_nsteps": 1000,
+    },
+    "Optimizer": {
+        "max_iterations": 1000,
+        "opt_method": "lbfgs",
+        "max_move": 0.1,
+        "converged_force": 0.01,
+    },
+}
+
+if __name__ == "__main__":
+    write_eon_config(Path("."), settings)

--- a/examples/neb-al/run_neb_al.py
+++ b/examples/neb-al/run_neb_al.py
@@ -1,0 +1,31 @@
+"""Nudged elastic band calculation with dictionary-style configuration.
+
+Equivalent to the config.ini in this directory. Runs an NEB calculation
+on Al with 7 intermediate images and LBFGS optimization.
+"""
+
+from pathlib import Path
+
+from rgpycrumbs.eon.helpers import write_eon_config
+
+settings = {
+    "Main": {
+        "job": "nudged_elastic_band",
+    },
+    "Potential": {
+        "potential": "eam_al",
+    },
+    "Nudged Elastic Band": {
+        "images": 7,
+        "spring": 5.0,
+    },
+    "Optimizer": {
+        "max_iterations": 1000,
+        "opt_method": "lbfgs",
+        "max_move": 0.1,
+        "converged_force": 0.001,
+    },
+}
+
+if __name__ == "__main__":
+    write_eon_config(Path("."), settings)

--- a/examples/parallel-replica/run_parrep.py
+++ b/examples/parallel-replica/run_parrep.py
@@ -1,0 +1,46 @@
+"""Parallel replica dynamics with dictionary-style configuration.
+
+Equivalent to the config.ini in this directory. Runs parallel replica
+dynamics on an Al(100) surface with an Andersen thermostat at 500 K.
+"""
+
+from pathlib import Path
+
+from rgpycrumbs.eon.helpers import write_eon_config
+
+settings = {
+    "Main": {
+        "job": "parallel_replica",
+        "temperature": 500,
+        "random_seed": 1042,
+    },
+    "Potential": {
+        "potential": "eam_al",
+    },
+    "Communicator": {
+        "type": "local",
+        "number_of_cpus": 1,
+        "num_jobs": 2,
+    },
+    "Dynamics": {
+        "time_step": 1.0,
+        "time": 5000.0,
+        "thermostat": "andersen",
+        "andersen_alpha": 0.2,
+        "andersen_collision_period": 10.0,
+    },
+    "Parallel Replica": {
+        "dephase_time": 1000.0,
+        "state_check_interval": 3000.0,
+        "state_save_interval": 1000.0,
+        "post_transition_time": 200.0,
+        "stop_after_transition": False,
+    },
+    "Optimizer": {
+        "opt_method": "cg",
+        "converged_force": 0.005,
+    },
+}
+
+if __name__ == "__main__":
+    write_eon_config(Path("."), settings)


### PR DESCRIPTION
Add run_*.py scripts to each major example directory (akmc-al, akmc-pt, akmc-cu-vacancy, basin-hopping, parallel-replica, neb-al) showing the equivalent config.ini expressed as Python dicts via write_eon_config. Also links to an advanced NEB example with climbing image, energy-weighted springs, and MMF options.

New tutorial page (dict_config.md) documents the approach with side-by-side INI/Python comparisons and a parameter sweep example. References eon.schema as the single source of truth for option names.