### PR TITLE
feat(bld): runtime loaded fortran potentials

### DIFF
--- a/client/DynLib.h
+++ b/client/DynLib.h
@@ -60,7 +60,16 @@ inline std::string error() {
 using Handle = void *;
 
 inline Handle open(const char *name) noexcept {
+  // RTLD_DEEPBIND (Linux-only): make the library prefer its own symbols over
+  // globally-visible ones.  Without this, Fortran helper symbols exported by
+  // Fortran shared libraries (e.g. neighbours_ in libeon_sw.so) can be
+  // hijacked by identically-named symbols in other loaded libraries (e.g.
+  // libxtb.so.6 also exports neighbours_), causing mis-dispatch and SIGSEGV.
+#if defined(__linux__)
+  return dlopen(name, RTLD_NOW | RTLD_LOCAL | RTLD_DEEPBIND);
+#else
   return dlopen(name, RTLD_NOW | RTLD_LOCAL);
+#endif
 }
 
 inline void *sym(Handle h, const char *name) noexcept { return dlsym(h, name); }

--- a/client/Parameters.h
+++ b/client/Parameters.h
@@ -67,6 +67,7 @@ public:
     bool EMTRasmussen{false};
     bool LogPotential{false};
     std::string extPotPath{"./ext_pot"};
+    std::string potentialsPath{""};  // colon-separated dirs for Fortran potential .so files
     int MPIPotentialRank{-1};
 #ifdef EONMPI
     MPI_Comm MPIClientComm;

--- a/client/ParametersINI.cpp
+++ b/client/ParametersINI.cpp
@@ -90,6 +90,8 @@ int load_ini(INIReader &ini, Parameters &params) {
       "Potential", "emt_rasmussen", params.potential_options.EMTRasmussen);
   params.potential_options.extPotPath =
       ini.Get("Potential", "ext_pot_path", params.potential_options.extPotPath);
+  params.potential_options.potentialsPath =
+      ini.Get("Potential", "potentials_path", params.potential_options.potentialsPath);
 
   if (params.potential_options.potential == PotType::MPI ||
       params.potential_options.potential == PotType::VASP) {

--- a/client/ParametersJSON.cpp
+++ b/client/ParametersJSON.cpp
@@ -67,6 +67,7 @@ json to_json(const Parameters &p) {
       {"emt_rasmussen", p.potential_options.EMTRasmussen},
       {"log_potential", p.potential_options.LogPotential},
       {"ext_pot_path", p.potential_options.extPotPath},
+      {"potentials_path", p.potential_options.potentialsPath},
   };
 
   // [Structure Comparison]
@@ -212,6 +213,7 @@ void from_json(const json &j, Parameters &p) {
     JSON_OPT(s, "emt_rasmussen", p.potential_options.EMTRasmussen);
     JSON_OPT(s, "log_potential", p.potential_options.LogPotential);
     JSON_OPT(s, "ext_pot_path", p.potential_options.extPotPath);
+    JSON_OPT(s, "potentials_path", p.potential_options.potentialsPath);
   }
 
   // [Structure Comparison]

--- a/client/Potential.cpp
+++ b/client/Potential.cpp
@@ -41,14 +41,14 @@
 #endif
 #include "potentials/ZBL/ZBLPot.h"
 
-#ifdef WITH_FORTRAN
+// Fortran potentials: always compiled, loaded at runtime via dlopen
 #include "potentials/Aluminum/Aluminum.h"
 #include "potentials/EDIP/EDIP.h"
 #include "potentials/FeHe/FeHe.h"
 #include "potentials/Lenosky/Lenosky.h"
 #include "potentials/SW/SW.h"
 #include "potentials/Tersoff/Tersoff.h"
-#endif
+#include "potentials/FortranPotLoader.h"
 
 #ifdef EMBED_PYTHON
 
@@ -133,10 +133,17 @@ std::tuple<double, AtomMatrix> Potential::get_ef(const AtomMatrix &pos,
 
 namespace eonc::helpers {
 std::shared_ptr<Potential> makePotential(const Parameters &params) {
+  // Inject config-file path before any potential constructor runs
+  FortranPotLoader::instance().add_config_paths(
+      params.potential_options.potentialsPath);
   return makePotential(params.potential_options.potential, params);
 }
 std::shared_ptr<Potential> makePotential(PotType ptype,
                                          const Parameters &params) {
+  // Inject config-file path before any potential constructor runs.
+  // Called on every code path including Job::Job which uses this overload.
+  FortranPotLoader::instance().add_config_paths(
+      params.potential_options.potentialsPath);
   switch (ptype) {
   // TODO: Every potential must know their own type
   case PotType::EMT: {
@@ -197,7 +204,7 @@ std::shared_ptr<Potential> makePotential(PotType ptype,
   }
 #endif
 #endif
-#ifdef WITH_FORTRAN
+  // Fortran potentials: always available, loaded at runtime via dlopen
   case PotType::EAM_AL: {
     return (std::make_shared<Aluminum>(params));
     break;
@@ -222,7 +229,6 @@ std::shared_ptr<Potential> makePotential(PotType ptype,
     return (std::make_shared<Tersoff>(params));
     break;
   }
-#endif
 #ifndef _WIN32
 #ifdef WITH_VASP
   case PotType::VASP: {

--- a/client/meson.build
+++ b/client/meson.build
@@ -263,7 +263,11 @@ else
     message('Highway SIMD: disabled (not found)')
 endif
 
-eoncbase_sources = ['fpe_handler.cpp', 'PotRegistry.cpp']
+# dl_dep needed for dlopen (FortranPotLoader, LammpsLoader)
+dl_dep = cppc.find_library('dl', required: false)
+_deps += dl_dep
+
+eoncbase_sources = ['fpe_handler.cpp', 'PotRegistry.cpp', 'potentials/FortranPotLoader.cpp']
 
 eoncbase = library(
     'eoncbase',
@@ -482,15 +486,29 @@ if py_embed
 endif
 
 if get_option('with_mpi')
-    mpi_dep = dependency('mpi')
-    _deps += [mpi_dep]
-    python_dep = py.dependency(embed: true, required: true)
-    _deps += [python_dep]
-    _args += ['-DEONMPI']
     subdir('potentials/MPIPot')
     potentials += [mpipot]
+    _args += ['-DEONMPI']
+    mpi_dep = dependency('mpi')
+    _deps += [mpi_dep]
 endif
 
+# Fortran potential C++ wrappers: always compiled (load Fortran libs at runtime)
+# The C++ wrappers use dlopen via FortranPotLoader to find the Fortran shared
+# libraries at runtime, so the client binary does not need Fortran at link time.
+fortran_pot_cpp_sources = [
+    'potentials/Aluminum/Aluminum.cpp',
+    'potentials/EDIP/EDIP.cpp',
+    'potentials/FeHe/FeHe.cpp',
+    'potentials/Lenosky/Lenosky.cpp',
+    'potentials/SW/SW.cpp',
+    'potentials/Tersoff/Tersoff.cpp',
+]
+eonclib_sources += fortran_pot_cpp_sources
+
+# Fortran shared libraries: built only when a Fortran compiler is available,
+# installed separately, and loaded at runtime via dlopen.
+_fortran_pot_libs = []
 if get_option('with_fortran')
     subdir('potentials/Aluminum')
     subdir('potentials/EDIP')
@@ -498,11 +516,11 @@ if get_option('with_fortran')
     subdir('potentials/Lenosky')
     subdir('potentials/SW')
     subdir('potentials/Tersoff')
+    _fortran_pot_libs += [eon_aluminum, eon_edip, eon_fehe, eon_lenosky, eon_sw, eon_tersoff]
     if get_option('with_water')
         subdir('potentials/Water_H')
         potentials += [water_h]
     endif
-    potentials += [aluminum, edip, fehe, lenosky, sw, tersoff]
     _args += ['-DWITH_FORTRAN']
 endif
 
@@ -961,15 +979,20 @@ if get_option('with_tests')
         ['test_dynamics', 'DynamicsTest.cpp', 'neb_morse'],
         ['test_jobs', 'JobIntegrationTest.cpp', 'neb_morse'],
         ['test_hessian', 'HessianTest.cpp', 'neb_morse'],
-        ['test_si_pot', 'SiPotTest.cpp', 'si_diamond'],
-        ['test_eam_al', 'EAMAlTest.cpp', 'al_fcc'],
-        ['test_fehe', 'FeHeTest.cpp', 'fe_bcc'],
         ['test_geom', 'GeometryAnalysisTest.cpp', 'neb_morse'],
         ['test_params_json', 'ParametersJSONTest.cpp', ''],
         ['test_bondboost', 'BondBoostTest.cpp', 'neb_morse'],
         ['test_emt_cu', 'EMTCuTest.cpp', 'cu_fcc'],
         ['test_neb_subsystem', 'NEBSubsystemTest.cpp', ''],
     ]
+    # Fortran potential tests: require Fortran shared libs at runtime
+    if get_option('with_fortran')
+        test_array += [
+            ['test_si_pot', 'SiPotTest.cpp', 'si_diamond'],
+            ['test_eam_al', 'EAMAlTest.cpp', 'al_fcc'],
+            ['test_fehe', 'FeHeTest.cpp', 'fe_bcc'],
+        ]
+    endif
     if get_option('with_ase')
         test_array += [['test_ase_pot', 'ASEPotTest.cpp', 'ase_pot']]
     endif
@@ -989,6 +1012,21 @@ if get_option('with_tests')
     if get_option('with_ira')
         test_array += [['test_ira', 'IRATest.cpp', 'saddle_search']]
     endif
+    # Build the Fortran potential library search path for tests.
+    # Each Fortran shared lib lives in its subdir of the build tree,
+    # matching the source layout: build/client/potentials/<Name>/
+    _fortran_pot_subdirs = ['Aluminum', 'EDIP', 'FeHe', 'Lenosky', 'SW', 'Tersoff']
+    _fortran_pot_dirs = []
+    if get_option('with_fortran')
+        foreach sub : _fortran_pot_subdirs
+            _fortran_pot_dirs += meson.project_build_root() / 'client' / 'potentials' / sub
+        endforeach
+    endif
+    _test_env = environment()
+    if _fortran_pot_dirs.length() > 0
+        _test_env.set('EON_POTENTIALS_PATH', ':'.join(_fortran_pot_dirs))
+    endif
+
     foreach test : test_array
         test_timeout = test.get(3, 30)
         test(
@@ -1009,6 +1047,7 @@ if get_option('with_tests')
                 2,
             ),
             timeout: test_timeout,
+            env: _test_env,
         )
     endforeach
     # Special handling for the nwchem test (due to the client server bit)

--- a/client/potentials/Aluminum/Aluminum.cpp
+++ b/client/potentials/Aluminum/Aluminum.cpp
@@ -19,5 +19,5 @@ void Aluminum::force(long N, const double *R, const int * /*atomicNrs*/,
                      const double *box) {
   assert(N > 1);
   variance = nullptr;
-  force_(&N, R, F, U, &box[0], &box[4], &box[8]);
+  m_force(&N, R, F, U, &box[0], &box[4], &box[8]);
 }

--- a/client/potentials/Aluminum/Aluminum.h
+++ b/client/potentials/Aluminum/Aluminum.h
@@ -12,26 +12,26 @@
 #pragma once
 
 #include "../../Potential.h"
+#include "../FortranPotLoader.h"
 
-/** Fortran interface for the Aluminum EAM potential.
-@param[in]  N           number of atoms
-@param[in]  R           array of positions in Angstrom
-@param[out] F           array of forces in eV/Angstrom
-@param[out] U           pointer to energy in eV
-@param[in]  bx, by, bz pointer to box dimensions in Angstrom
-*/
-extern "C" {
-void force_(const long int *N, const double *R, double *F, double *U,
-            const double *bx, const double *by, const double *bz);
-void potinit_();
-}
-
-/// Aluminum EAM potential (Fortran implementation).
+/// Aluminum EAM potential (Fortran implementation, loaded at runtime).
 class Aluminum final : public Potential {
 public:
+  using force_fn = void (*)(const long int *N, const double *R, double *F,
+                            double *U, const double *bx, const double *by,
+                            const double *bz);
+  using potinit_fn = void (*)();
+
   explicit Aluminum(const Parameters &params)
       : Potential(PotType::EAM_AL, params) {
-    potinit_();
+    auto &loader = eonc::FortranPotLoader::instance();
+    m_force = loader.load_sym<force_fn>("eon_aluminum", "force_");
+    m_potinit = loader.load_sym<potinit_fn>("eon_aluminum", "potinit_");
+    if (!m_force || !m_potinit) {
+      loader.throw_not_found("eon_aluminum",
+                             "Aluminum EAM potential (Fortran)");
+    }
+    m_potinit();
   }
   ~Aluminum() override = default;
 
@@ -39,4 +39,8 @@ public:
 
   void force(long N, const double *R, const int *atomicNrs, double *F,
              double *U, double *variance, const double *box) override;
+
+private:
+  force_fn m_force{nullptr};
+  potinit_fn m_potinit{nullptr};
 };

--- a/client/potentials/Aluminum/meson.build
+++ b/client/potentials/Aluminum/meson.build
@@ -1,15 +1,19 @@
-aluminum = library('aluminum',
+# Fortran-only shared library: loaded at runtime via dlopen
+eon_aluminum = shared_library('eon_aluminum',
            'fofrhoDblexp.f',
            'dfrhoDblexp.f',
            'potinit.f',
            'forces.f',
-           'Aluminum.cpp',
            'gagafeDblexp.f',
            'embedenergy.f',
            'sumembforce.f',
+           fortran_args : _fargs,
+           install : true)
+
+# C++ wrapper (compiled into client, loads Fortran lib at runtime)
+aluminum_cpp = static_library('aluminum_cpp',
+           'Aluminum.cpp',
            dependencies : _deps,
            cpp_args : _args,
-           fortran_args : _fargs,
            link_with : _linkto,
-           include_directories: _incdirs,
-           install : true)
+           include_directories: _incdirs)

--- a/client/potentials/EDIP/EDIP.cpp
+++ b/client/potentials/EDIP/EDIP.cpp
@@ -15,5 +15,5 @@
 void EDIP::force(long N, const double *R, const int * /*atomicNrs*/, double *F,
                  double *U, double *variance, const double *box) {
   variance = nullptr;
-  edip_(&N, R, F, U, &box[0], &box[4], &box[8]);
+  m_force(&N, R, F, U, &box[0], &box[4], &box[8]);
 }

--- a/client/potentials/EDIP/EDIP.h
+++ b/client/potentials/EDIP/EDIP.h
@@ -12,28 +12,30 @@
 #pragma once
 
 #include "../../Potential.h"
+#include "../FortranPotLoader.h"
 
-/** Fortran interface for the EDIP potential.
-@param[in]  N           Number of atoms
-@param[in]  R           Array of positions in Angstrom
-@param[out] F           Array of forces in eV/Angstrom
-@param[out] U           Pointer to energy in eV
-@param[in]  bx, by, bz Pointer to box dimensions in Angstrom
-*/
-extern "C" {
-void edip_(const long int *N, const double *R, double *F, double *U,
-           const double *bx, const double *by, const double *bz);
-}
-
-/// EDIP potential for Si (Fortran implementation).
+/// EDIP potential for Si (Fortran implementation, loaded at runtime).
 class EDIP final : public Potential {
 public:
+  using force_fn = void (*)(const long int *N, const double *R, double *F,
+                            double *U, const double *bx, const double *by,
+                            const double *bz);
+
   explicit EDIP(const Parameters &params)
-      : Potential(PotType::EDIP, params) {}
+      : Potential(PotType::EDIP, params) {
+    auto &loader = eonc::FortranPotLoader::instance();
+    m_force = loader.load_sym<force_fn>("eon_edip", "edip_");
+    if (!m_force) {
+      loader.throw_not_found("eon_edip", "EDIP potential (Fortran)");
+    }
+  }
   ~EDIP() override = default;
 
   [[nodiscard]] bool isThreadSafe() const noexcept override { return false; }
 
   void force(long N, const double *R, const int *atomicNrs, double *F,
              double *U, double *variance, const double *box) override;
+
+private:
+  force_fn m_force{nullptr};
 };

--- a/client/potentials/EDIP/meson.build
+++ b/client/potentials/EDIP/meson.build
@@ -1,9 +1,13 @@
-edip = library('edip',
-           'EDIP.cpp',
+# Fortran-only shared library: loaded at runtime via dlopen
+eon_edip = shared_library('eon_edip',
            'edipFortran.f90',
+           fortran_args : _fargs,
+           install : true)
+
+# C++ wrapper (compiled into client, loads Fortran lib at runtime)
+edip_cpp = static_library('edip_cpp',
+           'EDIP.cpp',
            dependencies : _deps,
            cpp_args : _args,
-           fortran_args : _fargs,
            link_with : _linkto,
-           include_directories: _incdirs,
-           install : true)
+           include_directories: _incdirs)

--- a/client/potentials/FeHe/FeHe.cpp
+++ b/client/potentials/FeHe/FeHe.cpp
@@ -30,8 +30,8 @@ void FeHe::force(long N, const double *R, const int *atomicNrs, double *F,
     ISPEC[i] = (atomicNrs[i] == 26) ? 0 : 1;
   }
 
-  feforce_(&N, RX.data(), RY.data(), RZ.data(), ISPEC.data(), FX.data(),
-           FY.data(), FZ.data(), U, &box[0], &box[4], &box[8]);
+  m_feforce(&N, RX.data(), RY.data(), RZ.data(), ISPEC.data(), FX.data(),
+            FY.data(), FZ.data(), U, &box[0], &box[4], &box[8]);
 
   for (long i = 0; i < N; i++) {
     F[i * 3] = FX[i];

--- a/client/potentials/FeHe/FeHe.h
+++ b/client/potentials/FeHe/FeHe.h
@@ -12,35 +12,32 @@
 #pragma once
 
 #include "../../Potential.h"
+#include "../FortranPotLoader.h"
 
-/** Fortran interface for the Fe-He potential.
-@param[in]  N           number of atoms
-@param[in]  RX          array of x positions of the atoms in Angstrom
-@param[in]  RY          array of y positions of the atoms in Angstrom
-@param[in]  RZ          array of z positions of the atoms in Angstrom
-@param[in]  ISPEC       array of species identifiers; Fe = 0, He = 1
-@param[out] FX          array of x forces between atoms, in eV/Angstrom
-@param[out] FY          array of y forces between atoms, in eV/Angstrom
-@param[out] FZ          array of z forces between atoms, in eV/Angstrom
-@param[out] U           pointer to energy in eV
-@param[in]  bx, by, bz  pointer to box dimensions in Angstrom
-*/
-extern "C" {
-void feforce_(const long int *N, const double *RX, const double *RY,
-              const double *RZ, const int *ISPEC, double *FX, double *FY,
-              double *FZ, double *U, const double *bx, const double *by,
-              const double *bz);
-}
-
-/// Fe-He interatomic potential (Fortran implementation).
+/// Fe-He interatomic potential (Fortran implementation, loaded at runtime).
 class FeHe final : public Potential {
 public:
+  using feforce_fn = void (*)(const long int *N, const double *RX,
+                              const double *RY, const double *RZ,
+                              const int *ISPEC, double *FX, double *FY,
+                              double *FZ, double *U, const double *bx,
+                              const double *by, const double *bz);
+
   explicit FeHe(const Parameters &params)
-      : Potential(params) {}
+      : Potential(params) {
+    auto &loader = eonc::FortranPotLoader::instance();
+    m_feforce = loader.load_sym<feforce_fn>("eon_fehe", "feforce_");
+    if (!m_feforce) {
+      loader.throw_not_found("eon_fehe", "Fe-He potential (Fortran)");
+    }
+  }
   ~FeHe() override = default;
 
   [[nodiscard]] bool isThreadSafe() const noexcept override { return false; }
 
   void force(long N, const double *R, const int *atomicNrs, double *F,
              double *U, double *variance, const double *box) override;
+
+private:
+  feforce_fn m_feforce{nullptr};
 };

--- a/client/potentials/FeHe/meson.build
+++ b/client/potentials/FeHe/meson.build
@@ -1,9 +1,13 @@
-fehe = library('fehe',
+# Fortran-only shared library: loaded at runtime via dlopen
+eon_fehe = shared_library('eon_fehe',
            'feforce.f',
+           fortran_args : _fargs,
+           install : true)
+
+# C++ wrapper (compiled into client, loads Fortran lib at runtime)
+fehe_cpp = static_library('fehe_cpp',
            'FeHe.cpp',
            dependencies : _deps,
            cpp_args : _args,
-           fortran_args : _fargs,
            link_with : _linkto,
-           include_directories: _incdirs,
-           install : true)
+           include_directories: _incdirs)

--- a/client/potentials/FortranPotLoader.cpp
+++ b/client/potentials/FortranPotLoader.cpp
@@ -1,0 +1,174 @@
+/*
+** This file is part of eOn.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eOn Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eOn
+*/
+#include "FortranPotLoader.h"
+
+#include <cstdlib>
+#include <filesystem>
+#include <sstream>
+
+namespace eonc {
+
+FortranPotLoader &FortranPotLoader::instance() {
+  static FortranPotLoader loader;
+  return loader;
+}
+
+FortranPotLoader::FortranPotLoader() {
+  // Seed from EON_POTENTIALS_PATH env var (colon-separated on POSIX).
+  // Config-file paths are prepended later via add_config_paths().
+  const char *env = std::getenv("EON_POTENTIALS_PATH");
+  if (env && *env) {
+#ifdef _WIN32
+    append_paths(env, ';');
+#else
+    append_paths(env, ':');
+#endif
+  }
+}
+
+FortranPotLoader::~FortranPotLoader() {
+  for (auto &[name, handle] : m_handles) {
+    dynlib::close(handle);
+  }
+}
+
+void FortranPotLoader::append_paths(const std::string &path_str, char sep) {
+  std::string::size_type start = 0;
+  while (start < path_str.size()) {
+    auto pos = path_str.find(sep, start);
+    if (pos == std::string::npos)
+      pos = path_str.size();
+    if (pos > start) {
+      std::string p = path_str.substr(start, pos - start);
+      bool dup = false;
+      for (const auto &existing : m_search_paths) {
+        if (existing == p) {
+          dup = true;
+          break;
+        }
+      }
+      if (!dup)
+        m_search_paths.push_back(std::move(p));
+    }
+    start = pos + 1;
+  }
+}
+
+void FortranPotLoader::add_config_paths(const std::string &colon_paths) {
+  if (colon_paths.empty())
+    return;
+  std::lock_guard<std::mutex> lock(m_mutex);
+  // Config paths have higher priority than env-var paths: insert at front.
+  std::vector<std::string> new_paths;
+#ifdef _WIN32
+  const char sep = ';';
+#else
+  const char sep = ':';
+#endif
+  std::string::size_type start = 0;
+  while (start < colon_paths.size()) {
+    auto pos = colon_paths.find(sep, start);
+    if (pos == std::string::npos)
+      pos = colon_paths.size();
+    if (pos > start) {
+      std::string p = colon_paths.substr(start, pos - start);
+      bool dup = false;
+      for (const auto &existing : m_search_paths) {
+        if (existing == p) {
+          dup = true;
+          break;
+        }
+      }
+      if (!dup)
+        new_paths.push_back(std::move(p));
+    }
+    start = pos + 1;
+  }
+  m_search_paths.insert(m_search_paths.begin(), new_paths.begin(),
+                        new_paths.end());
+}
+
+std::vector<std::string>
+FortranPotLoader::lib_names(const char *lib_base) const {
+  std::vector<std::string> names;
+#ifdef _WIN32
+  names.push_back(std::string(lib_base) + ".dll");
+  names.push_back(std::string("lib") + lib_base + ".dll");
+#elif defined(__APPLE__)
+  names.push_back(std::string("lib") + lib_base + ".dylib");
+#else
+  names.push_back(std::string("lib") + lib_base + ".so");
+#endif
+  return names;
+}
+
+dynlib::Handle FortranPotLoader::open_lib(const char *lib_base) {
+  std::lock_guard<std::mutex> lock(m_mutex);
+
+  auto it = m_handles.find(lib_base);
+  if (it != m_handles.end()) {
+    return it->second;
+  }
+
+  auto names = lib_names(lib_base);
+  dynlib::Handle h{};
+
+  // Try each search path (config paths precede env-var paths in m_search_paths)
+  for (const auto &dir : m_search_paths) {
+    for (const auto &name : names) {
+      std::string full = (std::filesystem::path(dir) / name).string();
+      h = dynlib::open(full.c_str());
+      if (h) {
+        m_handles[lib_base] = h;
+        return h;
+      }
+    }
+  }
+
+  // Fall back to system search (LD_LIBRARY_PATH, etc.)
+  for (const auto &name : names) {
+    h = dynlib::open(name.c_str());
+    if (h) {
+      m_handles[lib_base] = h;
+      return h;
+    }
+  }
+
+  m_handles[lib_base] = nullptr;
+  return nullptr;
+}
+
+void FortranPotLoader::throw_not_found(const char *lib_base,
+                                       const char *description) const {
+  auto names = lib_names(lib_base);
+  std::ostringstream oss;
+  oss << description << " requested but library not found.\n"
+      << "Looked for: ";
+  for (size_t i = 0; i < names.size(); ++i) {
+    if (i > 0)
+      oss << ", ";
+    oss << names[i];
+  }
+  oss << "\n";
+  if (!m_search_paths.empty()) {
+    oss << "Search paths (config potentials_path + EON_POTENTIALS_PATH):\n";
+    for (const auto &p : m_search_paths) {
+      oss << "  " << p << "\n";
+    }
+  }
+  oss << "Set [Potential] potentials_path in config.ini, "
+         "or set EON_POTENTIALS_PATH,\n"
+         "or ensure the libraries are in LD_LIBRARY_PATH.";
+  throw std::runtime_error(oss.str());
+}
+
+} // namespace eonc

--- a/client/potentials/FortranPotLoader.h
+++ b/client/potentials/FortranPotLoader.h
@@ -1,0 +1,83 @@
+/*
+** This file is part of eOn.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eOn Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eOn
+*/
+#pragma once
+
+/// Runtime loader for Fortran potential shared libraries.
+///
+/// Uses dlopen (POSIX) or LoadLibrary (Windows) to load Fortran potential
+/// libraries at runtime. The search order is:
+///   1. Paths from the [Potential] potentials_path config key
+///   2. EON_POTENTIALS_PATH environment variable (colon-separated)
+///   3. Default system library search path (LD_LIBRARY_PATH, etc.)
+///
+/// Call add_config_paths() once at startup (before any potential constructor)
+/// to inject config-file paths into the singleton.
+
+#include "../DynLib.h"
+
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace eonc {
+
+class FortranPotLoader {
+public:
+  /// Thread-safe singleton accessor (Meyer's pattern).
+  static FortranPotLoader &instance();
+
+  /// Inject search paths from the eOn config file.
+  /// @param colon_paths  colon-separated directory list (may be empty)
+  /// These paths are inserted before the EON_POTENTIALS_PATH paths.
+  void add_config_paths(const std::string &colon_paths);
+
+  /// Load a symbol from a named potential library.
+  /// @param lib_base  Base name without platform prefix/suffix (e.g. "eon_sw")
+  /// @param sym_name  Symbol to load (e.g. "sw_")
+  /// @returns Function pointer, or nullptr if not found.
+  template <typename Fn>
+  Fn load_sym(const char *lib_base, const char *sym_name) {
+    dynlib::Handle h = open_lib(lib_base);
+    if (!h)
+      return nullptr;
+    return dynlib::loadSym<Fn>(h, sym_name);
+  }
+
+  /// Throw a descriptive error for a missing potential library.
+  [[noreturn]] void throw_not_found(const char *lib_base,
+                                    const char *description) const;
+
+  /// Get the current search paths (for diagnostics).
+  [[nodiscard]] const std::vector<std::string> &
+  search_paths() const noexcept {
+    return m_search_paths;
+  }
+
+  FortranPotLoader(const FortranPotLoader &) = delete;
+  FortranPotLoader &operator=(const FortranPotLoader &) = delete;
+
+private:
+  FortranPotLoader();
+  ~FortranPotLoader();
+
+  dynlib::Handle open_lib(const char *lib_base);
+  std::vector<std::string> lib_names(const char *lib_base) const;
+  void append_paths(const std::string &path_str, char sep);
+
+  std::vector<std::string> m_search_paths;
+  std::mutex m_mutex;
+  std::unordered_map<std::string, dynlib::Handle> m_handles;
+};
+
+} // namespace eonc

--- a/client/potentials/LAMMPS/meson.build
+++ b/client/potentials/LAMMPS/meson.build
@@ -1,9 +1,8 @@
 # LAMMPS potential: loaded at runtime via dlopen, no compile-time dependency
-dl_dep = cppc.find_library('dl', required: false)
 lammps_pot = library('lammps_pot',
     'LAMMPSPot.cpp',
     'LammpsLoader.cpp',
-    dependencies: [_deps, dl_dep],
+    dependencies: _deps,
     cpp_args: _args,
     link_with: _linkto,
     include_directories: _incdirs,

--- a/client/potentials/Lenosky/Lenosky.cpp
+++ b/client/potentials/Lenosky/Lenosky.cpp
@@ -15,5 +15,5 @@
 void Lenosky::force(long N, const double *R, const int * /*atomicNrs*/,
                     double *F, double *U, double *variance, const double *box) {
   variance = nullptr;
-  lenosky_(&N, R, F, U, &box[0], &box[4], &box[8]);
+  m_force(&N, R, F, U, &box[0], &box[4], &box[8]);
 }

--- a/client/potentials/Lenosky/Lenosky.h
+++ b/client/potentials/Lenosky/Lenosky.h
@@ -12,28 +12,30 @@
 #pragma once
 
 #include "../../Potential.h"
+#include "../FortranPotLoader.h"
 
-/** Fortran interface for the Lenosky potential.
-@param[in]  N           number of atoms
-@param[in]  R           array of positions in Angstrom
-@param[out] F           array of forces in eV/Angstrom
-@param[out] U           pointer to energy in eV
-@param[in]  bx, by, bz pointer to box dimensions in Angstrom
-*/
-extern "C" {
-void lenosky_(const long int *N, const double *R, double *F, double *U,
-              const double *bx, const double *by, const double *bz);
-}
-
-/// Lenosky potential for Si (Fortran implementation).
+/// Lenosky potential for Si (Fortran implementation, loaded at runtime).
 class Lenosky final : public Potential {
 public:
+  using force_fn = void (*)(const long int *N, const double *R, double *F,
+                            double *U, const double *bx, const double *by,
+                            const double *bz);
+
   explicit Lenosky(const Parameters &params)
-      : Potential(params) {}
+      : Potential(params) {
+    auto &loader = eonc::FortranPotLoader::instance();
+    m_force = loader.load_sym<force_fn>("eon_lenosky", "lenosky_");
+    if (!m_force) {
+      loader.throw_not_found("eon_lenosky", "Lenosky potential (Fortran)");
+    }
+  }
   ~Lenosky() override = default;
 
   [[nodiscard]] bool isThreadSafe() const noexcept override { return false; }
 
   void force(long N, const double *R, const int *atomicNrs, double *F,
              double *U, double *variance, const double *box) override;
+
+private:
+  force_fn m_force{nullptr};
 };

--- a/client/potentials/Lenosky/meson.build
+++ b/client/potentials/Lenosky/meson.build
@@ -1,9 +1,13 @@
-lenosky = library('lenosky',
+# Fortran-only shared library: loaded at runtime via dlopen
+eon_lenosky = shared_library('eon_lenosky',
            'lenoskyFortran.f90',
+           fortran_args : _fargs,
+           install : true)
+
+# C++ wrapper (compiled into client, loads Fortran lib at runtime)
+lenosky_cpp = static_library('lenosky_cpp',
            'Lenosky.cpp',
            dependencies : _deps,
            cpp_args : _args,
-           fortran_args : _fargs,
            link_with : _linkto,
-           include_directories: _incdirs,
-           install : true)
+           include_directories: _incdirs)

--- a/client/potentials/SW/SW.cpp
+++ b/client/potentials/SW/SW.cpp
@@ -15,5 +15,5 @@
 void SW::force(long N, const double *R, const int * /*atomicNrs*/, double *F,
                double *U, double *variance, const double *box) {
   variance = nullptr;
-  sw_(&N, R, F, U, &box[0], &box[4], &box[8]);
+  m_force(&N, R, F, U, &box[0], &box[4], &box[8]);
 }

--- a/client/potentials/SW/SW.h
+++ b/client/potentials/SW/SW.h
@@ -12,28 +12,30 @@
 #pragma once
 
 #include "../../Potential.h"
+#include "../FortranPotLoader.h"
 
-/** Fortran interface for the Stillinger-Weber potential.
-@param[in]  N           number of atoms
-@param[in]  R           array of positions in Angstrom
-@param[out] F           array of forces in eV/Angstrom
-@param[out] U           pointer to energy in eV
-@param[in]  bx, by, bz pointer to box dimensions in Angstrom
-*/
-extern "C" {
-void sw_(const long int *N, const double *R, double *F, double *U,
-         const double *bx, const double *by, const double *bz);
-}
-
-/// Stillinger-Weber potential for Si (Fortran implementation).
+/// Stillinger-Weber potential for Si (Fortran implementation, loaded at runtime).
 class SW final : public Potential {
 public:
+  using force_fn = void (*)(const long int *N, const double *R, double *F,
+                            double *U, const double *bx, const double *by,
+                            const double *bz);
+
   explicit SW(const Parameters &p)
-      : Potential(p) {}
+      : Potential(p) {
+    auto &loader = eonc::FortranPotLoader::instance();
+    m_force = loader.load_sym<force_fn>("eon_sw", "sw_");
+    if (!m_force) {
+      loader.throw_not_found("eon_sw", "Stillinger-Weber potential (Fortran)");
+    }
+  }
   ~SW() override = default;
 
   [[nodiscard]] bool isThreadSafe() const noexcept override { return false; }
 
   void force(long N, const double *R, const int *atomicNrs, double *F,
              double *U, double *variance, const double *box) override;
+
+private:
+  force_fn m_force{nullptr};
 };

--- a/client/potentials/SW/meson.build
+++ b/client/potentials/SW/meson.build
@@ -1,9 +1,13 @@
-sw=library('sw',
+# Fortran-only shared library: loaded at runtime via dlopen
+eon_sw = shared_library('eon_sw',
            'SWFortran.f90',
+           fortran_args : _fargs,
+           install : true)
+
+# C++ wrapper (compiled into client, loads Fortran lib at runtime)
+sw_cpp = static_library('sw_cpp',
            'SW.cpp',
            dependencies : _deps,
            cpp_args : _args,
-           fortran_args : _fargs,
            link_with : _linkto,
-           include_directories: _incdirs,
-           install : true)
+           include_directories: _incdirs)

--- a/client/potentials/Tersoff/Tersoff.cpp
+++ b/client/potentials/Tersoff/Tersoff.cpp
@@ -15,5 +15,5 @@
 void Tersoff::force(long N, const double *R, const int * /*atomicNrs*/,
                     double *F, double *U, double *variance, const double *box) {
   variance = nullptr;
-  tersoff_(&N, R, F, U, &box[0], &box[4], &box[8]);
+  m_force(&N, R, F, U, &box[0], &box[4], &box[8]);
 }

--- a/client/potentials/Tersoff/Tersoff.h
+++ b/client/potentials/Tersoff/Tersoff.h
@@ -12,28 +12,30 @@
 #pragma once
 
 #include "../../Potential.h"
+#include "../FortranPotLoader.h"
 
-/** Fortran interface for the Tersoff potential.
-@param[in]  N           Number of atoms
-@param[in]  R           Array of positions in Angstrom
-@param[out] F           Array of forces in eV/Angstrom
-@param[out] U           Pointer to energy in eV
-@param[in]  bx, by, bz Pointer to box dimensions in Angstrom
-*/
-extern "C" {
-void tersoff_(const long int *N, const double *R, double *F, double *U,
-              const double *bx, const double *by, const double *bz);
-}
-
-/// Tersoff potential for Si (Fortran implementation).
+/// Tersoff potential for Si (Fortran implementation, loaded at runtime).
 class Tersoff final : public Potential {
 public:
+  using force_fn = void (*)(const long int *N, const double *R, double *F,
+                            double *U, const double *bx, const double *by,
+                            const double *bz);
+
   explicit Tersoff(const Parameters &p)
-      : Potential(p) {}
+      : Potential(p) {
+    auto &loader = eonc::FortranPotLoader::instance();
+    m_force = loader.load_sym<force_fn>("eon_tersoff", "tersoff_");
+    if (!m_force) {
+      loader.throw_not_found("eon_tersoff", "Tersoff potential (Fortran)");
+    }
+  }
   ~Tersoff() override = default;
 
   [[nodiscard]] bool isThreadSafe() const noexcept override { return false; }
 
   void force(long N, const double *R, const int *atomicNrs, double *F,
              double *U, double *variance, const double *box) override;
+
+private:
+  force_fn m_force{nullptr};
 };

--- a/client/potentials/Tersoff/meson.build
+++ b/client/potentials/Tersoff/meson.build
@@ -1,9 +1,13 @@
-tersoff=library('tersoff',
-           'Tersoff.cpp',
+# Fortran-only shared library: loaded at runtime via dlopen
+eon_tersoff = shared_library('eon_tersoff',
            'tersoffFortran.f90',
+           fortran_args : _fargs,
+           install : true)
+
+# C++ wrapper (compiled into client, loads Fortran lib at runtime)
+tersoff_cpp = static_library('tersoff_cpp',
+           'Tersoff.cpp',
            dependencies : _deps,
            cpp_args : _args,
-           fortran_args : _fargs,
            link_with : _linkto,
-           include_directories: _incdirs,
-           install : true)
+           include_directories: _incdirs)


### PR DESCRIPTION
Each Fortran potential is now an installed shared_library (eon_aluminum,
eon_edip, eon_fehe, eon_lenosky, eon_sw, eon_tersoff). The C++ wrappers
are compiled into the client but carry no Fortran link-time dependency;
they resolve symbols via FortranPotLoader, a singleton that uses dlopen
(POSIX) / LoadLibrary (Windows) with a configurable search path.

FortranPotLoader search order:
  1. [Potential] potentials_path config key (added in the next commit)
  2. EON_POTENTIALS_PATH environment variable (colon-separated)
  3. System library path (LD_LIBRARY_PATH, etc.)

The WITH_FORTRAN guard is removed from makePotential: the Fortran cases
are always compiled and simply throw at construction time if the shared
library is absent. This mirrors the existing LAMMPS dlopen path.

dl_dep (libdl) moves from the LAMMPS subdirectory into the shared _deps
list in client/meson.build so FortranPotLoader can also link against it.
Meson tests gain an EON_POTENTIALS_PATH environment entry pointing at the
build-tree Fortran subdirs so the in-tree tests find the libraries without
an install step.
