### PR TITLE
fix(client): synthesize displacement.con from mode (#79)

### DIFF
--- a/client/HelperFunctions.cpp
+++ b/client/HelperFunctions.cpp
@@ -141,6 +141,48 @@ AtomMatrix eonc::helpers::loadMode(string filename, int nAtoms) {
   return loadMode(modeFile.get(), nAtoms);
 }
 
+bool eonc::helpers::loadOrSynthesizeDisplacement(
+    Matter &target, const Matter &initial, const std::string &displacementPath,
+    const std::string &modePath) {
+  if (target.con2matter(displacementPath)) {
+    // displacement.con may carry stale fixed-atom coordinates from a prior run.
+    const AtomMatrix &initPos = initial.getPositions();
+    AtomMatrix pos = target.getPositionsCopy();
+    const long n = initial.numberOfAtoms();
+    for (long i = 0; i < n; i++) {
+      if (initial.getFixed(i)) {
+        pos.row(i) = initPos.row(i);
+      }
+    }
+    target.setPositions(pos);
+    return true;
+  }
+  if (!existsFile(modePath)) {
+    return false;
+  }
+  AtomMatrix mode =
+      loadMode(modePath, static_cast<int>(initial.numberOfAtoms()));
+  const double norm = mode.norm();
+  if (norm > 0.0) {
+    mode /= norm;
+  }
+  target = initial;
+  AtomMatrix pos = initial.getPositionsCopy();
+  pos += mode;
+  const AtomMatrix &initPos = initial.getPositions();
+  const long n = initial.numberOfAtoms();
+  for (long i = 0; i < n; i++) {
+    if (initial.getFixed(i)) {
+      pos.row(i) = initPos.row(i);
+    }
+  }
+  target.setPositions(pos);
+  EONC_LOG_INFO("Synthesized displacement from pos.con + unit mode in {} "
+                "(missing {})",
+                modePath, displacementPath);
+  return true;
+}
+
 void eonc::helpers::saveMode(FILE *modeFile, std::shared_ptr<Matter> matter,
                              AtomMatrix mode) {
   long const nAtoms = matter->numberOfAtoms();

--- a/client/HelperFunctions.cpp
+++ b/client/HelperFunctions.cpp
@@ -143,7 +143,7 @@ AtomMatrix eonc::helpers::loadMode(string filename, int nAtoms) {
 
 bool eonc::helpers::loadOrSynthesizeDisplacement(
     Matter &target, const Matter &initial, const std::string &displacementPath,
-    const std::string &modePath) {
+    const std::string &modePath, double scale) {
   if (target.con2matter(displacementPath)) {
     // displacement.con may carry stale fixed-atom coordinates from a prior run.
     const AtomMatrix &initPos = initial.getPositions();
@@ -163,9 +163,10 @@ bool eonc::helpers::loadOrSynthesizeDisplacement(
   AtomMatrix mode =
       loadMode(modePath, static_cast<int>(initial.numberOfAtoms()));
   const double norm = mode.norm();
-  if (norm > 0.0) {
-    mode /= norm;
+  if (!(norm > 0.0)) {
+    return false;
   }
+  mode *= (scale / norm);
   target = initial;
   AtomMatrix pos = initial.getPositionsCopy();
   pos += mode;
@@ -177,9 +178,9 @@ bool eonc::helpers::loadOrSynthesizeDisplacement(
     }
   }
   target.setPositions(pos);
-  EONC_LOG_INFO("Synthesized displacement from pos.con + unit mode in {} "
-                "(missing {})",
-                modePath, displacementPath);
+  EONC_LOG_INFO("Synthesized displacement from pos.con + scale {:.6g} * unit "
+                "mode in {} (missing {})",
+                scale, modePath, displacementPath);
   return true;
 }
 

--- a/client/HelperFunctions.h
+++ b/client/HelperFunctions.h
@@ -63,6 +63,12 @@ getRelevantFile(std::string filename); // return filename containing _checkpoint
 VectorXd loadMasses(std::string filename, int nAtoms);
 AtomMatrix loadMode(FILE *modeFile, int nAtoms);
 AtomMatrix loadMode(std::string filename, int nAtoms);
+// Load displacement.con, or synthesize initial + unit(direction.dat) (issue
+// #79). Fixed-atom rows are always restored from initial. Returns false if
+// neither displacement nor mode file is usable.
+bool loadOrSynthesizeDisplacement(Matter &target, const Matter &initial,
+                                  const std::string &displacementPath,
+                                  const std::string &modePath);
 void saveMode(FILE *modeFile, std::shared_ptr<Matter> matter, AtomMatrix mode);
 void saveMode(const std::string &filename, std::shared_ptr<Matter> matter,
               AtomMatrix mode);

--- a/client/HelperFunctions.h
+++ b/client/HelperFunctions.h
@@ -63,12 +63,14 @@ getRelevantFile(std::string filename); // return filename containing _checkpoint
 VectorXd loadMasses(std::string filename, int nAtoms);
 AtomMatrix loadMode(FILE *modeFile, int nAtoms);
 AtomMatrix loadMode(std::string filename, int nAtoms);
-// Load displacement.con, or synthesize initial + unit(direction.dat) (issue
-// #79). Fixed-atom rows are always restored from initial. Returns false if
-// neither displacement nor mode file is usable.
+// Load displacement.con, or synthesize initial + scale * unit(direction.dat)
+// (issue #79). scale is saddle_search.displace_magnitude (default 0.1).
+// Fixed-atom rows are always restored from initial. Returns false if neither
+// displacement nor mode file is usable, or mode has zero norm when
+// synthesizing.
 bool loadOrSynthesizeDisplacement(Matter &target, const Matter &initial,
                                   const std::string &displacementPath,
-                                  const std::string &modePath);
+                                  const std::string &modePath, double scale);
 void saveMode(FILE *modeFile, std::shared_ptr<Matter> matter, AtomMatrix mode);
 void saveMode(const std::string &filename, std::shared_ptr<Matter> matter,
               AtomMatrix mode);

--- a/client/ProcessSearchJob.cpp
+++ b/client/ProcessSearchJob.cpp
@@ -77,7 +77,8 @@ std::vector<std::string> ProcessSearchJob::run() {
       // Load displacement.con, or synthesize from pos.con + direction.dat
       // (#79).
       if (!eonc::helpers::loadOrSynthesizeDisplacement(
-              *saddle, *initial, displacementFilename, modeFilename)) {
+              *saddle, *initial, displacementFilename, modeFilename,
+              params.saddle_search_options.displace_magnitude)) {
         EONC_LOG_CRITICAL("Failed to load {} (and no usable {})",
                           displacementFilename, modeFilename);
         exit(1);

--- a/client/ProcessSearchJob.cpp
+++ b/client/ProcessSearchJob.cpp
@@ -74,24 +74,13 @@ std::vector<std::string> ProcessSearchJob::run() {
       params.saddle_search_options.method == "bgsd") {
     if (params.saddle_search_options.displace_type ==
         eonc::EpiCenters::DISP_LOAD) {
-      if (!saddle->con2matter(displacementFilename)) {
-        EONC_LOG_CRITICAL("Failed to load {}", displacementFilename);
+      // Load displacement.con, or synthesize from pos.con + direction.dat
+      // (#79).
+      if (!eonc::helpers::loadOrSynthesizeDisplacement(
+              *saddle, *initial, displacementFilename, modeFilename)) {
+        EONC_LOG_CRITICAL("Failed to load {} (and no usable {})",
+                          displacementFilename, modeFilename);
         exit(1);
-      }
-      // displacement.con may carry stale fixed-atom coordinates from a prior
-      // run.  Restore every fixed-atom row in saddle from the initial
-      // structure so the invariant "fixed atoms never move" holds through all
-      // downstream endpoint writes (reactant.con, product.con).
-      {
-        const AtomMatrix &initPos = initial->getPositions();
-        AtomMatrix saddlePos = saddle->getPositionsCopy();
-        long n = initial->numberOfAtoms();
-        for (long i = 0; i < n; i++) {
-          if (initial->getFixed(i)) {
-            saddlePos.row(i) = initPos.row(i);
-          }
-        }
-        saddle->setPositions(saddlePos);
       }
       *min1 = *min2 = *initial;
     } else {

--- a/client/SaddleSearchJob.cpp
+++ b/client/SaddleSearchJob.cpp
@@ -52,7 +52,8 @@ std::vector<std::string> SaddleSearchJob::run() {
                              eonc::EpiCenters::DISP_LOAD) {
     // Load displacement.con, or synthesize from pos.con + direction.dat (#79).
     if (!eonc::helpers::loadOrSynthesizeDisplacement(
-            *saddle, *initial, displacementFilename, modeFilename)) {
+            *saddle, *initial, displacementFilename, modeFilename,
+            params.saddle_search_options.displace_magnitude)) {
       EONC_LOG_CRITICAL("Failed to load {} (and no usable {})",
                         displacementFilename, modeFilename);
       throw std::runtime_error("missing displacement.con and direction.dat");

--- a/client/SaddleSearchJob.cpp
+++ b/client/SaddleSearchJob.cpp
@@ -13,6 +13,7 @@
 #ifdef WITH_ARTN
 #include "ARTnSaddleSearch.h"
 #endif
+#include "EonLogger.h"
 #include "EpiCenters.h"
 #include "HelperFunctions.h"
 #include "Potential.h"
@@ -49,7 +50,13 @@ std::vector<std::string> SaddleSearchJob::run() {
 
   if (!standaloneARTn && params.saddle_search_options.displace_type ==
                              eonc::EpiCenters::DISP_LOAD) {
-    saddle->con2matter(displacementFilename);
+    // Load displacement.con, or synthesize from pos.con + direction.dat (#79).
+    if (!eonc::helpers::loadOrSynthesizeDisplacement(
+            *saddle, *initial, displacementFilename, modeFilename)) {
+      EONC_LOG_CRITICAL("Failed to load {} (and no usable {})",
+                        displacementFilename, modeFilename);
+      throw std::runtime_error("missing displacement.con and direction.dat");
+    }
   } else {
     *saddle = *initial;
   }

--- a/docs/newsfragments/79.fixed.md
+++ b/docs/newsfragments/79.fixed.md
@@ -1,1 +1,1 @@
-Saddle and process search synthesize `displacement.con` from `pos.con` plus a unit `direction.dat` mode when the displacement file is missing (issue #79).
+Saddle and process search synthesize a missing `displacement.con` from `pos.con` plus `saddle_search.displace_magnitude` times a unit `direction.dat` mode (issue #79).

--- a/docs/newsfragments/79.fixed.md
+++ b/docs/newsfragments/79.fixed.md
@@ -1,0 +1,1 @@
+Saddle and process search synthesize `displacement.con` from `pos.con` plus a unit `direction.dat` mode when the displacement file is missing (issue #79).


### PR DESCRIPTION
## Summary
- Implements [#79](https://github.com/TheochemUI/eOn/issues/79): when `DISP_LOAD` is set and `displacement.con` is missing, build saddle start as `pos.con` + unit `direction.dat`.
- Shared helper restores fixed-atom rows from the reactant for both load and synthesize paths in process search and saddle search jobs.

## Test plan
- [ ] CI green
- [ ] Job with only `pos.con` + `direction.dat` runs without critical failure on missing displacement
- [ ] Existing fixtures with `displacement.con` unchanged