### PR TITLE
fix(LAMMPS): run each per-image LAMMPS in its own process for parallel NEB

### DIFF
--- a/.github/workflows/ci_build_akmc.yml
+++ b/.github/workflows/ci_build_akmc.yml
@@ -35,6 +35,10 @@ jobs:
           meson setup bbdir --prefix=$CONDA_PREFIX --libdir=lib
           meson install -C bbdir
 
+      - name: Activate MSVC (Windows)
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1
+
       - name: Compile and install [windows]
         if: runner.os == 'Windows'
         shell: pixi run bash -e {0}

--- a/client/ClientEON.cpp
+++ b/client/ClientEON.cpp
@@ -290,8 +290,8 @@ int main(int argc, char **argv) {
       MPI_Group orig_group, new_group;
       MPI_Comm_group(MPI_COMM_WORLD, &orig_group);
       int offset = i * potential_group_size;
-      MPI_Group_incl(orig_group, potential_group_size,
-                     &potential_ranks[offset], &new_group);
+      MPI_Group_incl(orig_group, potential_group_size, &potential_ranks[offset],
+                     &new_group);
       MPI_Comm pot_comm;
       MPI_Comm_create(MPI_COMM_WORLD, new_group, &pot_comm);
     }
@@ -375,10 +375,15 @@ int main(int argc, char **argv) {
           irank, server_rank);
       // Tag "1" is to interrupt the main loop and tell the communicator that a
       // client is ready
-      { MPI_Request eon_rq; MPI_Isend(&ready, 1, MPI_INT, server_rank, 1, MPI_COMM_WORLD, &eon_rq); MPI_Request_free(&eon_rq); }
+      {
+        MPI_Request eon_rq;
+        MPI_Isend(&ready, 1, MPI_INT, server_rank, 1, MPI_COMM_WORLD, &eon_rq);
+        MPI_Request_free(&eon_rq);
+      }
 
       // Get the path we should run in from the server
-      MPI_Recv(&path[0], 1024, MPI_CHAR, server_rank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+      MPI_Recv(&path[0], 1024, MPI_CHAR, server_rank, 0, MPI_COMM_WORLD,
+               MPI_STATUS_IGNORE);
       if (path.starts_with("STOPCAR")) {
         QUILL_LOG_INFO(logger, "rank {} got STOPCAR", irank);
         MPI_Finalize();
@@ -493,7 +498,12 @@ int main(int argc, char **argv) {
     if (client_standalone) {
       break;
     }
-    { MPI_Request eon_rq; MPI_Isend(&path[0], 1024, MPI_CHAR, server_rank, 0, MPI_COMM_WORLD, &eon_rq); MPI_Request_free(&eon_rq); }
+    {
+      MPI_Request eon_rq;
+      MPI_Isend(&path[0], 1024, MPI_CHAR, server_rank, 0, MPI_COMM_WORLD,
+                &eon_rq);
+      MPI_Request_free(&eon_rq);
+    }
 
     // End of MPI while loop
   }

--- a/client/Parameters.h
+++ b/client/Parameters.h
@@ -67,7 +67,8 @@ public:
     bool EMTRasmussen{false};
     bool LogPotential{false};
     std::string extPotPath{"./ext_pot"};
-    std::string potentialsPath{""};  // colon-separated dirs for Fortran potential .so files
+    std::string potentialsPath{
+        ""}; // colon-separated dirs for Fortran potential .so files
     int MPIPotentialRank{-1};
 #ifdef EONMPI
     MPI_Comm MPIClientComm;

--- a/client/ParametersINI.cpp
+++ b/client/ParametersINI.cpp
@@ -90,8 +90,8 @@ int load_ini(INIReader &ini, Parameters &params) {
       "Potential", "emt_rasmussen", params.potential_options.EMTRasmussen);
   params.potential_options.extPotPath =
       ini.Get("Potential", "ext_pot_path", params.potential_options.extPotPath);
-  params.potential_options.potentialsPath =
-      ini.Get("Potential", "potentials_path", params.potential_options.potentialsPath);
+  params.potential_options.potentialsPath = ini.Get(
+      "Potential", "potentials_path", params.potential_options.potentialsPath);
 
   if (params.potential_options.potential == PotType::MPI ||
       params.potential_options.potential == PotType::VASP) {

--- a/client/Potential.cpp
+++ b/client/Potential.cpp
@@ -45,10 +45,10 @@
 #include "potentials/Aluminum/Aluminum.h"
 #include "potentials/EDIP/EDIP.h"
 #include "potentials/FeHe/FeHe.h"
+#include "potentials/FortranPotLoader.h"
 #include "potentials/Lenosky/Lenosky.h"
 #include "potentials/SW/SW.h"
 #include "potentials/Tersoff/Tersoff.h"
-#include "potentials/FortranPotLoader.h"
 
 #ifdef EMBED_PYTHON
 

--- a/client/potentials/FortranPotLoader.h
+++ b/client/potentials/FortranPotLoader.h
@@ -59,8 +59,7 @@ public:
                                     const char *description) const;
 
   /// Get the current search paths (for diagnostics).
-  [[nodiscard]] const std::vector<std::string> &
-  search_paths() const noexcept {
+  [[nodiscard]] const std::vector<std::string> &search_paths() const noexcept {
     return m_search_paths;
   }
 

--- a/client/potentials/LAMMPS/LAMMPSPot.cpp
+++ b/client/potentials/LAMMPS/LAMMPSPot.cpp
@@ -19,6 +19,15 @@
 #include <map>
 #include <string>
 
+#ifndef EONMPI
+#include <cerrno>
+#include <cstdlib>
+#include <vector>
+
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
 #ifdef EONMPI
 #define LAMMPS_LIB_MPI
 #endif
@@ -33,20 +42,197 @@ LAMMPSPot::LAMMPSPot(const Parameters &p)
 {
   // Fail fast if LAMMPS library not available
   eonc::LammpsLoader::instance().require_loaded();
+#ifndef EONMPI
+  // Fork the worker NOW, at construction, before this process ever opens a
+  // LAMMPS instance (and thus before liblammps initialises MPI).  Open MPI
+  // does not support using MPI in a process that called MPI_Init before fork,
+  // so the worker must be spawned from a still-MPI-clean parent.  Every
+  // LAMMPSPot -- endpoints and per-image alike -- runs its LAMMPS in its own
+  // child process, so the parent never initialises MPI at all.
+  ensureWorker();
+#endif
 }
 
 LAMMPSPot::~LAMMPSPot() { cleanMemory(); }
 
 void LAMMPSPot::cleanMemory() {
+#ifndef EONMPI
+  stopWorker();
+#endif
   if (LAMMPSObj != nullptr) {
     eonc::LammpsLoader::instance().close(LAMMPSObj);
     LAMMPSObj = nullptr;
   }
 }
 
+#ifndef EONMPI
+// ---------------------------------------------------------------------------
+// Process-per-image worker plumbing
+// ---------------------------------------------------------------------------
+namespace {
+// Blocking read/write of exactly n bytes over a pipe.  Returns false on EOF or
+// error, so a dead peer is detected rather than silently producing garbage.
+bool readExact(int fd, void *buf, size_t n) {
+  auto *p = static_cast<char *>(buf);
+  while (n > 0) {
+    ssize_t r = read(fd, p, n);
+    if (r <= 0) {
+      if (r < 0 && errno == EINTR)
+        continue;
+      return false;
+    }
+    p += r;
+    n -= static_cast<size_t>(r);
+  }
+  return true;
+}
+bool writeExact(int fd, const void *buf, size_t n) {
+  const auto *p = static_cast<const char *>(buf);
+  while (n > 0) {
+    ssize_t w = write(fd, p, n);
+    if (w < 0) {
+      if (errno == EINTR)
+        continue;
+      return false;
+    }
+    p += w;
+    n -= static_cast<size_t>(w);
+  }
+  return true;
+}
+} // namespace
+
+void LAMMPSPot::ensureWorker() {
+  if (workerSpawned)
+    return;
+
+  int reqPipe[2]; // parent -> child
+  int resPipe[2]; // child -> parent
+  if (pipe(reqPipe) != 0 || pipe(resPipe) != 0) {
+    throw std::runtime_error("LAMMPSPot: failed to create worker pipes");
+  }
+
+  // Fork BEFORE opening any LAMMPS instance in this process, so MPI is first
+  // initialised inside the child.  Each child is its own process with its own
+  // MPI_COMM_WORLD; concurrent children never share a communicator.
+  pid_t pid = fork();
+  if (pid < 0) {
+    throw std::runtime_error("LAMMPSPot: fork for worker failed");
+  }
+
+  if (pid == 0) {
+    // Child: keep reqPipe read end and resPipe write end.
+    close(reqPipe[1]);
+    close(resPipe[0]);
+    reqFd = reqPipe[0];
+    resFd = resPipe[1];
+    runWorkerLoop(); // never returns
+  }
+
+  // Parent: keep reqPipe write end and resPipe read end.
+  close(reqPipe[0]);
+  close(resPipe[1]);
+  reqFd = reqPipe[1];
+  resFd = resPipe[0];
+  workerPid = pid;
+  workerSpawned = true;
+}
+
+void LAMMPSPot::runWorkerLoop() {
+  // Running in the forked child.  Evaluate forces with an in-process LAMMPS
+  // (this child's own MPI_COMM_WORLD) and stream results back to the parent.
+  for (;;) {
+    long N = 0;
+    if (!readExact(reqFd, &N, sizeof(N))) {
+      _exit(0); // request pipe closed -> shut down cleanly
+    }
+    if (N < 0) {
+      _exit(0); // explicit shutdown sentinel from stopWorker()
+    }
+    std::vector<int> atomicNrs(static_cast<size_t>(N));
+    std::vector<double> R(static_cast<size_t>(3 * N));
+    double box[9];
+    if (!readExact(reqFd, atomicNrs.data(), sizeof(int) * static_cast<size_t>(N)) ||
+        !readExact(reqFd, box, sizeof(box)) ||
+        !readExact(reqFd, R.data(), sizeof(double) * static_cast<size_t>(3 * N))) {
+      _exit(1);
+    }
+
+    std::vector<double> F(static_cast<size_t>(3 * N), 0.0);
+    double U = 0.0;
+    int status = 0;
+    try {
+      forceLocal(N, R.data(), atomicNrs.data(), F.data(), &U, box);
+    } catch (...) {
+      status = 1;
+    }
+
+    if (!writeExact(resFd, &status, sizeof(status)) ||
+        !writeExact(resFd, &U, sizeof(U)) ||
+        !writeExact(resFd, F.data(), sizeof(double) * static_cast<size_t>(3 * N))) {
+      _exit(1);
+    }
+  }
+}
+
+void LAMMPSPot::stopWorker() {
+  if (!workerSpawned)
+    return;
+  if (reqFd >= 0) {
+    // Send an explicit shutdown sentinel, then close.  A sentinel (rather than
+    // relying on pipe EOF) guarantees the child exits even when sibling worker
+    // processes hold an inherited copy of this write end.
+    long sentinel = -1;
+    writeExact(reqFd, &sentinel, sizeof(sentinel));
+    close(reqFd);
+    reqFd = -1;
+  }
+  if (resFd >= 0) {
+    close(resFd);
+    resFd = -1;
+  }
+  if (workerPid > 0) {
+    int st = 0;
+    waitpid(workerPid, &st, 0);
+    workerPid = -1;
+  }
+  workerSpawned = false;
+}
+#endif // !EONMPI
+
 void LAMMPSPot::force(long N, const double *R, const int *atomicNrs, double *F,
                       double *U, double *variance, const double *box) {
   variance = nullptr;
+
+#ifdef EONMPI
+  forceLocal(N, R, atomicNrs, F, U, box);
+#else
+  // Drive the dedicated worker process so this image's LAMMPS runs in its own
+  // process (own MPI_COMM_WORLD).  Per-image NEB threads thus evaluate forces
+  // as truly concurrent processes with no shared-communicator contention.
+  ensureWorker();
+
+  if (!writeExact(reqFd, &N, sizeof(N)) ||
+      !writeExact(reqFd, atomicNrs, sizeof(int) * static_cast<size_t>(N)) ||
+      !writeExact(reqFd, box, sizeof(double) * 9) ||
+      !writeExact(reqFd, R, sizeof(double) * static_cast<size_t>(3 * N))) {
+    throw std::runtime_error("LAMMPSPot: failed to send request to worker");
+  }
+
+  int status = 0;
+  if (!readExact(resFd, &status, sizeof(status)) ||
+      !readExact(resFd, U, sizeof(double)) ||
+      !readExact(resFd, F, sizeof(double) * static_cast<size_t>(3 * N))) {
+    throw std::runtime_error("LAMMPSPot: worker process died during force eval");
+  }
+  if (status != 0) {
+    throw std::runtime_error("LAMMPSPot: worker reported a force evaluation error");
+  }
+#endif
+}
+
+void LAMMPSPot::forceLocal(long N, const double *R, const int *atomicNrs,
+                           double *F, double *U, const double *box) {
   auto &lmp = eonc::LammpsLoader::instance();
 
   bool newLammps = false;
@@ -106,7 +292,8 @@ void LAMMPSPot::makeNewLAMMPS(long N, const double *R, const int *atomicNrs,
   std::memcpy(oldBox, box, 9 * sizeof(double));
 
   if (LAMMPSObj != nullptr) {
-    cleanMemory();
+    eonc::LammpsLoader::instance().close(LAMMPSObj);
+    LAMMPSObj = nullptr;
   }
 
   // Map atomic numbers to LAMMPS type indices (1-based)

--- a/client/potentials/LAMMPS/LAMMPSPot.cpp
+++ b/client/potentials/LAMMPS/LAMMPSPot.cpp
@@ -152,9 +152,11 @@ void LAMMPSPot::runWorkerLoop() {
     std::vector<int> atomicNrs(static_cast<size_t>(N));
     std::vector<double> R(static_cast<size_t>(3 * N));
     double box[9];
-    if (!readExact(reqFd, atomicNrs.data(), sizeof(int) * static_cast<size_t>(N)) ||
+    if (!readExact(reqFd, atomicNrs.data(),
+                   sizeof(int) * static_cast<size_t>(N)) ||
         !readExact(reqFd, box, sizeof(box)) ||
-        !readExact(reqFd, R.data(), sizeof(double) * static_cast<size_t>(3 * N))) {
+        !readExact(reqFd, R.data(),
+                   sizeof(double) * static_cast<size_t>(3 * N))) {
       _exit(1);
     }
 
@@ -169,7 +171,8 @@ void LAMMPSPot::runWorkerLoop() {
 
     if (!writeExact(resFd, &status, sizeof(status)) ||
         !writeExact(resFd, &U, sizeof(U)) ||
-        !writeExact(resFd, F.data(), sizeof(double) * static_cast<size_t>(3 * N))) {
+        !writeExact(resFd, F.data(),
+                    sizeof(double) * static_cast<size_t>(3 * N))) {
       _exit(1);
     }
   }
@@ -226,10 +229,12 @@ void LAMMPSPot::force(long N, const double *R, const int *atomicNrs, double *F,
   if (!readExact(resFd, &status, sizeof(status)) ||
       !readExact(resFd, U, sizeof(double)) ||
       !readExact(resFd, F, sizeof(double) * static_cast<size_t>(3 * N))) {
-    throw std::runtime_error("LAMMPSPot: worker process died during force eval");
+    throw std::runtime_error(
+        "LAMMPSPot: worker process died during force eval");
   }
   if (status != 0) {
-    throw std::runtime_error("LAMMPSPot: worker reported a force evaluation error");
+    throw std::runtime_error(
+        "LAMMPSPot: worker reported a force evaluation error");
   }
 #endif
 }
@@ -318,7 +323,7 @@ void LAMMPSPot::makeNewLAMMPS(long N, const double *R, const int *atomicNrs,
         "Install an MPI-enabled LAMMPS build.");
   }
   MPI_Comm inst_comm = MPI_COMM_NULL;
-  MPI_Comm_dup(mpiComm, &inst_comm);  // private comm per per-image instance
+  MPI_Comm_dup(mpiComm, &inst_comm); // private comm per per-image instance
   LAMMPSObj =
       lmp.open_mpi(lmpargc, const_cast<char **>(lmpargv), inst_comm, nullptr);
 #else

--- a/client/potentials/LAMMPS/LAMMPSPot.cpp
+++ b/client/potentials/LAMMPS/LAMMPSPot.cpp
@@ -19,7 +19,7 @@
 #include <map>
 #include <string>
 
-#ifndef EONMPI
+#if !defined(EONMPI) && !defined(IS_WINDOWS)
 #include <cerrno>
 #include <cstdlib>
 #include <vector>
@@ -42,7 +42,7 @@ LAMMPSPot::LAMMPSPot(const Parameters &p)
 {
   // Fail fast if LAMMPS library not available
   eonc::LammpsLoader::instance().require_loaded();
-#ifndef EONMPI
+#if !defined(EONMPI) && !defined(IS_WINDOWS)
   // Fork the worker NOW, at construction, before this process ever opens a
   // LAMMPS instance (and thus before liblammps initialises MPI).  Open MPI
   // does not support using MPI in a process that called MPI_Init before fork,
@@ -56,7 +56,7 @@ LAMMPSPot::LAMMPSPot(const Parameters &p)
 LAMMPSPot::~LAMMPSPot() { cleanMemory(); }
 
 void LAMMPSPot::cleanMemory() {
-#ifndef EONMPI
+#if !defined(EONMPI) && !defined(IS_WINDOWS)
   stopWorker();
 #endif
   if (LAMMPSObj != nullptr) {
@@ -65,9 +65,9 @@ void LAMMPSPot::cleanMemory() {
   }
 }
 
-#ifndef EONMPI
+#if !defined(EONMPI) && !defined(IS_WINDOWS)
 // ---------------------------------------------------------------------------
-// Process-per-image worker plumbing
+// Process-per-image worker plumbing (POSIX only)
 // ---------------------------------------------------------------------------
 namespace {
 // Blocking read/write of exactly n bytes over a pipe.  Returns false on EOF or
@@ -198,13 +198,16 @@ void LAMMPSPot::stopWorker() {
   }
   workerSpawned = false;
 }
-#endif // !EONMPI
+#endif // !EONMPI && !IS_WINDOWS
 
 void LAMMPSPot::force(long N, const double *R, const int *atomicNrs, double *F,
                       double *U, double *variance, const double *box) {
   variance = nullptr;
 
 #ifdef EONMPI
+  forceLocal(N, R, atomicNrs, F, U, box);
+#elif defined(IS_WINDOWS)
+  // No fork/pipe on Windows; call forceLocal directly.
   forceLocal(N, R, atomicNrs, F, U, box);
 #else
   // Drive the dedicated worker process so this image's LAMMPS runs in its own

--- a/client/potentials/LAMMPS/LAMMPSPot.h
+++ b/client/potentials/LAMMPS/LAMMPSPot.h
@@ -19,7 +19,9 @@
 class LAMMPSPot : public Potential {
 
 public:
-  [[nodiscard]] bool needsPerImageInstance() const noexcept override { return true; }
+  [[nodiscard]] bool needsPerImageInstance() const noexcept override {
+    return true;
+  }
   LAMMPSPot(const Parameters &p);
   ~LAMMPSPot();
   void cleanMemory();
@@ -47,8 +49,8 @@ private:
   // in its own process with its own MPI_COMM_WORLD and true parallelism.
   // Not available on Windows (no fork/pipe).
   int workerPid{-1};
-  int reqFd{-1};  // parent writes requests here (child stdin side)
-  int resFd{-1};  // parent reads results here (child stdout side)
+  int reqFd{-1}; // parent writes requests here (child stdin side)
+  int resFd{-1}; // parent reads results here (child stdout side)
   bool workerSpawned{false};
 
   // Fork the worker child on first use; child enters runWorkerLoop().

--- a/client/potentials/LAMMPS/LAMMPSPot.h
+++ b/client/potentials/LAMMPS/LAMMPSPot.h
@@ -24,7 +24,7 @@ public:
   ~LAMMPSPot();
   void cleanMemory();
   void force(long N, const double *R, const int *atomicNrs, double *F,
-             double *U, double *variance, const double *box);
+             double *U, double *variance, const double *box) override;
 
 private:
   int lammpsThr{0};
@@ -37,4 +37,26 @@ private:
   void makeNewLAMMPS(long N, const double *R, const int *atomicNrs,
                      const double *box);
   bool realunits{false};
+
+#ifndef EONMPI
+  // Process-per-image evaluation.  NEB drives intermediate images on separate
+  // std::threads; if each thread opened LAMMPS in this process they would all
+  // share one MPI_COMM_WORLD and their concurrent reduction collectives would
+  // collide (heap corruption / MPI_ERR_OP).  Instead each LAMMPSPot forks a
+  // dedicated worker process that owns its LAMMPS instance, so every image runs
+  // in its own process with its own MPI_COMM_WORLD and true parallelism.
+  int workerPid{-1};
+  int reqFd{-1};  // parent writes requests here (child stdin side)
+  int resFd{-1};  // parent reads results here (child stdout side)
+  bool workerSpawned{false};
+
+  // In-process LAMMPS force evaluation (runs inside the worker child).
+  void forceLocal(long N, const double *R, const int *atomicNrs, double *F,
+                  double *U, const double *box);
+  // Fork the worker child on first use; child enters runWorkerLoop().
+  void ensureWorker();
+  // Child main loop: read requests, evaluate, write results; never returns.
+  [[noreturn]] void runWorkerLoop();
+  void stopWorker();
+#endif
 };

--- a/client/potentials/LAMMPS/LAMMPSPot.h
+++ b/client/potentials/LAMMPS/LAMMPSPot.h
@@ -38,25 +38,27 @@ private:
                      const double *box);
   bool realunits{false};
 
-#ifndef EONMPI
+#if !defined(EONMPI) && !defined(IS_WINDOWS)
   // Process-per-image evaluation.  NEB drives intermediate images on separate
   // std::threads; if each thread opened LAMMPS in this process they would all
   // share one MPI_COMM_WORLD and their concurrent reduction collectives would
   // collide (heap corruption / MPI_ERR_OP).  Instead each LAMMPSPot forks a
   // dedicated worker process that owns its LAMMPS instance, so every image runs
   // in its own process with its own MPI_COMM_WORLD and true parallelism.
+  // Not available on Windows (no fork/pipe).
   int workerPid{-1};
   int reqFd{-1};  // parent writes requests here (child stdin side)
   int resFd{-1};  // parent reads results here (child stdout side)
   bool workerSpawned{false};
 
-  // In-process LAMMPS force evaluation (runs inside the worker child).
-  void forceLocal(long N, const double *R, const int *atomicNrs, double *F,
-                  double *U, const double *box);
   // Fork the worker child on first use; child enters runWorkerLoop().
   void ensureWorker();
   // Child main loop: read requests, evaluate, write results; never returns.
   [[noreturn]] void runWorkerLoop();
   void stopWorker();
 #endif
+  // In-process LAMMPS force evaluation (used directly on Windows/MPI, and
+  // inside the worker child on POSIX).
+  void forceLocal(long N, const double *R, const int *atomicNrs, double *F,
+                  double *U, const double *box);
 };

--- a/client/potentials/MPIPot/MPIPot.cpp
+++ b/client/potentials/MPIPot/MPIPot.cpp
@@ -54,18 +54,22 @@ void MPIPot::force(long N, const double *R, const int *atomicNrs, double *F,
     MPI_Iprobe(potentialRank, 0, MPI_COMM_WORLD, &eon_flag, MPI_STATUS_IGNORE);
     while (!eon_flag) {
       usleep(static_cast<useconds_t>(poll_period / 1000000.0));
-      MPI_Iprobe(potentialRank, 0, MPI_COMM_WORLD, &eon_flag, MPI_STATUS_IGNORE);
+      MPI_Iprobe(potentialRank, 0, MPI_COMM_WORLD, &eon_flag,
+                 MPI_STATUS_IGNORE);
     }
   }
 
   // Recv data from potential
-  MPI_Recv(&failed, 1, MPI_INT, potentialRank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+  MPI_Recv(&failed, 1, MPI_INT, potentialRank, 0, MPI_COMM_WORLD,
+           MPI_STATUS_IGNORE);
   if (failed == 1) {
     throw 100;
   }
 
-  MPI_Recv(U, 1, MPI_DOUBLE, potentialRank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-  MPI_Recv(F, 3 * N, MPI_DOUBLE, potentialRank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+  MPI_Recv(U, 1, MPI_DOUBLE, potentialRank, 0, MPI_COMM_WORLD,
+           MPI_STATUS_IGNORE);
+  MPI_Recv(F, 3 * N, MPI_DOUBLE, potentialRank, 0, MPI_COMM_WORLD,
+           MPI_STATUS_IGNORE);
   // printf("energy: %12.4e\n", *U);
   // printf("forces:\n");
   // for (int i=0;i<N;i++) printf("%12.4e %12.4e %12.4e\n", F[3*i], F[3*i+1],

--- a/client/potentials/SW/SW.h
+++ b/client/potentials/SW/SW.h
@@ -14,7 +14,8 @@
 #include "../../Potential.h"
 #include "../FortranPotLoader.h"
 
-/// Stillinger-Weber potential for Si (Fortran implementation, loaded at runtime).
+/// Stillinger-Weber potential for Si (Fortran implementation, loaded at
+/// runtime).
 class SW final : public Potential {
 public:
   using force_fn = void (*)(const long int *N, const double *R, double *F,

--- a/client/unit_tests/JobIntegrationTest.cpp
+++ b/client/unit_tests/JobIntegrationTest.cpp
@@ -18,8 +18,8 @@
 #include "Job.h"
 #include "Matter.h"
 #include "Parameters.h"
-#include "Potential.h"
 #include "PotRegistry.h"
+#include "Potential.h"
 #include "TestUtils.hpp"
 #include "catch2/catch_amalgamated.hpp"
 #ifdef WITH_ARTN
@@ -1456,13 +1456,14 @@ parseConAtoms(const std::filesystem::path &path) {
   if (!f)
     return atoms;
   std::string line;
-  // consume lines 0-6 (header: title, json/blank, cell, angles, 2 blanks, nTypes)
+  // consume lines 0-6 (header: title, json/blank, cell, angles, 2 blanks,
+  // nTypes)
   for (int i = 0; i < 7; i++)
     std::getline(f, line);
   // line 7: space-separated n_atoms per component; take the first token
   int n_atoms = 0;
   {
-    std::getline(f, line);  // reads line 7
+    std::getline(f, line); // reads line 7
     std::istringstream ss(line);
     ss >> n_atoms;
   }
@@ -1499,9 +1500,8 @@ TEST_CASE_METHOD(JobIntegrationFixture,
     for (size_t i = 0; i < pos_atoms.size(); i++) {
       if (pos_atoms[i].second != 0) {
         for (int ax = 0; ax < 3; ax++) {
-          max_stale =
-              std::max(max_stale, std::abs(pos_atoms[i].first[ax] -
-                                           dis_atoms[i].first[ax]));
+          max_stale = std::max(max_stale, std::abs(pos_atoms[i].first[ax] -
+                                                   dis_atoms[i].first[ax]));
         }
       }
     }
@@ -1564,8 +1564,8 @@ default_value = 1e12
       ++n_fixed;
       for (int ax = 0; ax < 3; ax++) {
         max_fixed_drift =
-            std::max(max_fixed_drift,
-                     std::abs(pos_atoms[i].first[ax] - reactant_atoms[i].first[ax]));
+            std::max(max_fixed_drift, std::abs(pos_atoms[i].first[ax] -
+                                               reactant_atoms[i].first[ax]));
       }
     }
   }
@@ -1593,15 +1593,16 @@ TEST_CASE("ProcessSearchJob fixed-atom restore: displacement.con stale rows "
 
   // initial = pos.con (the authoritative reference)
   auto initial = std::make_shared<Matter>(pot, params);
-  REQUIRE(initial->con2matter(std::string("../Pt_Heptamer_FrozenLayers/pos.con")));
+  REQUIRE(
+      initial->con2matter(std::string("../Pt_Heptamer_FrozenLayers/pos.con")));
   REQUIRE(initial->numberOfAtoms() == 343);
   REQUIRE(initial->numberOfFixedAtoms() == 336);
 
   // saddle = displacement.con from process_search_fixed_drift -- has +0.1 A
   // offset on all fixed-atom rows vs pos.con.
   auto saddle = std::make_shared<Matter>(pot, params);
-  REQUIRE(
-      saddle->con2matter(std::string("../process_search_fixed_drift/displacement.con")));
+  REQUIRE(saddle->con2matter(
+      std::string("../process_search_fixed_drift/displacement.con")));
   REQUIRE(saddle->numberOfAtoms() == 343);
 
   // Confirm the stale fixed-atom drift is present before the fix.
@@ -1611,10 +1612,11 @@ TEST_CASE("ProcessSearchJob fixed-atom restore: displacement.con stale rows "
     double max_stale = 0.0;
     for (long i = 0; i < initial->numberOfAtoms(); i++) {
       if (initial->getFixed(i)) {
-        max_stale = std::max(max_stale, (iPos.row(i) - sPos.row(i)).cwiseAbs().maxCoeff());
+        max_stale = std::max(max_stale,
+                             (iPos.row(i) - sPos.row(i)).cwiseAbs().maxCoeff());
       }
     }
-    REQUIRE(max_stale > 0.05);  // displacement.con was built with +0.1 A
+    REQUIRE(max_stale > 0.05); // displacement.con was built with +0.1 A
   }
 
   // Apply the fix: restore fixed-atom rows from initial into saddle.
@@ -1638,7 +1640,8 @@ TEST_CASE("ProcessSearchJob fixed-atom restore: displacement.con stale rows "
     for (long i = 0; i < initial->numberOfAtoms(); i++) {
       if (initial->getFixed(i)) {
         ++n_fixed;
-        max_drift = std::max(max_drift, (iPos.row(i) - sPos.row(i)).cwiseAbs().maxCoeff());
+        max_drift = std::max(max_drift,
+                             (iPos.row(i) - sPos.row(i)).cwiseAbs().maxCoeff());
       }
     }
     REQUIRE(n_fixed == 336);


### PR DESCRIPTION

NEB parallel force evaluation creates one LAMMPSPot per band image as in-process threads that all share the process MPI_COMM_WORLD. LAMMPS issues reduction collectives on MPI_COMM_WORLD internally regardless of any per-instance communicator, so concurrent image threads race on those collectives and corrupt the heap (free(): invalid pointer inside CommBrick::borders).

Each LAMMPSPot now forks a dedicated worker process in its constructor, before MPI is initialized, so every child owns its own MPI_COMM_WORLD. The worker holds the LAMMPS instance and serves force requests over pipes; force() ships positions and reads back energy and forces. Per-image evaluation stays fully parallel across separate processes, with no shared communicator to collide on.