### PR TITLE
fix: suppress metatomic FPE, disable uncertainty default, align dimer cols

### DIFF
--- a/client/ImprovedDimer.cpp
+++ b/client/ImprovedDimer.cpp
@@ -351,13 +351,13 @@ void ImprovedDimer::compute(std::shared_ptr<Matter> matter,
       statsRotations += 1;
       SPDLOG_LOGGER_INFO(
           log,
-          "[IDimerRot]  -----   ---------   ----------   ----------   "
-          "{:9.4f}   {:7.3f}   {:6.2f}   {:4}   {:5.3f}",
+          "[IDimerRot]  -----   ---------   ----------   ------------------   "
+          "{:9.4f}   {:7.3f}   {:6.3f}   {:4}   {:5.3f}",
           C_tau, statsTorque, statsAngle, statsRotations, alignment);
     } else {
       SPDLOG_LOGGER_INFO(
           log,
-          "[IDimerRot]  -----   ---------   ----------   ----------   "
+          "[IDimerRot]  -----   ---------   ----------   ------------------   "
           "{:9.4f}   {:7.3f}   ------   ----   {:5.3f}",
           C_tau, F_R.norm() / delta, alignment);
     }

--- a/client/MinModeSaddleSearch.cpp
+++ b/client/MinModeSaddleSearch.cpp
@@ -265,9 +265,9 @@ int MinModeSaddleSearch::run() {
         LowestEigenmode::MINMODE_DIMER) {
       SPDLOG_LOGGER_INFO(log,
                          "[Dimer]  {:9s}   {:9s}   {:10s}   {:18s}   {:9s}   "
-                         "{:7s}   {:6s}   {:4s}\n",
+                         "{:7s}   {:6s}   {:4s}   {:5s}\n",
                          "Step", "Step Size", "Delta E", forceLabel,
-                         "Curvature", "Torque", "Angle", "Rots", "Alignment");
+                         "Curvature", "Torque", "Angle", "Rots", "Align");
     } else if (params.saddle_search_options.minmode_method ==
                LowestEigenmode::MINMODE_LANCZOS) {
       SPDLOG_LOGGER_INFO(

--- a/client/Parameters.cpp
+++ b/client/Parameters.cpp
@@ -218,7 +218,7 @@ Parameters::Parameters() {
   metatomic_options.length_unit = "angstrom"s;
   metatomic_options.extensions_directory = ""s;
   metatomic_options.check_consistency = false;
-  metatomic_options.uncertainty_threshold = 0.1;
+  metatomic_options.uncertainty_threshold = -1.0;
   metatomic_options.variant.base = ""s;
   metatomic_options.variant.energy = ""s;
   metatomic_options.variant.energy_uncertainty = ""s;
@@ -884,7 +884,7 @@ int Parameters::load(FILE *file) {
       metatomic_options.check_consistency =
           ini.GetValueB("Metatomic", "check_consistency", false);
       metatomic_options.uncertainty_threshold =
-          ini.GetValueF("Metatomic", "uncertainty_threshold", 0.1);
+          ini.GetValueF("Metatomic", "uncertainty_threshold", -1.0);
       auto &_variant = metatomic_options.variant;
       _variant.base = ini.GetValue("Metatomic", "variant_base", "");
       _variant.energy = ini.GetValue("Metatomic", "variant_energy", "");

--- a/client/potentials/Metatomic/MetatomicPotential.cpp
+++ b/client/potentials/Metatomic/MetatomicPotential.cpp
@@ -1,5 +1,6 @@
 #include "MetatomicPotential.h"
 #include "../../Parameters.h"
+#include "../../fpe_handler.h"
 #include "vesin.h"
 
 #include <cstdint>
@@ -20,6 +21,9 @@ MetatomicPotential::MetatomicPotential(const Parameters &params)
       model_(torch::jit::Module()),
       device_type_(c10::DeviceType::CPU),
       device_(torch::Device(device_type_)) {
+
+  eonc::FPEHandler fpeh;
+  fpeh.eat_fpe();
 
   m_log->info("[MetatomicPotential] Initializing...");
 
@@ -140,6 +144,8 @@ MetatomicPotential::MetatomicPotential(const Parameters &params)
 
   this->check_consistency_ = m_params.metatomic_options.check_consistency;
   m_log->info("[MetatomicPotential] Initialization complete.");
+
+  fpeh.restore_fpe();
 }
 
 // --- MetatomicPotential::force ---
@@ -148,6 +154,9 @@ void MetatomicPotential::force(long nAtoms, const double *positions,
                                const int *atomicNrs, double *forces,
                                double *energy, double *variance,
                                const double *box) {
+  eonc::FPEHandler fpeh;
+  fpeh.eat_fpe();
+
   // 1. Convert input arrays to torch::Tensors
   auto f64_options =
       torch::TensorOptions().dtype(torch::kFloat64).device(torch::kCPU);
@@ -325,6 +334,8 @@ void MetatomicPotential::force(long nAtoms, const double *positions,
 
   std::memcpy(forces, forces_tensor.contiguous().data_ptr<double>(),
               nAtoms * 3 * sizeof(double));
+
+  fpeh.restore_fpe();
 }
 
 // --- MetatomicPotential::computeNeighbors (helper) ---

--- a/docs/newsfragments/+idimer-alignment.fixed.md
+++ b/docs/newsfragments/+idimer-alignment.fixed.md
@@ -1,0 +1,3 @@
+Fix `[IDimerRot]` column misalignment: widen force placeholder from 10 to 18
+dashes, change angle precision from `{:6.2f}` to `{:6.3f}`, and add missing
+"Align" column specifier to the `[Dimer]` header.

--- a/docs/newsfragments/+metatomic-fpe.fixed.md
+++ b/docs/newsfragments/+metatomic-fpe.fixed.md
@@ -1,0 +1,4 @@
+Suppress FPE trapping during libtorch operations in `MetatomicPotential`
+constructor and `force()`, preventing SIGFPE from benign NaN/Inf produced by
+SiLU (sleef) and autograd internals. Follows the existing `FPEHandler` pattern
+from ASE_ORCA, ASE_NWCHEM, and AtomicGPDimer.

--- a/docs/newsfragments/+uncertainty-default.fixed.md
+++ b/docs/newsfragments/+uncertainty-default.fixed.md
@@ -1,0 +1,3 @@
+Change `uncertainty_threshold` default from `0.1` to `-1` (disabled) in both
+C++ and Python. Most models lack uncertainty outputs, so the previous default
+triggered a noisy exception+catch in the metatomic constructor for no benefit.

--- a/docs/source/releases/index.md
+++ b/docs/source/releases/index.md
@@ -17,6 +17,7 @@ has more details.
 :caption: Versions
 
 changelog
+v2.11.2/index
 v2.11.1/index
 v2.11.0/index
 v2.10.1/index

--- a/docs/source/releases/v2.11.2/index.md
+++ b/docs/source/releases/v2.11.2/index.md
@@ -1,0 +1,21 @@
+---
+myst:
+  html_meta:
+    "description": "Overview of the eOn v2.11.2 release, fixing metatomic FPE trapping, uncertainty default, and improved dimer log alignment."
+    "keywords": "eOn v2.11.2, release, metatomic, SIGFPE, FPE, uncertainty, dimer"
+---
+
+## [v2.11.2] - 2026-03-02
+
+A patch release that fixes SIGFPE crashes when using the built-in `metatomic`
+potential (libtorch triggers benign FPE), changes the `uncertainty_threshold`
+default to disabled (`-1`) so models without uncertainty outputs no longer
+produce noisy warnings, and corrects column alignment in `[IDimerRot]` and
+`[Dimer]` log output.
+
+```{toctree}
+:maxdepth: 2
+:caption: Contents
+
+release-notes
+```

--- a/docs/source/releases/v2.11.2/release-notes.md
+++ b/docs/source/releases/v2.11.2/release-notes.md
@@ -1,0 +1,35 @@
+---
+myst:
+  html_meta:
+    "description": "Detailed release notes for eOn v2.11.2, covering metatomic FPE fix, uncertainty default change, and improved dimer log alignment."
+    "keywords": "eOn release notes, metatomic, FPE, SIGFPE, uncertainty, dimer, IDimerRot"
+---
+
+# Release notes
+
+## [v2.11.2] - 2026-03-02
+
+### Fixed
+
+#### Metatomic SIGFPE with in-process libtorch
+
+The built-in `metatomic` potential triggered `SIGFPE: Invalid operation` during
+libtorch forward/backward passes because eOn enables global FPE trapping at
+startup.  Libtorch internals (SiLU via sleef, autograd intermediates) produce
+benign NaN/Inf that get trapped.  The constructor and `force()` method now
+suppress FPE trapping for the duration of torch operations using `FPEHandler`,
+matching the pattern already used by ASE_ORCA, ASE_NWCHEM, and AtomicGPDimer.
+
+#### Uncertainty threshold default too eager
+
+`uncertainty_threshold` defaulted to `0.1` in both C++ and Python.  Most models
+lack uncertainty outputs, so the default triggered a noisy exception+catch in the
+metatomic constructor for no benefit.  The default is now `-1` (disabled),
+making uncertainty checking opt-in.
+
+#### IDimerRot column misalignment
+
+The `[IDimerRot]` force column placeholder was 10 dashes but `[Dimer]` uses
+`{:18.5e}` (18 characters), shifting all subsequent columns left by 8
+characters.  Angle precision also differed (`{:6.2f}` vs `{:6.3f}`).  The
+`[Dimer]` header was also missing a format specifier for the "Align" column.

--- a/eon/schema.py
+++ b/eon/schema.py
@@ -693,7 +693,7 @@ class Metatomic(BaseModel):
         description="Whether to check consistency of the Metatomic model.",
     )
     uncertainty_threshold: float = Field(
-        default=0.1,  # 100meV/atom
+        default=-1,
         description="Threshold to report per-atom uncertainties, if positive. Also used to populate the variance.",
     )
     variant_base: str = Field(


### PR DESCRIPTION
- Suppress FPE trapping during libtorch operations in `MetatomicPotential` constructor and `force()`, preventing SIGFPE from benign NaN/Inf in SiLU/autograd internals (follows existing `FPEHandler` pattern from ASE_ORCA, ASE_NWCHEM, AtomicGPDimer)
- Change `uncertainty_threshold` default from `0.1` to `-1` (disabled) in C++ (`Parameters.cpp`) and Python (`schema.py`), making uncertainty checking opt-in for models that actually provide it
- Fix `[IDimerRot]` force column placeholder width (10 to 18 dashes) and angle precision (`{:6.2f}` to `{:6.3f}`) for alignment parity with `[Dimer]`
- Add missing `{:5s}` "Align" column to `[Dimer]` header in `MinModeSaddleSearch.cpp`