### PR TITLE
feat(minmode): Davidson subspace as alternative to dimer rotation

### DIFF
--- a/client/Davidson.cpp
+++ b/client/Davidson.cpp
@@ -1,0 +1,193 @@
+/*
+** This file is part of eOn.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eOn Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eOn
+*/
+// Minimum-mode via Davidson subspace iteration with finite-difference
+// Hessian-vector products (same H*v as Lanczos). Replaces dimer rotation
+// constrained minimization when min_mode_method = davidson.
+
+#include "Davidson.h"
+#include "HelperFunctions.h"
+#include "Potential.h"
+#include "SafeMath.h"
+
+#include "EonLogger.h"
+
+#include <cmath>
+#include <vector>
+
+Davidson::Davidson(std::shared_ptr<Matter> matter, const Parameters &params,
+                   std::shared_ptr<Potential> pot)
+    : LowestEigenmode(pot, params) {
+  lowestEv.resize(matter->numberOfAtoms(), 3);
+  lowestEv.setZero();
+  lowestEw = 0.0;
+}
+
+void Davidson::compute(std::shared_ptr<Matter> matter, AtomMatrix direction) {
+  const int size = 3 * matter->numberOfFreeAtoms();
+  const long maxIter = params.davidson_options.max_iterations;
+  const double tol = params.davidson_options.tolerance;
+  const double dr = params.main_options.finiteDifference;
+  const bool useDiagPrec = params.davidson_options.diagonal_preconditioner;
+
+  MatrixXd V(size, maxIter);
+  MatrixXd HV(size, maxIter);
+  V.setZero();
+  HV.setZero();
+
+  VectorXd r(size);
+  int i, j;
+  for (i = 0, j = 0; i < matter->numberOfAtoms(); i++) {
+    if (!matter->getFixed(i)) {
+      r.segment<3>(j) = direction.row(i);
+      j += 3;
+    }
+  }
+
+  double beta = r.norm();
+  if (beta < eonc::safemath::eps) {
+    lowestEw = 0.0;
+    lowestEv.resize(matter->numberOfAtoms(), 3);
+    lowestEv.setZero();
+    return;
+  }
+  r /= beta;
+
+  auto tmpMatter = std::make_unique<Matter>(*matter);
+  const VectorXd force0 = tmpMatter->getForcesFreeV();
+
+  // Apply H via central finite difference of forces: H v ≈ -(F(x+dr v) - F(x)) / dr
+  auto applyH = [&](const VectorXd &v) -> VectorXd {
+    tmpMatter->setPositionsFreeV(matter->getPositionsFreeV() + dr * v);
+    const VectorXd force1 = tmpMatter->getForcesFreeV();
+    return -(force1 - force0) / dr;
+  };
+
+  // Optional cheap diagonal preconditioner: one FD probe along e_k is too
+  // expensive, so approximate diag(H) from the first H*v0 components | (Hv)_i / v_i |
+  // when |v_i| is appreciable; else 1.0.
+  VectorXd diagH = VectorXd::Ones(size);
+
+  V.col(0) = r;
+  HV.col(0) = applyH(V.col(0));
+  if (useDiagPrec) {
+    for (int k = 0; k < size; ++k) {
+      const double vk = V(k, 0);
+      if (std::fabs(vk) > 1e-8) {
+        diagH(k) = std::max(std::fabs(HV(k, 0) / vk), 1e-3);
+      }
+    }
+  }
+
+  double ew = 0.0, ewOld = 0.0;
+  VectorXd evEst = V.col(0);
+  VectorXd evOldEst = evEst;
+  int subspace = 1;
+
+  for (int iter = 0; iter < maxIter; ++iter) {
+    statsRotations = iter;
+    statsAngle = 0.0;
+
+    // Rayleigh-Ritz on current subspace: G = V^T H V
+    MatrixXd G = V.leftCols(subspace).transpose() * HV.leftCols(subspace);
+    // Symmetrize numerical noise
+    G = 0.5 * (G + G.transpose());
+
+    Eigen::SelfAdjointEigenSolver<MatrixXd> es(G);
+    ew = es.eigenvalues()(0);
+    VectorXd y = es.eigenvectors().col(0);
+    evEst = V.leftCols(subspace) * y;
+    evEst.normalize();
+
+    // Residual r = H x - lambda x  (using HV * y)
+    VectorXd Hx = HV.leftCols(subspace) * y;
+    VectorXd resid = Hx - ew * evEst;
+    const double residNorm = resid.norm();
+    const double ewAbsRelErr =
+        (iter == 0)
+            ? 1.0
+            : eonc::safemath::safe_div(std::fabs(ew - ewOld), std::fabs(ewOld),
+                                      1.0);
+    ewOld = ew;
+    statsTorque = std::max(ewAbsRelErr, residNorm / (std::fabs(ew) + 1e-12));
+    statsAngle = eonc::safemath::safe_acos(std::fabs(evEst.dot(evOldEst))) *
+                 (180 / eonc::helpers::pi);
+    evOldEst = evEst;
+
+    QUILL_LOG_INFO(log,
+                   "[Davidson] ew={:10.6f} rel_err={:10.6f} |r|={:10.6f} "
+                   "angle={:7.3f} dim={:3d} iter={:3d}",
+                   ew, ewAbsRelErr, residNorm, statsAngle, subspace, iter);
+
+    if (ewAbsRelErr < tol && residNorm < tol * (std::fabs(ew) + 1.0)) {
+      QUILL_LOG_INFO(log, "[Davidson] Tolerance reached: {}", tol);
+      break;
+    }
+    if (subspace >= maxIter) {
+      QUILL_LOG_ERROR(log, "[Davidson] Max subspace dimension");
+      break;
+    }
+
+    // Preconditioned residual correction (classical Davidson step)
+    VectorXd t(size);
+    if (useDiagPrec) {
+      for (int k = 0; k < size; ++k) {
+        const double denom = diagH(k) - ew;
+        t(k) = resid(k) / (std::fabs(denom) > 1e-12 ? denom : 1e-12);
+      }
+    } else {
+      t = resid;
+    }
+
+    // Orthogonalize against V and normalize
+    for (int c = 0; c < subspace; ++c) {
+      t -= V.col(c).dot(t) * V.col(c);
+    }
+    const double tnorm = t.norm();
+    if (tnorm < 1e-14) {
+      QUILL_LOG_ERROR(log, "[Davidson] Linear dependence in residual");
+      break;
+    }
+    t /= tnorm;
+
+    V.col(subspace) = t;
+    HV.col(subspace) = applyH(t);
+    if (useDiagPrec) {
+      for (int k = 0; k < size; ++k) {
+        const double vk = t(k);
+        if (std::fabs(vk) > 1e-8) {
+          const double d = std::fabs(HV(k, subspace) / vk);
+          diagH(k) = std::max(diagH(k), std::max(d, 1e-3));
+        }
+      }
+    }
+    ++subspace;
+
+    if (iter >= maxIter - 1) {
+      QUILL_LOG_ERROR(log, "[Davidson] Max iterations");
+      break;
+    }
+  }
+
+  lowestEw = ew;
+  lowestEv.resize(matter->numberOfAtoms(), 3);
+  lowestEv.setZero();
+  for (i = 0, j = 0; i < matter->numberOfAtoms(); i++) {
+    if (!matter->getFixed(i)) {
+      lowestEv.row(i) = evEst.segment<3>(j);
+      j += 3;
+    }
+  }
+}
+
+double Davidson::getEigenvalue() { return lowestEw; }
+
+AtomMatrix Davidson::getEigenvector() { return lowestEv; }

--- a/client/Davidson.cpp
+++ b/client/Davidson.cpp
@@ -64,7 +64,8 @@ void Davidson::compute(std::shared_ptr<Matter> matter, AtomMatrix direction) {
   auto tmpMatter = std::make_unique<Matter>(*matter);
   const VectorXd force0 = tmpMatter->getForcesFreeV();
 
-  // Apply H via one-sided FD of forces (same as Lanczos): H v ≈ -(F(x+dr v)-F(x))/dr
+  // Apply H via one-sided FD of forces (same as Lanczos): H v ≈ -(F(x+dr
+  // v)-F(x))/dr
   auto applyH = [&](const VectorXd &v) -> VectorXd {
     tmpMatter->setPositionsFreeV(matter->getPositionsFreeV() + dr * v);
     const VectorXd force1 = tmpMatter->getForcesFreeV();
@@ -72,8 +73,8 @@ void Davidson::compute(std::shared_ptr<Matter> matter, AtomMatrix direction) {
   };
 
   // Optional cheap diagonal preconditioner: one FD probe along e_k is too
-  // expensive, so approximate diag(H) from the first H*v0 components | (Hv)_i / v_i |
-  // when |v_i| is appreciable; else 1.0.
+  // expensive, so approximate diag(H) from the first H*v0 components | (Hv)_i /
+  // v_i | when |v_i| is appreciable; else 1.0.
   VectorXd diagH = VectorXd::Ones(size);
 
   V.col(0) = r;
@@ -112,10 +113,9 @@ void Davidson::compute(std::shared_ptr<Matter> matter, AtomMatrix direction) {
     VectorXd resid = Hx - ew * evEst;
     const double residNorm = resid.norm();
     const double ewAbsRelErr =
-        (iter == 0)
-            ? 1.0
-            : eonc::safemath::safe_div(std::fabs(ew - ewOld), std::fabs(ewOld),
-                                      1.0);
+        (iter == 0) ? 1.0
+                    : eonc::safemath::safe_div(std::fabs(ew - ewOld),
+                                               std::fabs(ewOld), 1.0);
     ewOld = ew;
     statsTorque = std::max(ewAbsRelErr, residNorm / (std::fabs(ew) + 1e-12));
     statsAngle = eonc::safemath::safe_acos(std::fabs(evEst.dot(evOldEst))) *

--- a/client/Davidson.cpp
+++ b/client/Davidson.cpp
@@ -64,7 +64,7 @@ void Davidson::compute(std::shared_ptr<Matter> matter, AtomMatrix direction) {
   auto tmpMatter = std::make_unique<Matter>(*matter);
   const VectorXd force0 = tmpMatter->getForcesFreeV();
 
-  // Apply H via central finite difference of forces: H v ≈ -(F(x+dr v) - F(x)) / dr
+  // Apply H via one-sided FD of forces (same as Lanczos): H v ≈ -(F(x+dr v)-F(x))/dr
   auto applyH = [&](const VectorXd &v) -> VectorXd {
     tmpMatter->setPositionsFreeV(matter->getPositionsFreeV() + dr * v);
     const VectorXd force1 = tmpMatter->getForcesFreeV();

--- a/client/Davidson.h
+++ b/client/Davidson.h
@@ -1,0 +1,46 @@
+/*
+** This file is part of eOn.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eOn Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eOn
+*/
+#pragma once
+#include "Eigen.h"
+#include "EonLogger.h"
+
+#include "LowestEigenmode.h"
+#include "Matter.h"
+#include "Parameters.h"
+
+namespace eonc {
+
+/// Davidson method for the lowest Hessian curvature mode (min-mode).
+/// Uses the same finite-difference Hessian-vector products as Lanczos, but
+/// expands a Ritz subspace with residual correction (optionally diagonal-
+/// preconditioned) instead of dimer rotational constrained minimization.
+/// See Olsen et al., J. Chem. Phys. 121, 9776 (2004) for FD context; Davidson
+/// subspace expansion follows the classical residual-correction form.
+class Davidson : public LowestEigenmode {
+
+public:
+  Davidson(std::shared_ptr<Matter> matter, const Parameters &params,
+           std::shared_ptr<Potential> pot);
+  ~Davidson() = default;
+  void compute(std::shared_ptr<Matter> matter, AtomMatrix initialDirection);
+  double getEigenvalue();
+  AtomMatrix getEigenvector();
+
+private:
+  AtomMatrix lowestEv;
+  double lowestEw;
+  eonc::log::Scoped log;
+};
+
+} // namespace eonc
+
+using eonc::Davidson;

--- a/client/EigenmodeStrategy.h
+++ b/client/EigenmodeStrategy.h
@@ -11,6 +11,7 @@
 */
 #pragma once
 
+#include "Davidson.h"
 #include "Dimer.h"
 #include "ImprovedDimer.h"
 #include "Lanczos.h"
@@ -25,12 +26,14 @@ namespace eonc {
 
 #ifdef WITH_GPRD
 using EigenmodeStrategy =
-    std::variant<Dimer, ImprovedDimer, Lanczos, AtomicGPDimer>;
+    std::variant<Dimer, ImprovedDimer, Lanczos, Davidson, AtomicGPDimer>;
 #else
-using EigenmodeStrategy = std::variant<Dimer, ImprovedDimer, Lanczos>;
+using EigenmodeStrategy =
+    std::variant<Dimer, ImprovedDimer, Lanczos, Davidson>;
 #endif
 
 /// Build the eigenmode solver from parameters.
+/// min_mode_method: dimer (rotation CG) | lanczos | davidson | gprdimer
 inline std::shared_ptr<EigenmodeStrategy>
 buildEigenmodeStrategy(std::shared_ptr<Matter> matter, const Parameters &params,
                        std::shared_ptr<Potential> pot) {
@@ -44,6 +47,9 @@ buildEigenmodeStrategy(std::shared_ptr<Matter> matter, const Parameters &params,
   } else if (params.saddle_search_options.minmode_method ==
              LowestEigenmode::MINMODE_LANCZOS) {
     return std::make_shared<EigenmodeStrategy>(Lanczos(matter, params, pot));
+  } else if (params.saddle_search_options.minmode_method ==
+             LowestEigenmode::MINMODE_DAVIDSON) {
+    return std::make_shared<EigenmodeStrategy>(Davidson(matter, params, pot));
   }
 #ifdef WITH_GPRD
   else if (params.saddle_search_options.minmode_method ==

--- a/client/EigenmodeStrategy.h
+++ b/client/EigenmodeStrategy.h
@@ -28,8 +28,7 @@ namespace eonc {
 using EigenmodeStrategy =
     std::variant<Dimer, ImprovedDimer, Lanczos, Davidson, AtomicGPDimer>;
 #else
-using EigenmodeStrategy =
-    std::variant<Dimer, ImprovedDimer, Lanczos, Davidson>;
+using EigenmodeStrategy = std::variant<Dimer, ImprovedDimer, Lanczos, Davidson>;
 #endif
 
 /// Build the eigenmode solver from parameters.

--- a/client/LowestEigenmode.cpp
+++ b/client/LowestEigenmode.cpp
@@ -14,3 +14,4 @@
 const char LowestEigenmode::MINMODE_DIMER[] = "dimer";
 const char LowestEigenmode::MINMODE_GPRDIMER[] = "gprdimer";
 const char LowestEigenmode::MINMODE_LANCZOS[] = "lanczos";
+const char LowestEigenmode::MINMODE_DAVIDSON[] = "davidson";

--- a/client/LowestEigenmode.h
+++ b/client/LowestEigenmode.h
@@ -37,6 +37,7 @@ public:
   static const char MINMODE_DIMER[];
   static const char MINMODE_GPRDIMER[];
   static const char MINMODE_LANCZOS[];
+  static const char MINMODE_DAVIDSON[];
 
   LowestEigenmode(std::shared_ptr<Potential> potPassed,
                   const Parameters &parameters)

--- a/client/Parameters.h
+++ b/client/Parameters.h
@@ -345,6 +345,14 @@ public:
     bool quit_early{true};
   } lanczos_options;
 
+  // [Davidson] min-mode (alternative to dimer rotation / Lanczos)
+  struct davidson_options_t {
+    double tolerance{0.01};
+    long max_iterations{20};
+    /// Cheap diagonal preconditioner from H*v components (no extra force calls).
+    bool diagonal_preconditioner{true};
+  } davidson_options;
+
   // [Prefactor] //
   struct prefactor_options_t {
     double default_value{0.0};

--- a/client/Parameters.h
+++ b/client/Parameters.h
@@ -349,8 +349,8 @@ public:
   struct davidson_options_t {
     double tolerance{0.01};
     long max_iterations{20};
-    /// Cheap diagonal preconditioner from H*v components (no extra force calls).
-    bool diagonal_preconditioner{true};
+    /// Heuristic | (H v)_i / v_i | preconditioner (not true diag(H); off by default).
+    bool diagonal_preconditioner{false};
   } davidson_options;
 
   // [Prefactor] //

--- a/client/Parameters.h
+++ b/client/Parameters.h
@@ -349,7 +349,8 @@ public:
   struct davidson_options_t {
     double tolerance{0.01};
     long max_iterations{20};
-    /// Heuristic | (H v)_i / v_i | preconditioner (not true diag(H); off by default).
+    /// Heuristic | (H v)_i / v_i | preconditioner (not true diag(H); off by
+    /// default).
     bool diagonal_preconditioner{false};
   } davidson_options;
 

--- a/client/ParametersINI.cpp
+++ b/client/ParametersINI.cpp
@@ -458,6 +458,15 @@ int load_ini(INIReader &ini, Parameters &params) {
   params.lanczos_options.quit_early = ini.GetBoolean(
       "Lanczos", "quit_early", params.lanczos_options.quit_early);
 
+  // [Davidson] //
+  params.davidson_options.tolerance =
+      ini.GetReal("Davidson", "tolerance", params.davidson_options.tolerance);
+  params.davidson_options.max_iterations = ini.GetInteger(
+      "Davidson", "max_iterations", params.davidson_options.max_iterations);
+  params.davidson_options.diagonal_preconditioner = ini.GetBoolean(
+      "Davidson", "diagonal_preconditioner",
+      params.davidson_options.diagonal_preconditioner);
+
   // [ARTn] //
   params.artn_options.push_step_size =
       ini.GetReal("ARTn", "push_step_size", params.artn_options.push_step_size);

--- a/client/ParametersINI.cpp
+++ b/client/ParametersINI.cpp
@@ -463,9 +463,9 @@ int load_ini(INIReader &ini, Parameters &params) {
       ini.GetReal("Davidson", "tolerance", params.davidson_options.tolerance);
   params.davidson_options.max_iterations = ini.GetInteger(
       "Davidson", "max_iterations", params.davidson_options.max_iterations);
-  params.davidson_options.diagonal_preconditioner = ini.GetBoolean(
-      "Davidson", "diagonal_preconditioner",
-      params.davidson_options.diagonal_preconditioner);
+  params.davidson_options.diagonal_preconditioner =
+      ini.GetBoolean("Davidson", "diagonal_preconditioner",
+                     params.davidson_options.diagonal_preconditioner);
 
   // [ARTn] //
   params.artn_options.push_step_size =

--- a/client/meson.build
+++ b/client/meson.build
@@ -357,6 +357,7 @@ eonclib_sources = [
     'Matter.cpp',
     'FiniteDifferenceJob.cpp',
     'Lanczos.cpp',
+    'Davidson.cpp',
     'HessianJob.cpp',
     'ReplicaDynamicsJob.cpp',
     'TADJob.cpp',

--- a/client/unit_tests/DimerTest.cpp
+++ b/client/unit_tests/DimerTest.cpp
@@ -10,6 +10,7 @@
 ** https://github.com/TheochemUI/eOn
 */
 
+#include "Davidson.h"
 #include "Dimer.h"
 #include "EigenmodeStrategy.h"
 #include "ImprovedDimer.h"
@@ -99,6 +100,42 @@ TEST_CASE_METHOD(DimerFixture, "Lanczos computes negative eigenvalue",
   double eigenvalue = lanczos->getEigenvalue();
   REQUIRE(std::isfinite(eigenvalue));
   REQUIRE(eigenvalue < 0.0);
+}
+
+TEST_CASE_METHOD(DimerFixture, "Davidson computes negative eigenvalue",
+                 "[davidson][eigenmode]") {
+  params.saddle_search_options.minmode_method =
+      LowestEigenmode::MINMODE_DAVIDSON;
+  auto davidson = std::make_unique<Davidson>(matter, params, pot);
+  davidson->compute(matter, mode);
+
+  double eigenvalue = davidson->getEigenvalue();
+  REQUIRE(std::isfinite(eigenvalue));
+  REQUIRE(eigenvalue < 0.0);
+}
+
+TEST_CASE_METHOD(DimerFixture,
+                 "Davidson and Lanczos agree on lowest mode sign",
+                 "[davidson][lanczos][eigenmode]") {
+  params.saddle_search_options.minmode_method =
+      LowestEigenmode::MINMODE_LANCZOS;
+  Lanczos lanczos(matter, params, pot);
+  lanczos.compute(matter, mode);
+  const double ewL = lanczos.getEigenvalue();
+
+  params.saddle_search_options.minmode_method =
+      LowestEigenmode::MINMODE_DAVIDSON;
+  Davidson davidson(matter, params, pot);
+  davidson.compute(matter, mode);
+  const double ewD = davidson.getEigenvalue();
+
+  REQUIRE(std::isfinite(ewL));
+  REQUIRE(std::isfinite(ewD));
+  // Both should find a negative curvature direction on this saddle-ish LJ setup.
+  REQUIRE(ewL < 0.0);
+  REQUIRE(ewD < 0.0);
+  // Magnitudes within a loose factor (FD noise + method differences).
+  REQUIRE(std::fabs(ewD - ewL) < 0.5 * (std::fabs(ewL) + std::fabs(ewD) + 1e-6));
 }
 
 // --- EigenmodeStrategy variant dispatch tests ---

--- a/client/unit_tests/DimerTest.cpp
+++ b/client/unit_tests/DimerTest.cpp
@@ -172,6 +172,17 @@ TEST_CASE_METHOD(DimerFixture, "buildEigenmodeStrategy returns Lanczos variant",
   REQUIRE(std::holds_alternative<Lanczos>(*strategy));
 }
 
+TEST_CASE_METHOD(DimerFixture,
+                 "buildEigenmodeStrategy returns Davidson variant",
+                 "[eigenmode][strategy][davidson]") {
+  params.saddle_search_options.minmode_method =
+      LowestEigenmode::MINMODE_DAVIDSON;
+
+  auto strategy = eonc::buildEigenmodeStrategy(matter, params, pot);
+  REQUIRE(strategy != nullptr);
+  REQUIRE(std::holds_alternative<Davidson>(*strategy));
+}
+
 // --- asImprovedDimer tests ---
 
 TEST_CASE_METHOD(DimerFixture,

--- a/client/unit_tests/DimerTest.cpp
+++ b/client/unit_tests/DimerTest.cpp
@@ -10,8 +10,8 @@
 ** https://github.com/TheochemUI/eOn
 */
 
-#include "Davidson.h"
 #include "Dimer.h"
+#include "Davidson.h"
 #include "EigenmodeStrategy.h"
 #include "ImprovedDimer.h"
 #include "Lanczos.h"
@@ -114,8 +114,7 @@ TEST_CASE_METHOD(DimerFixture, "Davidson computes negative eigenvalue",
   REQUIRE(eigenvalue < 0.0);
 }
 
-TEST_CASE_METHOD(DimerFixture,
-                 "Davidson and Lanczos agree on lowest mode sign",
+TEST_CASE_METHOD(DimerFixture, "Davidson and Lanczos agree on lowest mode sign",
                  "[davidson][lanczos][eigenmode]") {
   params.saddle_search_options.minmode_method =
       LowestEigenmode::MINMODE_LANCZOS;
@@ -131,11 +130,13 @@ TEST_CASE_METHOD(DimerFixture,
 
   REQUIRE(std::isfinite(ewL));
   REQUIRE(std::isfinite(ewD));
-  // Both should find a negative curvature direction on this saddle-ish LJ setup.
+  // Both should find a negative curvature direction on this saddle-ish LJ
+  // setup.
   REQUIRE(ewL < 0.0);
   REQUIRE(ewD < 0.0);
   // Magnitudes within a loose factor (FD noise + method differences).
-  REQUIRE(std::fabs(ewD - ewL) < 0.5 * (std::fabs(ewL) + std::fabs(ewD) + 1e-6));
+  REQUIRE(std::fabs(ewD - ewL) <
+          0.5 * (std::fabs(ewL) + std::fabs(ewD) + 1e-6));
 }
 
 // --- EigenmodeStrategy variant dispatch tests ---

--- a/docs/newsfragments/+davidson-minmode.added.md
+++ b/docs/newsfragments/+davidson-minmode.added.md
@@ -1,0 +1,1 @@
+Minimum-mode finding supports `min_mode_method = davidson`: Ritz subspace with FD Hessian-vector products and residual correction (alternative to dimer rotation minimization and Lanczos).

--- a/eon/config.yaml
+++ b/eon/config.yaml
@@ -1057,6 +1057,24 @@ Lanczos:
 
 ################################################################################
 
+Davidson:
+
+    options:
+
+        tolerance:
+            kind: float
+            default: 0.01
+
+        max_iterations:
+            kind: int
+            default: 20
+
+        diagonal_preconditioner:
+            kind: boolean
+            default: false
+
+################################################################################
+
 ARTn:
 
     options:
@@ -1308,6 +1326,7 @@ Saddle Search:
             values:
                 - dimer
                 - lanczos
+                - davidson
                 - gprdimer
                 - artn
 

--- a/eon/schema.py
+++ b/eon/schema.py
@@ -823,13 +823,14 @@ class SaddleSearchConfig(BaseModel):
         relaxation internally. ``direction.dat`` is optional and only biases
         the initial push when present.
     """
-    min_mode_method: Literal["dimer", "lanczos", "gprdimer", "artn"] = Field(
-        default="dimer", description="Min-mode method to use."
-    )
+    min_mode_method: Literal[
+        "dimer", "lanczos", "davidson", "gprdimer", "artn"
+    ] = Field(default="dimer", description="Min-mode method to use.")
     """
     Options:
      - ``dimer``: Use the dimer min-mode method from :cite:t:`ss-henkelmanDimerMethodFinding1999`
      - ``lanczos``: Use the Lanczos min-mode method from :cite:t:`ss-malekDynamicsLennardJonesClusters2000`
+     - ``davidson``: Davidson Ritz subspace with FD Hessian-vector products (alternative to dimer rotation).
      - ``gprdimer``: Use the GP accelerated dimer method.
      - ``artn``: Use ARTn as a drop-in for min-mode search. eOn's displacement
        seeds the initial mode; ARTn takes over from the displaced structure.
@@ -1711,6 +1712,23 @@ class LanczosConfig(BaseModel):
     )
 
 
+class DavidsonConfig(BaseModel):
+    model_config = ConfigDict(use_attribute_docstrings=True)
+
+    tolerance: float = Field(
+        default=0.01,
+        description="Convergence on relative eigenvalue change and residual norm for the Davidson min-mode Ritz pair.",
+    )
+    max_iterations: int = Field(
+        default=20,
+        description="Maximum subspace dimension / Davidson iterations.",
+    )
+    diagonal_preconditioner: bool = Field(
+        default=False,
+        description="Use a cheap | (H v)_i / v_i | heuristic preconditioner (not the true Hessian diagonal).",
+    )
+
+
 class ARTnConfig(BaseModel):
     model_config = ConfigDict(use_attribute_docstrings=True)
 
@@ -2000,6 +2018,7 @@ class Config(BaseModel):
     dimer: DimerConfig
     neb: NudgedElasticBandConfig
     lanczos: LanczosConfig
+    davidson: DavidsonConfig
     hessian: HessianConfig
     communicator: CommunicatorConfig
     process_search: ProcessSearchConfig


### PR DESCRIPTION
## Summary
- Adds **Davidson** minimum-mode finder: FD Hessian-vector products (same class as Lanczos), Ritz projection, residual correction with optional diagonal preconditioner from `H*v` components.
- Select with `[Saddle Search] min_mode_method = davidson` (dimer rotation CG and Lanczos unchanged).
- `[Davidson] tolerance`, `max_iterations`, `diagonal_preconditioner`.
- Unit tests: negative eigenvalue; strategy variant; agreement with Lanczos on sign/magnitude band.

## Why
Dimer min-mode spends effort on **constrained rotational minimization**. Davidson expands a Ritz subspace with residual correction — better asymptotic convergence for the lowest curvature mode without the rotational force loop.

## Test plan
- [ ] CI green
- [ ] Local: `DimerTest` cases tagged `[davidson]`
- [ ] Optional: process_search with `min_mode_method=davidson` on an LJ/Morse fixture