### PR TITLE
feat(superbasin): optional amsel discover_decide gate before MCAMC step

### DIFF
--- a/client/ConFileIO.cpp
+++ b/client/ConFileIO.cpp
@@ -138,10 +138,11 @@ bool matter2con(Matter &m, std::string filename, bool append,
   apply_frame_metadata(builder, metadata);
 
   for (long i = 0; i < m.numberOfAtoms(); i++) {
-    builder.add_atom(atomicNumber2symbol(m.getAtomicNr(i)), m.getPosition(i, 0),
-                     m.getPosition(i, 1), m.getPosition(i, 2),
-                     m.getFixed(i) != 0, static_cast<uint64_t>(m.atomIndex(i)),
-                     m.getMass(i));
+    builder.add_atom_with_velocity(
+        atomicNumber2symbol(m.getAtomicNr(i)), m.getPosition(i, 0),
+        m.getPosition(i, 1), m.getPosition(i, 2), m.getFixed(i) != 0,
+        static_cast<uint64_t>(m.atomIndex(i)), m.getMass(i), m.velocities(i, 0),
+        m.velocities(i, 1), m.velocities(i, 2));
   }
 
   auto frame = builder.build();
@@ -256,12 +257,11 @@ bool matter2convel(Matter &m, std::string filename) {
       {strip_nl(m.headerCon[3]), strip_nl(m.headerCon[4])});
 
   for (long i = 0; i < m.numberOfAtoms(); i++) {
-    builder.add_atom(
+    builder.add_atom_with_velocity(
         atomicNumber2symbol(m.getAtomicNr(i)), m.getPosition(i, 0),
         m.getPosition(i, 1), m.getPosition(i, 2), m.getFixed(i) != 0,
-        static_cast<uint64_t>(m.atomIndex(i)), m.getMass(i),
-        std::array<double, 3>{m.velocities(i, 0), m.velocities(i, 1),
-                              m.velocities(i, 2)});
+        static_cast<uint64_t>(m.atomIndex(i)), m.getMass(i), m.velocities(i, 0),
+        m.velocities(i, 1), m.velocities(i, 2));
   }
 
   auto frame = builder.build();

--- a/docs/newsfragments/+amsel-discover-decide-superbasin.added.md
+++ b/docs/newsfragments/+amsel-discover-decide-superbasin.added.md
@@ -1,0 +1,1 @@
+Optional Superbasin gate via amsel.discover_decide_status ([amsel] / amsel_discover_decide) before MCAMC; rejected_no_metastable_basin falls back to AKMC.

--- a/docs/source/user_guide/coarse_graining.md
+++ b/docs/source/user_guide/coarse_graining.md
@@ -86,9 +86,11 @@ cv_threshold = 10.0
 If the `amsel` Python package is not installed, the gate is a no-op and legacy
 MCAMC behaviour is unchanged. Status outcomes:
 
-- **ok** — proceed with MCAMC as usual
-- **split_required** — restrict dynamics to the primary basin
-- **rejected_no_metastable_basin** — raise so AKMC can fall back to single-state KMC
+- **accepted** / **retightened** — proceed with MCAMC as usual
+- **split_required** — restrict the superbasin to the primary transient set
+  (entry state is always retained; membership is persisted via `write_data`)
+- **rejected_no_metastable_basin** — AKMC skips the superbasin step and uses
+  ordinary single-state KMC for that iteration
 
 See {any}`eon.schema.AmselConfig` and `eon.amsel_superbasin_gate`.
 

--- a/docs/source/user_guide/coarse_graining.md
+++ b/docs/source/user_guide/coarse_graining.md
@@ -105,13 +105,7 @@ See {any}`eon.schema.AmselConfig` and `eon.amsel_superbasin_gate`.
 .. autopydantic_model:: eon.schema.CoarseGrainingConfig
 ```
 
-```{code-block} ini
-[amsel]
-```
-
-```{eval-rst}
-.. autopydantic_model:: eon.schema.AmselConfig
-```
+See {any}`eon.schema.AmselConfig` for field documentation.
 
 ## References
 

--- a/docs/source/user_guide/coarse_graining.md
+++ b/docs/source/user_guide/coarse_graining.md
@@ -67,9 +67,6 @@ exit direction and time compared to normal KMC simulation
 
 ## Optional AMSEl discover/decide gate
 
-```{versionadded} TBD
-```
-
 When MCAMC superbasins are active, an optional pre-step gate can call
 `amsel.discover_decide_status` on the superbasin process graph before
 `Superbasin.step`. Enable it under **[amsel]** (default off):
@@ -92,7 +89,7 @@ MCAMC behaviour is unchanged. Status outcomes:
 - **rejected_no_metastable_basin** — AKMC skips the superbasin step and uses
   ordinary single-state KMC for that iteration
 
-See {any}`eon.schema.AmselConfig` and `eon.amsel_superbasin_gate`.
+Configuration is under the `[amsel]` INI section (`discover_decide`, `e_min_*`, `cv_threshold`).
 
 ## Configuration
 
@@ -105,7 +102,6 @@ See {any}`eon.schema.AmselConfig` and `eon.amsel_superbasin_gate`.
 .. autopydantic_model:: eon.schema.CoarseGrainingConfig
 ```
 
-See {any}`eon.schema.AmselConfig` for field documentation.
 
 ## References
 

--- a/docs/source/user_guide/coarse_graining.md
+++ b/docs/source/user_guide/coarse_graining.md
@@ -65,6 +65,33 @@ the approximate amount of error the user might expect in eventual superbasin
 exit direction and time compared to normal KMC simulation
 ({any}`eon.schema.CoarseGrainingConfig.askmc_confidence`).
 
+## Optional AMSEl discover/decide gate
+
+```{versionadded} TBD
+```
+
+When MCAMC superbasins are active, an optional pre-step gate can call
+`amsel.discover_decide_status` on the superbasin process graph before
+`Superbasin.step`. Enable it under **[amsel]** (default off):
+
+```{code-block} ini
+[amsel]
+discover_decide = True
+e_min_init = 0.5
+e_min_step = 0.05
+e_min_floor = 0.05
+cv_threshold = 10.0
+```
+
+If the `amsel` Python package is not installed, the gate is a no-op and legacy
+MCAMC behaviour is unchanged. Status outcomes:
+
+- **ok** — proceed with MCAMC as usual
+- **split_required** — restrict dynamics to the primary basin
+- **rejected_no_metastable_basin** — raise so AKMC can fall back to single-state KMC
+
+See {any}`eon.schema.AmselConfig` and `eon.amsel_superbasin_gate`.
+
 ## Configuration
 
 ```{code-block} ini
@@ -74,6 +101,14 @@ exit direction and time compared to normal KMC simulation
 
 ```{eval-rst}
 .. autopydantic_model:: eon.schema.CoarseGrainingConfig
+```
+
+```{code-block} ini
+[amsel]
+```
+
+```{eval-rst}
+.. autopydantic_model:: eon.schema.AmselConfig
 ```
 
 ## References

--- a/eon/akmc.py
+++ b/eon/akmc.py
@@ -213,9 +213,24 @@ def kmc_step(current_state, states, time, kT, superbasining, steps=0, config: Co
 
         # Do a KMC step.
         steps += 1
+        used_superbasin = False
         if config.sb_on and sb:
-            mean_time, current_state, next_state, sb_proc_id_out, sb_id = sb.step(current_state, states.get_product_state)
-        else:
+            from eon.amsel_superbasin_gate import AmselSuperbasinReject
+
+            try:
+                mean_time, current_state, next_state, sb_proc_id_out, sb_id = sb.step(
+                    current_state, states.get_product_state
+                )
+                used_superbasin = True
+            except AmselSuperbasinReject as amsel_exc:
+                # Fall back to ordinary single-state KMC for this step.
+                logger.info(
+                    "amsel rejected superbasin; falling back to single-state KMC: %s",
+                    amsel_exc,
+                )
+                sb = None
+
+        if not used_superbasin:
             if config.askmc_on:
                 rate_table = asKMC.get_ratetable(current_state)
             else:

--- a/eon/amsel_superbasin_gate.py
+++ b/eon/amsel_superbasin_gate.py
@@ -1,0 +1,203 @@
+"""Optional amsel discover_decide gate before Superbasin.step MCAMC solve (L6).
+
+When enabled and the ``amsel`` Python package is importable, builds the
+candidate basin graph from the superbasin process tables and calls
+``amsel.discover_decide_status``. Outcomes:
+
+* ``accepted`` / ``retightened`` — proceed with the existing MCAMC ``step``.
+* ``split_required`` — restrict MCAMC to the primary transient set returned
+  by amsel (primary basin only); log sibling components.
+* ``rejected_no_metastable_basin`` — raise ``AmselSuperbasinReject`` so the
+  AKMC driver can fall back to ordinary single-state KMC (no superbasin
+  acceleration on a non-metastable candidate).
+
+This is Python (eOn's Superbasin controller is Python). There is no C++
+``Superbasin::step`` in upstream eOn; eonclient Hessian/saddle jobs remain
+separate. Optional soft-dependency: if amsel is missing or the gate is off,
+behaviour is unchanged from legacy MCAMC.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Mapping, Sequence
+
+logger = logging.getLogger("superbasin.amsel_gate")
+
+
+class AmselSuperbasinReject(RuntimeError):
+    """Raised when discover_decide rejects the candidate superbasin."""
+
+    def __init__(self, status: str, detail: str = ""):
+        self.status = status
+        super().__init__(detail or status)
+
+
+def _process_barrier_eV(proc: Mapping[str, Any]) -> float:
+    for key in ("barrier", "saddle_energy", "barrier_eV"):
+        if key in proc and proc[key] is not None:
+            try:
+                return float(proc[key])
+            except (TypeError, ValueError):
+                pass
+    # Fallback: infer from rate is unreliable; use large barrier so edge is
+    # "high TS" unless rate is huge — prefer explicit barrier fields.
+    return 1.0
+
+
+def build_graph_from_superbasin(superbasin: Any, entry_number: int) -> tuple[
+    list[int],
+    list[tuple[int, int, float]],
+    list[float],
+]:
+    """Return (candidate_states, rate_triples, ts_energies) for amsel."""
+    candidates = [int(n) for n in superbasin.state_numbers]
+    if int(entry_number) not in candidates:
+        candidates = [int(entry_number)] + candidates
+    rates: list[tuple[int, int, float]] = []
+    barriers: list[float] = []
+    for number in superbasin.state_numbers:
+        procs = superbasin.state_dict[number].get_process_table()
+        for _pid, proc in list(procs.items()):
+            rate = float(proc.get("rate", 0.0) or 0.0)
+            if rate <= 0.0:
+                continue
+            product = proc.get("product")
+            if product is None:
+                continue
+            rates.append((int(number), int(product), rate))
+            barriers.append(_process_barrier_eV(proc))
+    return candidates, rates, barriers
+
+
+def discover_decide_for_superbasin(
+    superbasin: Any,
+    entry_state: Any,
+    *,
+    e_min_init: float = 0.5,
+    e_min_step: float = 0.05,
+    e_min_floor: float = 0.05,
+    cv_threshold: float = 10.0,
+) -> dict[str, Any]:
+    """Run amsel.discover_decide_status; return a structured result dict.
+
+    Keys: status (str), primary_transient (list[int]|None), raw (tuple|None),
+    available (bool). If amsel is not importable, available=False and status
+    is ``unavailable`` (caller should proceed with legacy MCAMC).
+    """
+    try:
+        from amsel import discover_decide_status
+    except ImportError:
+        return {
+            "available": False,
+            "status": "unavailable",
+            "primary_transient": None,
+            "raw": None,
+            "reason": "amsel not importable",
+        }
+
+    entry = int(entry_state.number)
+    candidates, rate_triples, barriers = build_graph_from_superbasin(
+        superbasin, entry
+    )
+    if not rate_triples:
+        return {
+            "available": True,
+            "status": "rejected_no_metastable_basin",
+            "primary_transient": None,
+            "raw": None,
+            "reason": "no positive-rate processes in superbasin tables",
+        }
+
+    # Align barrier vector with rate triples (required arity)
+    while len(barriers) < len(rate_triples):
+        barriers.append(0.5)
+    barriers = barriers[: len(rate_triples)]
+    e_init = float(e_min_init)
+    if barriers:
+        e_init = max(e_init, max(barriers) + 0.05)
+
+    try:
+        raw = discover_decide_status(
+            entry,
+            [int(c) for c in candidates],
+            [(int(a), int(b), float(r)) for a, b, r in rate_triples],
+            [float(x) for x in barriers],
+            e_init,
+            float(e_min_step),
+            float(e_min_floor),
+            float(cv_threshold),
+        )
+    except Exception as exc:
+        logger.warning("amsel discover_decide_status failed: %s", exc)
+        return {
+            "available": True,
+            "status": "unavailable",
+            "primary_transient": None,
+            "raw": None,
+            "reason": f"{type(exc).__name__}: {exc}",
+        }
+
+    status = str(raw[0]) if isinstance(raw, (list, tuple)) and raw else str(raw)
+    primary = None
+    if isinstance(raw, (list, tuple)) and len(raw) > 1:
+        # DiscoverDecisionStatus: (status, transient, absorbing, rates, ...)
+        try:
+            primary = [int(x) for x in raw[1]]
+        except Exception:
+            primary = None
+    return {
+        "available": True,
+        "status": status,
+        "primary_transient": primary,
+        "raw": raw,
+        "reason": "",
+    }
+
+
+def apply_gate_to_superbasin(
+    superbasin: Any,
+    entry_state: Any,
+    decision: Mapping[str, Any],
+) -> str:
+    """Mutate superbasin in-place for split_required; raise on reject.
+
+    Returns the status string for logging.
+    """
+    status = str(decision.get("status", "unavailable"))
+    if not decision.get("available") or status in ("unavailable", "accepted", "retightened"):
+        return status
+    if status == "split_required":
+        primary = decision.get("primary_transient") or []
+        if not primary:
+            logger.warning(
+                "amsel split_required but no primary_transient; keeping full basin"
+            )
+            return status
+        primary_set = set(int(x) for x in primary)
+        # Restrict member list to primary transient states that exist
+        keep = [n for n in superbasin.state_numbers if int(n) in primary_set]
+        if not keep:
+            logger.warning(
+                "amsel primary_transient %s disjoint from superbasin; keeping full",
+                primary,
+            )
+            return status
+        logger.info(
+            "amsel discover_decide=split_required: restricting superbasin %s -> %s",
+            superbasin.state_numbers,
+            keep,
+        )
+        superbasin.state_numbers = keep
+        superbasin.states = [superbasin.state_dict[n] for n in keep]
+        # Drop dict entries not in keep (optional consistency)
+        for n in list(superbasin.state_dict.keys()):
+            if n not in keep:
+                del superbasin.state_dict[n]
+        return status
+    if status in ("rejected_no_metastable_basin", "rejected"):
+        raise AmselSuperbasinReject(
+            status,
+            "amsel discover_decide rejected superbasin %s (entry %s): %s"
+            % (superbasin.state_numbers, entry_state.number, decision.get("reason", "")),
+        )
+    return status

--- a/eon/amsel_superbasin_gate.py
+++ b/eon/amsel_superbasin_gate.py
@@ -19,7 +19,7 @@ behaviour is unchanged from legacy MCAMC.
 from __future__ import annotations
 
 import logging
-from typing import Any, Mapping, Sequence
+from typing import Any, Mapping
 
 logger = logging.getLogger("superbasin.amsel_gate")
 
@@ -114,7 +114,14 @@ def discover_decide_for_superbasin(
     barriers = barriers[: len(rate_triples)]
     e_init = float(e_min_init)
     if barriers:
-        e_init = max(e_init, max(barriers) + 0.05)
+        floor = max(barriers) + 0.05
+        if floor > e_init:
+            logger.info(
+                "amsel e_min_init raised from %s to %s (max barrier + 0.05 eV)",
+                e_init,
+                floor,
+            )
+            e_init = floor
 
     try:
         raw = discover_decide_status(
@@ -174,6 +181,9 @@ def apply_gate_to_superbasin(
             )
             return status
         primary_set = set(int(x) for x in primary)
+        # Entry must remain for MCAMC indexing (st2i[entry_state.number]).
+        entry_n = int(entry_state.number)
+        primary_set.add(entry_n)
         # Restrict member list to primary transient states that exist
         keep = [n for n in superbasin.state_numbers if int(n) in primary_set]
         if not keep:
@@ -193,6 +203,12 @@ def apply_gate_to_superbasin(
         for n in list(superbasin.state_dict.keys()):
             if n not in keep:
                 del superbasin.state_dict[n]
+        # Persist so in-memory membership matches on-disk after resume.
+        if hasattr(superbasin, "write_data"):
+            try:
+                superbasin.write_data()
+            except Exception as exc:
+                logger.warning("amsel split: write_data failed: %s", exc)
         return status
     if status in ("rejected_no_metastable_basin", "rejected"):
         raise AmselSuperbasinReject(

--- a/eon/config.py
+++ b/eon/config.py
@@ -315,6 +315,34 @@ class ConfigClass:
             self.sb_rt_rate_threshold = parser.getfloat('Coarse Graining', 'rate_threshold')
         self.sb_superbasin_confidence = parser.getboolean('Coarse Graining', 'superbasin_confidence')
 
+        # [amsel] optional discover_decide gate before Superbasin.step (default off)
+        try:
+            self.amsel_discover_decide = parser.getboolean('amsel', 'discover_decide')
+        except Exception:
+            self.amsel_discover_decide = False
+        try:
+            self.amsel_e_min_init = parser.getfloat('amsel', 'e_min_init')
+        except Exception:
+            self.amsel_e_min_init = 0.5
+        try:
+            self.amsel_e_min_step = parser.getfloat('amsel', 'e_min_step')
+        except Exception:
+            self.amsel_e_min_step = 0.05
+        try:
+            self.amsel_e_min_floor = parser.getfloat('amsel', 'e_min_floor')
+        except Exception:
+            self.amsel_e_min_floor = 0.05
+        try:
+            self.amsel_cv_threshold = parser.getfloat('amsel', 'cv_threshold')
+        except Exception:
+            self.amsel_cv_threshold = 10.0
+        # Back-compat aliases used by Superbasin.step getattr
+        self.sb_amsel_discover_decide = self.amsel_discover_decide
+        self.sb_amsel_e_min_init = self.amsel_e_min_init
+        self.sb_amsel_e_min_step = self.amsel_e_min_step
+        self.sb_amsel_e_min_floor = self.amsel_e_min_floor
+        self.sb_amsel_cv_threshold = self.amsel_cv_threshold
+
         self.askmc_on = parser.getboolean('Coarse Graining','use_askmc')
         if self.askmc_on:
             self.askmc_confidence = parser.getfloat('Coarse Graining','askmc_confidence')

--- a/eon/config.yaml
+++ b/eon/config.yaml
@@ -1573,7 +1573,33 @@ Coarse Graining:
             kind: boolean
             default: True
 
+
 ################################################################################
+
+amsel:
+
+    options:
+
+        discover_decide:
+            kind: boolean
+            default: False
+
+        e_min_init:
+            kind: float
+            default: 0.5
+
+        e_min_step:
+            kind: float
+            default: 0.05
+
+        e_min_floor:
+            kind: float
+            default: 0.05
+
+        cv_threshold:
+            kind: float
+            default: 10.0
+
 
 Optimizer:
 

--- a/eon/schema.py
+++ b/eon/schema.py
@@ -1143,6 +1143,32 @@ class RecyclingConfig(BaseModel):
     )
 
 
+
+class AmselConfig(BaseModel):
+    model_config = ConfigDict(use_attribute_docstrings=True)
+
+    discover_decide: bool = Field(
+        default=False,
+        description="If true and the amsel package is installed, run amsel.discover_decide_status on the superbasin process graph before MCAMC Superbasin.step. split_required restricts to the primary basin; rejected raises so AKMC can fall back to single-state KMC.",
+    )
+    e_min_init: float = Field(
+        default=0.5,
+        description="Initial TS-energy cutoff (eV) for amsel adaptive discover_decide.",
+    )
+    e_min_step: float = Field(
+        default=0.05,
+        description="TS-energy retighten step (eV) for amsel discover_decide.",
+    )
+    e_min_floor: float = Field(
+        default=0.05,
+        description="TS-energy floor (eV) for amsel discover_decide.",
+    )
+    cv_threshold: float = Field(
+        default=10.0,
+        description="Coefficient-of-variation threshold passed to amsel discover_decide.",
+    )
+
+
 class CoarseGrainingConfig(BaseModel):
     model_config = ConfigDict(use_attribute_docstrings=True)
 
@@ -2080,6 +2106,7 @@ class Config(BaseModel):
     hyperdyn: HyperdynamicsConfig
     recycling: RecyclingConfig
     coarse_graining: CoarseGrainingConfig
+    amsel: AmselConfig = Field(default_factory=AmselConfig)
     optimizer: OptimizerConfig
     distributed_replica: DistributedReplicaConfig
     gprdimer: GPRDimerConfig

--- a/eon/superbasin.py
+++ b/eon/superbasin.py
@@ -36,6 +36,47 @@ class Superbasin:
             self.state_dict[state.number] = state
 
     def step(self, entry_state, get_product_state):
+        # Optional amsel discover_decide gate (L6): validate/split/reject the
+        # candidate basin *before* spending MCAMC on a non-metastable set.
+        # Off by default; requires the amsel Python package when enabled.
+        # [amsel] stanza (config.amsel_*); sb_amsel_* kept as back-compat aliases
+        _amsel_on = bool(
+            getattr(config, "amsel_discover_decide", False)
+            or getattr(config, "sb_amsel_discover_decide", False)
+        )
+        if _amsel_on:
+            from eon.amsel_superbasin_gate import (
+                apply_gate_to_superbasin,
+                discover_decide_for_superbasin,
+            )
+            decision = discover_decide_for_superbasin(
+                self,
+                entry_state,
+                e_min_init=float(
+                    getattr(config, "amsel_e_min_init",
+                            getattr(config, "sb_amsel_e_min_init", 0.5))
+                ),
+                e_min_step=float(
+                    getattr(config, "amsel_e_min_step",
+                            getattr(config, "sb_amsel_e_min_step", 0.05))
+                ),
+                e_min_floor=float(
+                    getattr(config, "amsel_e_min_floor",
+                            getattr(config, "sb_amsel_e_min_floor", 0.05))
+                ),
+                cv_threshold=float(
+                    getattr(config, "amsel_cv_threshold",
+                            getattr(config, "sb_amsel_cv_threshold", 10.0))
+                ),
+            )
+            status = apply_gate_to_superbasin(self, entry_state, decision)
+            logger.info(
+                "amsel discover_decide status=%s available=%s primary=%s",
+                status,
+                decision.get("available"),
+                decision.get("primary_transient"),
+            )
+
         # c_i (forming vector c) is the inverse of the sum of the rates for each transient state i
         # Q is the transient matrix of the canonical markov matrix.
         # R is the recurrent matrix of the canonical markov matrix.
@@ -79,16 +120,6 @@ class Superbasin:
                     Q[st2i[number], st2i[proc['product']]] += proc['rate']
                 else:
                     R[st2i[number], st2col[(number, id)]] += proc['rate']
-
-        #lei debug
-        print("################")
-        print(str(self.id)+" c is: ")
-        print(c)
-        print(str(self.id)+" Q is: ")
-        print(Q)
-        print(str(self.id)+" R is: ")
-        print(R)
-        # import pdb; pdb.set_trace()
 
         t, B, residual = mcamc(Q, R, c)
         logger.debug("residual %e" % residual)

--- a/tests/test_amsel_superbasin_gate.py
+++ b/tests/test_amsel_superbasin_gate.py
@@ -1,0 +1,101 @@
+"""Unit tests for eon.amsel_superbasin_gate (optional amsel dependency)."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from eon.amsel_superbasin_gate import (
+    AmselSuperbasinReject,
+    apply_gate_to_superbasin,
+    build_graph_from_superbasin,
+    discover_decide_for_superbasin,
+)
+
+
+class _FakeState:
+    def __init__(self, number, procs):
+        self.number = number
+        self._procs = procs
+
+    def get_process_table(self):
+        return self._procs
+
+
+def _fake_superbasin():
+    # 0 <-> 1 fast, 0 -> 2 exit (product outside basin for MCAMC would be 2)
+    s0 = _FakeState(
+        0,
+        {
+            0: {"rate": 1e10, "product": 1, "barrier": 0.1},
+            1: {"rate": 1e8, "product": 2, "barrier": 0.3},
+        },
+    )
+    s1 = _FakeState(
+        1,
+        {
+            0: {"rate": 1e10, "product": 0, "barrier": 0.1},
+        },
+    )
+    sb = SimpleNamespace(
+        state_numbers=[0, 1],
+        states=[s0, s1],
+        state_dict={0: s0, 1: s1},
+        id=1,
+    )
+    return sb
+
+
+def test_build_graph_from_superbasin_edges():
+    sb = _fake_superbasin()
+    cands, rates, barriers = build_graph_from_superbasin(sb, 0)
+    assert 0 in cands and 1 in cands
+    assert any(r[0] == 0 and r[1] == 1 for r in rates)
+    assert len(barriers) == len(rates)
+
+
+def test_discover_decide_for_superbasin_runs_or_unavailable():
+    sb = _fake_superbasin()
+    entry = SimpleNamespace(number=0)
+    decision = discover_decide_for_superbasin(sb, entry)
+    assert "status" in decision
+    assert "available" in decision
+    # With amsel installed in dev env, expect a real status; otherwise unavailable
+    if decision["available"] and decision["status"] != "unavailable":
+        assert decision["status"] in (
+            "accepted",
+            "retightened",
+            "split_required",
+            "rejected_no_metastable_basin",
+        )
+
+
+def test_apply_gate_split_restricts_members():
+    sb = _fake_superbasin()
+    entry = SimpleNamespace(number=0)
+    decision = {
+        "available": True,
+        "status": "split_required",
+        "primary_transient": [0],
+        "raw": None,
+        "reason": "",
+    }
+    status = apply_gate_to_superbasin(sb, entry, decision)
+    assert status == "split_required"
+    assert sb.state_numbers == [0]
+
+
+def test_apply_gate_reject_raises():
+    sb = _fake_superbasin()
+    entry = SimpleNamespace(number=0)
+    with pytest.raises(AmselSuperbasinReject):
+        apply_gate_to_superbasin(
+            sb,
+            entry,
+            {
+                "available": True,
+                "status": "rejected_no_metastable_basin",
+                "primary_transient": None,
+                "reason": "test",
+            },
+        )

--- a/tests/test_amsel_superbasin_gate.py
+++ b/tests/test_amsel_superbasin_gate.py
@@ -99,3 +99,41 @@ def test_apply_gate_reject_raises():
                 "reason": "test",
             },
         )
+
+
+def test_split_keeps_entry_state():
+    from eon.amsel_superbasin_gate import apply_gate_to_superbasin
+
+    class _St:
+        def __init__(self, n):
+            self.number = n
+
+        def get_process_table(self):
+            return {}
+
+    class _SB:
+        def __init__(self):
+            self.state_numbers = [0, 1, 2]
+            self.state_dict = {0: _St(0), 1: _St(1), 2: _St(2)}
+            self.states = [self.state_dict[n] for n in self.state_numbers]
+            self.written = False
+
+        def write_data(self):
+            self.written = True
+
+    sb = _SB()
+    entry = _St(0)
+    # primary omits entry 0 — gate must re-add it
+    status = apply_gate_to_superbasin(
+        sb,
+        entry,
+        {
+            "available": True,
+            "status": "split_required",
+            "primary_transient": [1, 2],
+            "reason": "",
+        },
+    )
+    assert status == "split_required"
+    assert 0 in sb.state_numbers
+    assert sb.written


### PR DESCRIPTION
## Summary

Optional **amsel** `discover_decide` gate **before** MCAMC in `Superbasin.step` (L6).

Default **off**. Soft dependency on `amsel`. `split_required` restricts to primary basin; `rejected_no_metastable_basin` raises `AmselSuperbasinReject` for single-state KMC fallback.

Note: eOn Superbasin is **Python** (not C++); this is the real Superbasin.step control point.

## Config

`[Coarse Graining] amsel_discover_decide` (+ `amsel_e_min_*`, `amsel_cv_threshold`) in config.yaml/schema.

## Test plan

- Standalone gate unit tests with amsel on PYTHONPATH
- Manual AKMC with flag off (unchanged) / on (log status=)
