### PR TITLE
fix(neb): isolate per-image LAMMPS instances

### DIFF
--- a/client/ClientEON.cpp
+++ b/client/ClientEON.cpp
@@ -205,7 +205,8 @@ int main(int argc, char **argv) {
   int eon_mpi_inited = 0;
   MPI_Initialized(&eon_mpi_inited);
   if (!eon_mpi_inited) {
-    MPI_Init(&argc, &argv);
+    int eon_mpi_provided = 0;
+    MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &eon_mpi_provided);
   }
 
   int error;

--- a/client/potentials/LAMMPS/LAMMPSPot.cpp
+++ b/client/potentials/LAMMPS/LAMMPSPot.cpp
@@ -127,8 +127,10 @@ void LAMMPSPot::makeNewLAMMPS(long N, const double *R, const int *atomicNrs,
         "LAMMPS library found but lacks MPI support (lammps_open not found).\n"
         "Install an MPI-enabled LAMMPS build.");
   }
+  MPI_Comm inst_comm = MPI_COMM_NULL;
+  MPI_Comm_dup(mpiComm, &inst_comm);  // private comm per per-image instance
   LAMMPSObj =
-      lmp.open_mpi(lmpargc, const_cast<char **>(lmpargv), mpiComm, nullptr);
+      lmp.open_mpi(lmpargc, const_cast<char **>(lmpargv), inst_comm, nullptr);
 #else
   const char *lmpargv[] = {"liblammps", "-log",    "none", "-echo",
                            "log",       "-screen", "none"};

--- a/client/potentials/LAMMPS/LAMMPSPot.h
+++ b/client/potentials/LAMMPS/LAMMPSPot.h
@@ -19,6 +19,7 @@
 class LAMMPSPot : public Potential {
 
 public:
+  [[nodiscard]] bool needsPerImageInstance() const noexcept override { return true; }
   LAMMPSPot(const Parameters &p);
   ~LAMMPSPot();
   void cleanMemory();


### PR DESCRIPTION
Use sub-communicators.

Parallel NEB (parallel = true) evaluates band images concurrently in threads, each with its own LAMMPS instance. Every instance opened on the same communicator, so the concurrent MPI collectives collided and corrupted the heap (free(): invalid next size / SIGABRT inside LAMMPS comm code) at the first band force evaluation.

- LAMMPSPot::needsPerImageInstance() returns true so each image gets a fresh instance.
- each instance opens on its own MPI_Comm_dup of the client communicator, so concurrent threads no longer share a communicator.
- MPI_Init_thread(MPI_THREAD_MULTIPLE) makes the threaded MPI calls safe.

Parallel NEB now runs to completion (9 per-image instances, no SIGABRT, exit 0) with the parallel force evaluation intact. Builds on the C-API MPI revival; open_mpi takes a communicator, open_no_mpi cannot isolate.