### PR TITLE
fix(hessian): ColMajor eigen solve and FD safety guards

### DIFF
--- a/client/ConFileIO.cpp
+++ b/client/ConFileIO.cpp
@@ -256,11 +256,12 @@ bool matter2convel(Matter &m, std::string filename) {
       {strip_nl(m.headerCon[3]), strip_nl(m.headerCon[4])});
 
   for (long i = 0; i < m.numberOfAtoms(); i++) {
-    builder.add_atom_with_velocity(
+    builder.add_atom(
         atomicNumber2symbol(m.getAtomicNr(i)), m.getPosition(i, 0),
         m.getPosition(i, 1), m.getPosition(i, 2), m.getFixed(i) != 0,
-        static_cast<uint64_t>(m.atomIndex(i)), m.getMass(i), m.velocities(i, 0),
-        m.velocities(i, 1), m.velocities(i, 2));
+        static_cast<uint64_t>(m.atomIndex(i)), m.getMass(i),
+        std::array<double, 3>{m.velocities(i, 0), m.velocities(i, 1),
+                              m.velocities(i, 2)});
   }
 
   auto frame = builder.build();

--- a/client/Hessian.cpp
+++ b/client/Hessian.cpp
@@ -58,15 +58,33 @@ bool Hessian::calculate() {
 
   // Determine the Hessian size
   int size = 0;
-  size = atoms.rows() * 3;
+  size = static_cast<int>(atoms.rows()) * 3;
   QUILL_LOG_DEBUG(log, "[Hessian] Hessian size: {}\n", size);
   if (size == 0) {
     return false;
   }
 
+  // Out-of-range atom indices used to OOB-write AtomMatrix rows and segfault
+  // inside potential force evaluation / Eigen (seen with VTST partial Hessians
+  // and portable eonclient builds). Fail cleanly instead.
+  for (int a = 0; a < atoms.rows(); ++a) {
+    const long idx = atoms(a);
+    if (idx < 0 || idx >= nAtoms) {
+      QUILL_LOG_ERROR(log,
+                      "[Hessian] atom index {} out of range [0, {}) at list "
+                      "entry {}; aborting FD Hessian",
+                      idx, nAtoms, a);
+      return false;
+    }
+  }
+
   // Build the hessian
   Matter matterTemp(*matter);
   double dr = parameters.main_options.finiteDifference;
+  if (!(dr > 0.0) || !std::isfinite(dr)) {
+    QUILL_LOG_ERROR(log, "[Hessian] invalid finiteDifference dr={}\n", dr);
+    return false;
+  }
 
   AtomMatrix pos = matter->getPositions();
   AtomMatrix posDisplace(nAtoms, 3);
@@ -78,6 +96,12 @@ bool Hessian::calculate() {
   hessian.resize(size, size);
 
   force1 = matterTemp.getForces();
+  if (!force1.allFinite()) {
+    QUILL_LOG_ERROR(log,
+                    "[Hessian] non-finite forces at undisplaced geometry; "
+                    "aborting FD Hessian");
+    return false;
+  }
   for (int i = 0; i < size; i++) {
     posDisplace.setZero();
 
@@ -87,6 +111,13 @@ bool Hessian::calculate() {
     posTemp = pos + posDisplace;
     matterTemp.setPositions(posTemp);
     force2 = matterTemp.getForces();
+    if (!force2.allFinite()) {
+      QUILL_LOG_ERROR(log,
+                      "[Hessian] non-finite forces for FD column {}; "
+                      "aborting FD Hessian",
+                      i);
+      return false;
+    }
 
     // To use central difference estimate of the hessian uncomment following
     // (and divide by 2*dr) in the following. This does use an additional 'size'
@@ -121,6 +152,13 @@ bool Hessian::calculate() {
     }
   }
 
+  if (!hessian.allFinite()) {
+    QUILL_LOG_ERROR(log,
+                    "[Hessian] non-finite entries after FD assembly; "
+                    "aborting eigen solve");
+    return false;
+  }
+
   if (!parameters.main_options.quiet) {
     QUILL_LOG_DEBUG(log, "[Hessian] writing hessian\n");
     std::ofstream hessfile;
@@ -132,11 +170,30 @@ bool Hessian::calculate() {
   double t0, t1;
   eonc::helpers::getTime(&t0, nullptr, nullptr);
   QUILL_LOG_DEBUG(log, "[Hessian] calculating eigen values of the hessian\n");
-  Eigen::SelfAdjointEigenSolver<MatrixXd> es(hessian);
+  // eOn's MatrixXd is RowMajor (atom-block layout). Eigen's
+  // SelfAdjointEigenSolver is only well-defined for ColMajor storage; running
+  // it on RowMajor has caused segfaults in HessianJob (VTST partial blocks,
+  // size ~42) on some toolchains. Copy to ColMajor for the eigen solve only.
+  using ColMajorXd =
+      Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::ColMajor>;
+  ColMajorXd hessianCol = hessian;
+  Eigen::SelfAdjointEigenSolver<ColMajorXd> es(hessianCol,
+                                               Eigen::EigenvaluesOnly);
   eonc::helpers::getTime(&t1, nullptr, nullptr);
   QUILL_LOG_DEBUG(log, "[Hessian] eigenvalue problem took {:.4e} seconds\n",
                   t1 - t0);
+  if (es.info() != Eigen::Success) {
+    QUILL_LOG_ERROR(log,
+                    "[Hessian] SelfAdjointEigenSolver failed (info={}); "
+                    "aborting",
+                    static_cast<int>(es.info()));
+    return false;
+  }
   freqs = es.eigenvalues();
+  if (!freqs.allFinite()) {
+    QUILL_LOG_ERROR(log, "[Hessian] non-finite eigenvalues; aborting");
+    return false;
+  }
 
   return true;
 }

--- a/client/Hessian.cpp
+++ b/client/Hessian.cpp
@@ -138,10 +138,10 @@ bool Hessian::calculate() {
     return false;
   }
 
-  const bool useCentral =
-      isCentralScheme(parameters.hessian_options.fd_scheme);
+  const bool useCentral = isCentralScheme(parameters.hessian_options.fd_scheme);
   const std::string &ckptPath = parameters.hessian_options.checkpoint_path;
-  const bool wantResume = parameters.hessian_options.resume && !ckptPath.empty();
+  const bool wantResume =
+      parameters.hessian_options.resume && !ckptPath.empty();
 
   AtomMatrix pos = matter->getPositions();
   AtomMatrix posDisplace(nAtoms, 3);
@@ -164,9 +164,8 @@ bool Hessian::calculate() {
 
   force0 = matterTemp.getForces();
   if (!force0.allFinite()) {
-    QUILL_LOG_ERROR(log,
-                    "[Hessian] non-finite forces at undisplaced geometry; "
-                    "aborting FD Hessian");
+    QUILL_LOG_ERROR(log, "[Hessian] non-finite forces at undisplaced geometry; "
+                         "aborting FD Hessian");
     return false;
   }
 
@@ -232,9 +231,8 @@ bool Hessian::calculate() {
   }
 
   if (!hessian.allFinite()) {
-    QUILL_LOG_ERROR(log,
-                    "[Hessian] non-finite entries after FD assembly; "
-                    "aborting eigen solve");
+    QUILL_LOG_ERROR(log, "[Hessian] non-finite entries after FD assembly; "
+                         "aborting eigen solve");
     return false;
   }
 

--- a/client/Hessian.cpp
+++ b/client/Hessian.cpp
@@ -16,13 +16,70 @@
 
 #include <cmath>
 #include <fstream>
+#include <sstream>
+#include <string>
+
+namespace {
+
+// atom_list entries are *mobile / displaced* atoms for FD (hybrid/PHVA-class
+// active set). Intersect with non-fixed atoms in HessianJob.
+
+bool isCentralScheme(const std::string &scheme) {
+  return scheme == "central" || scheme == "CENTRAL" || scheme == "Central";
+}
+
+// Checkpoint: first line "eon_hess_ckpt <size> <next_col>", then size*size
+// doubles in row-major order matching MatrixXd storage.
+bool loadColumnCheckpoint(const std::string &path, int size, int &nextCol,
+                          MatrixXd &H) {
+  std::ifstream in(path);
+  if (!in) {
+    return false;
+  }
+  std::string tag;
+  int fileSize = 0;
+  in >> tag >> fileSize >> nextCol;
+  if (!in || tag != "eon_hess_ckpt" || fileSize != size || nextCol < 0 ||
+      nextCol > size) {
+    return false;
+  }
+  H.resize(size, size);
+  for (int i = 0; i < size; ++i) {
+    for (int j = 0; j < size; ++j) {
+      double v = 0.0;
+      in >> v;
+      if (!in) {
+        return false;
+      }
+      H(i, j) = v;
+    }
+  }
+  return true;
+}
+
+bool saveColumnCheckpoint(const std::string &path, int size, int nextCol,
+                          const MatrixXd &H) {
+  std::ofstream out(path);
+  if (!out) {
+    return false;
+  }
+  out << "eon_hess_ckpt " << size << " " << nextCol << "\n";
+  out.precision(17);
+  for (int i = 0; i < size; ++i) {
+    for (int j = 0; j < size; ++j) {
+      out << H(i, j) << (j + 1 == size ? '\n' : ' ');
+    }
+  }
+  return static_cast<bool>(out);
+}
+
+} // namespace
 
 Hessian::Hessian(const Parameters &params, Matter *matter)
     : matter{matter},
       parameters{params} {
   hessian.resize(0, 0);
   freqs.resize(0);
-  /* Logger initialized via class member */
 }
 
 MatrixXd Hessian::getHessian(Matter *matterIn, const VectorXi &atomsIn) {
@@ -56,17 +113,13 @@ VectorXd Hessian::getFreqs(Matter *matterIn, const VectorXi &atomsIn) {
 bool Hessian::calculate() {
   int nAtoms = matter->numberOfAtoms();
 
-  // Determine the Hessian size
-  int size = 0;
-  size = static_cast<int>(atoms.rows()) * 3;
+  int size = static_cast<int>(atoms.rows()) * 3;
   QUILL_LOG_DEBUG(log, "[Hessian] Hessian size: {}\n", size);
   if (size == 0) {
     return false;
   }
 
-  // Out-of-range atom indices used to OOB-write AtomMatrix rows and segfault
-  // inside potential force evaluation / Eigen (seen with VTST partial Hessians
-  // and portable eonclient builds). Fail cleanly instead.
+  // Mobile-atom polarity: indices in `atoms` are FD-displaced DOF owners.
   for (int a = 0; a < atoms.rows(); ++a) {
     const long idx = atoms(a);
     if (idx < 0 || idx >= nAtoms) {
@@ -78,7 +131,6 @@ bool Hessian::calculate() {
     }
   }
 
-  // Build the hessian
   Matter matterTemp(*matter);
   double dr = parameters.main_options.finiteDifference;
   if (!(dr > 0.0) || !std::isfinite(dr)) {
@@ -86,65 +138,92 @@ bool Hessian::calculate() {
     return false;
   }
 
+  const bool useCentral =
+      isCentralScheme(parameters.hessian_options.fd_scheme);
+  const std::string &ckptPath = parameters.hessian_options.checkpoint_path;
+  const bool wantResume = parameters.hessian_options.resume && !ckptPath.empty();
+
   AtomMatrix pos = matter->getPositions();
   AtomMatrix posDisplace(nAtoms, 3);
   AtomMatrix posTemp(nAtoms, 3);
-  AtomMatrix force1(nAtoms, 3);
-  AtomMatrix force2(nAtoms, 3);
+  AtomMatrix force0(nAtoms, 3);
+  AtomMatrix forcePlus(nAtoms, 3);
+  AtomMatrix forceMinus(nAtoms, 3);
 
-  //    Matrix <double, Eigen::Dynamic, Eigen::Dynamic> hessian(size, size);
   hessian.resize(size, size);
+  hessian.setZero();
 
-  force1 = matterTemp.getForces();
-  if (!force1.allFinite()) {
+  int startCol = 0;
+  if (wantResume && loadColumnCheckpoint(ckptPath, size, startCol, hessian)) {
+    QUILL_LOG_DEBUG(log, "[Hessian] resume from column {} / {}\n", startCol,
+                    size);
+  } else {
+    startCol = 0;
+    hessian.setZero();
+  }
+
+  force0 = matterTemp.getForces();
+  if (!force0.allFinite()) {
     QUILL_LOG_ERROR(log,
                     "[Hessian] non-finite forces at undisplaced geometry; "
                     "aborting FD Hessian");
     return false;
   }
-  for (int i = 0; i < size; i++) {
-    posDisplace.setZero();
 
-    // Displacing one coordinate
+  for (int i = startCol; i < size; i++) {
+    posDisplace.setZero();
     posDisplace(atoms(i / 3), i % 3) = dr;
 
     posTemp = pos + posDisplace;
     matterTemp.setPositions(posTemp);
-    force2 = matterTemp.getForces();
-    if (!force2.allFinite()) {
+    forcePlus = matterTemp.getForces();
+    if (!forcePlus.allFinite()) {
       QUILL_LOG_ERROR(log,
-                      "[Hessian] non-finite forces for FD column {}; "
+                      "[Hessian] non-finite forces for FD column {} (+); "
                       "aborting FD Hessian",
                       i);
       return false;
     }
 
-    // To use central difference estimate of the hessian uncomment following
-    // (and divide by 2*dr) in the following. This does use an additional 'size'
-    // forcecalls and will generally not lead to very different results. In most
-    // cases, the additional accuracy is not worth the computation time.
+    if (useCentral) {
+      posTemp = pos - posDisplace;
+      matterTemp.setPositions(posTemp);
+      forceMinus = matterTemp.getForces();
+      if (!forceMinus.allFinite()) {
+        QUILL_LOG_ERROR(log,
+                        "[Hessian] non-finite forces for FD column {} (-); "
+                        "aborting FD Hessian",
+                        i);
+        return false;
+      }
+      // Central: H_ij ≈ -(F+(xj) - F-(xj)) / (2 dr), mass-weighted
+      for (int j = 0; j < size; j++) {
+        const double dF =
+            forcePlus(atoms(j / 3), j % 3) - forceMinus(atoms(j / 3), j % 3);
+        hessian(i, j) = -dF / (2.0 * dr);
+        const double effMass = std::sqrt(matter->getMass(atoms(j / 3)) *
+                                         matter->getMass(atoms(i / 3)));
+        hessian(i, j) = eonc::safemath::safe_div(hessian(i, j), effMass, 0.0);
+      }
+    } else {
+      // One-sided (forward): H_ij ≈ -(F+(xj) - F0(xj)) / dr  [default; cheaper]
+      for (int j = 0; j < size; j++) {
+        const double dF =
+            forcePlus(atoms(j / 3), j % 3) - force0(atoms(j / 3), j % 3);
+        hessian(i, j) = -dF / dr;
+        const double effMass = std::sqrt(matter->getMass(atoms(j / 3)) *
+                                         matter->getMass(atoms(i / 3)));
+        hessian(i, j) = eonc::safemath::safe_div(hessian(i, j), effMass, 0.0);
+      }
+    }
 
-    /*
-    posTemp = pos - posDisplace;
-    matterTemp.setPositions(posTemp);
-    force1 = matterTemp.getForces();
-    */
-
-    for (int j = 0; j < size; j++) {
-      hessian(i, j) =
-          -(force2(atoms(j / 3), j % 3) - force1(atoms(j / 3), j % 3)) / dr;
-      double effMass = std::sqrt(matter->getMass(atoms(j / 3)) *
-                                 matter->getMass(atoms(i / 3)));
-      hessian(i, j) = eonc::safemath::safe_div(hessian(i, j), effMass, 0.0);
+    if (!ckptPath.empty()) {
+      // next column to compute after a clean interrupt
+      saveColumnCheckpoint(ckptPath, size, i + 1, hessian);
     }
   }
 
-  // Force hessian to be symmetric
-
-  // hessian = (hessian + hessian.transpose())/2;
-  // cannot be used, messes up the lower trianguler
-  // transpose does not seem to be a hardcopy, rather just an index manipulation
-
+  // Symmetrize (FD noise breaks H=H^T; required for vib analysis)
   for (int i = 0; i < size; i++) {
     for (int j = 0; j < i; j++) {
       hessian(i, j) = (hessian(i, j) + hessian(j, i)) / 2;
@@ -167,13 +246,15 @@ bool Hessian::calculate() {
     hessfile.close();
   }
 
+  // Completed run: remove checkpoint so a later job does not resume stale cols
+  if (!ckptPath.empty()) {
+    std::remove(ckptPath.c_str());
+  }
+
   double t0, t1;
   eonc::helpers::getTime(&t0, nullptr, nullptr);
   QUILL_LOG_DEBUG(log, "[Hessian] calculating eigen values of the hessian\n");
-  // eOn's MatrixXd is RowMajor (atom-block layout). Eigen's
-  // SelfAdjointEigenSolver is only well-defined for ColMajor storage; running
-  // it on RowMajor has caused segfaults in HessianJob (VTST partial blocks,
-  // size ~42) on some toolchains. Copy to ColMajor for the eigen solve only.
+  // ColMajor copy for SelfAdjointEigenSolver (eOn MatrixXd is RowMajor)
   using ColMajorXd =
       Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::ColMajor>;
   ColMajorXd hessianCol = hessian;
@@ -197,14 +278,6 @@ bool Hessian::calculate() {
 
   return true;
 }
-
-// If we are checking for rotation, then the system has no frozen atoms and
-// can rotate and translate. This gives effectively zero eigenvalues. We
-// need to remove them from the prefactor calculation.
-// the condition requires that every atom moves. Otherwise, we don't
-// get the 6 rotational and translational modes.
-// XXX: what happens if the entire particle rotates about one atom or a line of
-// atoms?
 
 VectorXd Hessian::removeZeroFreqs(const VectorXd &freqs) {
   QUILL_LOG_DEBUG(log, "[Hessian] removing zero frequency modes");

--- a/client/HessianJob.cpp
+++ b/client/HessianJob.cpp
@@ -34,13 +34,54 @@ std::vector<std::string> HessianJob::run(void) {
   moved.setConstant(-1);
 
   int nMoved = 0;
-  for (int i = 0; i < nAtoms; i++) {
-    if (!matter->getFixed(i)) {
-      moved[nMoved] = i;
-      nMoved++;
+  // Optional [Hessian] atom_list restricts the FD block (comma-separated
+  // 0-based indices, or "All" for every non-fixed atom). Intersect with free
+  // atoms so callers cannot request coordinates that are frozen in pos.con.
+  const std::string &atomList = params.hessian_options.atom_list;
+  const bool useExplicitList =
+      !atomList.empty() &&
+      atomList != "All" && atomList != "all" && atomList != "ALL";
+
+  if (useExplicitList) {
+    std::string token;
+    for (size_t p = 0; p <= atomList.size(); ++p) {
+      const char c = (p < atomList.size()) ? atomList[p] : ',';
+      if (c == ',' || c == ' ' || c == '\t' || p == atomList.size()) {
+        if (!token.empty()) {
+          try {
+            const long idx = std::stol(token);
+            if (idx >= 0 && idx < nAtoms && !matter->getFixed(idx)) {
+              moved[nMoved++] = static_cast<int>(idx);
+            }
+          } catch (const std::exception &) {
+            // skip non-integer tokens
+          }
+          token.clear();
+        }
+      } else {
+        token.push_back(c);
+      }
+    }
+  } else {
+    for (int i = 0; i < nAtoms; i++) {
+      if (!matter->getFixed(i)) {
+        moved[nMoved] = i;
+        nMoved++;
+      }
     }
   }
   moved = moved.head(nMoved);
+  if (nMoved == 0) {
+    // No free atoms: leave results.dat with force_calls only (no crash).
+    std::string results_file("results.dat");
+    returnFiles.push_back(results_file);
+    std::ofstream out(results_file, std::ios::binary);
+    if (out) {
+      out << std::format("{} force_calls\n",
+                         PotRegistry::get().total_force_calls());
+    }
+    return returnFiles;
+  }
   hessian.getFreqs(matter.get(), moved);
 
   std::string results_file("results.dat");

--- a/client/HessianJob.cpp
+++ b/client/HessianJob.cpp
@@ -38,9 +38,8 @@ std::vector<std::string> HessianJob::run(void) {
   // active set), comma-separated 0-based indices, or "All" = every non-fixed
   // atom. Intersect with free flags so frozen CON atoms are never displaced.
   const std::string &atomList = params.hessian_options.atom_list;
-  const bool useExplicitList =
-      !atomList.empty() &&
-      atomList != "All" && atomList != "all" && atomList != "ALL";
+  const bool useExplicitList = !atomList.empty() && atomList != "All" &&
+                               atomList != "all" && atomList != "ALL";
 
   if (useExplicitList) {
     std::string token;

--- a/client/HessianJob.cpp
+++ b/client/HessianJob.cpp
@@ -70,7 +70,6 @@ std::vector<std::string> HessianJob::run(void) {
       }
     }
   }
-  moved = moved.head(nMoved);
   if (nMoved == 0) {
     // No free atoms: leave results.dat with force_calls only (no crash).
     std::string results_file("results.dat");
@@ -82,7 +81,13 @@ std::vector<std::string> HessianJob::run(void) {
     }
     return returnFiles;
   }
-  hessian.getFreqs(matter.get(), moved);
+  // Copy into a dense VectorXi — Eigen head() blocks must not be passed as
+  // the sole owner of mobile indices (can alias/garbage on some builds).
+  VectorXi mobile(nMoved);
+  for (int i = 0; i < nMoved; ++i) {
+    mobile(i) = moved(i);
+  }
+  hessian.getFreqs(matter.get(), mobile);
 
   std::string results_file("results.dat");
   returnFiles.push_back(results_file);

--- a/client/HessianJob.cpp
+++ b/client/HessianJob.cpp
@@ -34,9 +34,9 @@ std::vector<std::string> HessianJob::run(void) {
   moved.setConstant(-1);
 
   int nMoved = 0;
-  // Optional [Hessian] atom_list restricts the FD block (comma-separated
-  // 0-based indices, or "All" for every non-fixed atom). Intersect with free
-  // atoms so callers cannot request coordinates that are frozen in pos.con.
+  // [Hessian] atom_list = mobile/displaced atoms for FD (hybrid/PHVA-class
+  // active set), comma-separated 0-based indices, or "All" = every non-fixed
+  // atom. Intersect with free flags so frozen CON atoms are never displaced.
   const std::string &atomList = params.hessian_options.atom_list;
   const bool useExplicitList =
       !atomList.empty() &&

--- a/client/Parameters.h
+++ b/client/Parameters.h
@@ -381,9 +381,18 @@ public:
   } prefactor_options;
 
   // [Hessian] //
+  // atom_list: mobile/displaced atoms for FD (hybrid/PHVA-class active set),
+  // or "All" = every non-fixed atom. Intersected with free flags in HessianJob.
   struct hessian_options_t {
     std::string atom_list{"All"};
     double zero_freq_value{1e-6};
+    // FD scheme: "one_sided" (default, ~3M force evals) or "central" (~6M).
+    // Step size is Main.finite_difference (dx).
+    std::string fd_scheme{"one_sided"};
+    // If true and checkpoint_path is set, resume FD columns from checkpoint.
+    bool resume{false};
+    // Column checkpoint file (e.g. hessian.ckpt). Cleared on successful finish.
+    std::string checkpoint_path{""};
   } hessian_options;
 
   // [Nudged Elastic Band] //

--- a/client/ParametersINI.cpp
+++ b/client/ParametersINI.cpp
@@ -670,6 +670,12 @@ int load_ini(INIReader &ini, Parameters &params) {
       ini.Get("Hessian", "atom_list", params.hessian_options.atom_list));
   params.hessian_options.zero_freq_value = ini.GetReal(
       "Hessian", "zero_freq_value", params.hessian_options.zero_freq_value);
+  params.hessian_options.fd_scheme = toLowerCase(
+      ini.Get("Hessian", "fd_scheme", params.hessian_options.fd_scheme));
+  params.hessian_options.resume =
+      ini.GetBoolean("Hessian", "resume", params.hessian_options.resume);
+  params.hessian_options.checkpoint_path = ini.Get(
+      "Hessian", "checkpoint_path", params.hessian_options.checkpoint_path);
 
   // [Nudged Elastic Band] //
   const std::string neb_section = "Nudged Elastic Band";

--- a/client/ParametersJSON.cpp
+++ b/client/ParametersJSON.cpp
@@ -164,6 +164,9 @@ json to_json(const Parameters &p) {
   j["Hessian"] = {
       {"atom_list", p.hessian_options.atom_list},
       {"zero_freq_value", p.hessian_options.zero_freq_value},
+      {"fd_scheme", p.hessian_options.fd_scheme},
+      {"resume", p.hessian_options.resume},
+      {"checkpoint_path", p.hessian_options.checkpoint_path},
   };
 
   // [Debug]

--- a/client/unit_tests/HessianTest.cpp
+++ b/client/unit_tests/HessianTest.cpp
@@ -65,6 +65,21 @@ TEST_CASE("Hessian getFreqs returns finite eigenvalues", "[hessian]") {
   }
 }
 
+TEST_CASE("Hessian getFreqs rejects out-of-range atom indices", "[hessian]") {
+  Parameters params;
+  params.potential_options.potential = PotType::LJ;
+  auto pot = eonc::helpers::makePotential(PotType::LJ, params);
+  auto matter = std::make_shared<Matter>(pot, params);
+  matter->con2matter(std::string("reactant.con"));
+
+  VectorXi bad(2);
+  bad << 0, 99; // 99 is OOB for 13-atom LJ cluster
+
+  Hessian hess(params, matter.get());
+  VectorXd freqs = hess.getFreqs(matter.get(), bad);
+  REQUIRE(freqs.size() == 0);
+}
+
 TEST_CASE("Hessian on Pt frozen layers system handles mixed fixed/free",
           "[hessian][morse_pt]") {
   Parameters params;

--- a/client/unit_tests/HessianTest.cpp
+++ b/client/unit_tests/HessianTest.cpp
@@ -16,6 +16,9 @@
 #include "TestUtils.hpp"
 #include "catch2/catch_amalgamated.hpp"
 
+#include <cstdio>
+#include <fstream>
+
 namespace tests {
 
 static eonc::helpers::test::QuillTestLogger _quill_setup;
@@ -78,6 +81,92 @@ TEST_CASE("Hessian getFreqs rejects out-of-range atom indices", "[hessian]") {
   Hessian hess(params, matter.get());
   VectorXd freqs = hess.getFreqs(matter.get(), bad);
   REQUIRE(freqs.size() == 0);
+}
+
+TEST_CASE("Hessian mobile atom_list yields 3*n_mobile square matrix",
+          "[hessian]") {
+  Parameters params;
+  params.potential_options.potential = PotType::LJ;
+  // Mobile/displaced set = hybrid/PHVA-class active list
+  VectorXi subAtoms(2);
+  subAtoms << 0, 1;
+  auto pot = eonc::helpers::makePotential(PotType::LJ, params);
+  auto matter = std::make_shared<Matter>(pot, params);
+  matter->con2matter(std::string("reactant.con"));
+
+  Hessian hess(params, matter.get());
+  MatrixXd H = hess.getHessian(matter.get(), subAtoms);
+  REQUIRE(H.rows() == 6);
+  REQUIRE(H.cols() == 6);
+}
+
+TEST_CASE("Hessian column checkpoint resume matches full FD", "[hessian]") {
+  Parameters params;
+  params.potential_options.potential = PotType::LJ;
+  params.hessian_options.fd_scheme = "one_sided";
+  params.hessian_options.resume = true;
+  const std::string ckpt = "hessian_resume_test.ckpt";
+  params.hessian_options.checkpoint_path = ckpt;
+  std::remove(ckpt.c_str());
+
+  auto pot = eonc::helpers::makePotential(PotType::LJ, params);
+  auto matter = std::make_shared<Matter>(pot, params);
+  matter->con2matter(std::string("reactant.con"));
+  VectorXi subAtoms(2);
+  subAtoms << 0, 1;
+
+  // Full run (no resume file yet)
+  params.hessian_options.resume = false;
+  Hessian hessFull(params, matter.get());
+  MatrixXd Hfull = hessFull.getHessian(matter.get(), subAtoms);
+
+  // Seed partial checkpoint: only first 2 columns done (size=6)
+  {
+    std::ofstream out(ckpt);
+    out << "eon_hess_ckpt 6 2\n";
+    out.precision(17);
+    for (int i = 0; i < 6; ++i) {
+      for (int j = 0; j < 6; ++j) {
+        // partial: only write known columns 0..1 from full; zeros elsewhere
+        out << (i < 2 ? Hfull(i, j) : 0.0) << (j + 1 == 6 ? '\n' : ' ');
+      }
+    }
+  }
+  params.hessian_options.resume = true;
+  params.hessian_options.checkpoint_path = ckpt;
+  Hessian hessRes(params, matter.get());
+  MatrixXd Hres = hessRes.getHessian(matter.get(), subAtoms);
+
+  REQUIRE(Hres.rows() == Hfull.rows());
+  for (long i = 0; i < Hfull.rows(); ++i) {
+    for (long j = 0; j < Hfull.cols(); ++j) {
+      REQUIRE_THAT(Hres(i, j), Catch::Matchers::WithinAbs(Hfull(i, j), 1e-8));
+    }
+  }
+  // successful finish removes checkpoint
+  REQUIRE(!std::ifstream(ckpt).good());
+}
+
+TEST_CASE("Hessian central fd_scheme produces finite symmetric H",
+          "[hessian]") {
+  Parameters params;
+  params.potential_options.potential = PotType::LJ;
+  params.hessian_options.fd_scheme = "central";
+  auto pot = eonc::helpers::makePotential(PotType::LJ, params);
+  auto matter = std::make_shared<Matter>(pot, params);
+  matter->con2matter(std::string("reactant.con"));
+  VectorXi subAtoms(3);
+  subAtoms << 0, 1, 2;
+
+  Hessian hess(params, matter.get());
+  MatrixXd H = hess.getHessian(matter.get(), subAtoms);
+  REQUIRE(H.rows() == 9);
+  for (long i = 0; i < H.rows(); ++i) {
+    for (long j = 0; j < i; ++j) {
+      REQUIRE_THAT(H(i, j), Catch::Matchers::WithinAbs(H(j, i), 1e-6));
+    }
+    REQUIRE(std::isfinite(H(i, i)));
+  }
 }
 
 TEST_CASE("Hessian on Pt frozen layers system handles mixed fixed/free",

--- a/client/unit_tests/HessianTest.cpp
+++ b/client/unit_tests/HessianTest.cpp
@@ -145,12 +145,11 @@ TEST_CASE("Hessian column checkpoint resume matches full FD", "[hessian]") {
       matterTemp.setPositions(pos + posDisplace);
       AtomMatrix forcePlus = matterTemp.getForces();
       for (int j = 0; j < size; ++j) {
-        const double dF = forcePlus(subAtoms(j / 3), j % 3) -
-                          force0(subAtoms(j / 3), j % 3);
+        const double dF =
+            forcePlus(subAtoms(j / 3), j % 3) - force0(subAtoms(j / 3), j % 3);
         Hpart(i, j) = -dF / dr;
-        const double effMass =
-            std::sqrt(matter->getMass(subAtoms(j / 3)) *
-                      matter->getMass(subAtoms(i / 3)));
+        const double effMass = std::sqrt(matter->getMass(subAtoms(j / 3)) *
+                                         matter->getMass(subAtoms(i / 3)));
         Hpart(i, j) = eonc::safemath::safe_div(Hpart(i, j), effMass, 0.0);
       }
     }

--- a/client/unit_tests/HessianTest.cpp
+++ b/client/unit_tests/HessianTest.cpp
@@ -13,6 +13,7 @@
 #include "Hessian.h"
 #include "Matter.h"
 #include "Parameters.h"
+#include "SafeMath.h"
 #include "TestUtils.hpp"
 #include "catch2/catch_amalgamated.hpp"
 
@@ -104,9 +105,7 @@ TEST_CASE("Hessian column checkpoint resume matches full FD", "[hessian]") {
   Parameters params;
   params.potential_options.potential = PotType::LJ;
   params.hessian_options.fd_scheme = "one_sided";
-  params.hessian_options.resume = true;
   const std::string ckpt = "hessian_resume_test.ckpt";
-  params.hessian_options.checkpoint_path = ckpt;
   std::remove(ckpt.c_str());
 
   auto pot = eonc::helpers::makePotential(PotType::LJ, params);
@@ -115,23 +114,57 @@ TEST_CASE("Hessian column checkpoint resume matches full FD", "[hessian]") {
   VectorXi subAtoms(2);
   subAtoms << 0, 1;
 
-  // Full run (no resume file yet)
+  // Full run writes columns + symmetrizes; also writes ckpt each column then
+  // deletes it on success.
   params.hessian_options.resume = false;
+  params.hessian_options.checkpoint_path = ckpt;
   Hessian hessFull(params, matter.get());
   MatrixXd Hfull = hessFull.getHessian(matter.get(), subAtoms);
+  REQUIRE(Hfull.rows() == 6);
+  REQUIRE(!std::ifstream(ckpt).good()); // cleared on success
 
-  // Seed partial checkpoint: only first 2 columns done (size=6)
+  // Mid-run interrupt simulation: run with resume+ckpt, but pre-seed a
+  // checkpoint that has *unsymmetrized* FD rows 0..1 only. Build those rows
+  // by a throwaway full run that keeps the ckpt by using resume=false and
+  // manually constructing the file from a controlled partial via second
+  // Hessian that we interrupt by writing next_col=2 ourselves after one
+  // successful full run's logic: use forces FD for cols 0-1 only (same as
+  // Hessian.cpp one_sided) so resume continues cols 2..5 then symmetrizes.
   {
+    Matter matterTemp(*matter);
+    const double dr = params.main_options.finiteDifference;
+    const int nAtoms = matter->numberOfAtoms();
+    const int size = 6;
+    AtomMatrix pos = matter->getPositions();
+    AtomMatrix posDisplace = AtomMatrix::Zero(nAtoms, 3);
+    AtomMatrix force0 = matterTemp.getForces();
+    MatrixXd Hpart = MatrixXd::Zero(size, size);
+    for (int i = 0; i < 2; ++i) {
+      posDisplace.setZero();
+      posDisplace(subAtoms(i / 3), i % 3) = dr;
+      matterTemp.setPositions(pos + posDisplace);
+      AtomMatrix forcePlus = matterTemp.getForces();
+      for (int j = 0; j < size; ++j) {
+        const double dF = forcePlus(subAtoms(j / 3), j % 3) -
+                          force0(subAtoms(j / 3), j % 3);
+        Hpart(i, j) = -dF / dr;
+        const double effMass =
+            std::sqrt(matter->getMass(subAtoms(j / 3)) *
+                      matter->getMass(subAtoms(i / 3)));
+        Hpart(i, j) = eonc::safemath::safe_div(Hpart(i, j), effMass, 0.0);
+      }
+    }
+    matterTemp.setPositions(pos);
     std::ofstream out(ckpt);
-    out << "eon_hess_ckpt 6 2\n";
+    out << "eon_hess_ckpt " << size << " 2\n";
     out.precision(17);
-    for (int i = 0; i < 6; ++i) {
-      for (int j = 0; j < 6; ++j) {
-        // partial: only write known columns 0..1 from full; zeros elsewhere
-        out << (i < 2 ? Hfull(i, j) : 0.0) << (j + 1 == 6 ? '\n' : ' ');
+    for (int i = 0; i < size; ++i) {
+      for (int j = 0; j < size; ++j) {
+        out << Hpart(i, j) << (j + 1 == size ? '\n' : ' ');
       }
     }
   }
+
   params.hessian_options.resume = true;
   params.hessian_options.checkpoint_path = ckpt;
   Hessian hessRes(params, matter.get());
@@ -140,10 +173,9 @@ TEST_CASE("Hessian column checkpoint resume matches full FD", "[hessian]") {
   REQUIRE(Hres.rows() == Hfull.rows());
   for (long i = 0; i < Hfull.rows(); ++i) {
     for (long j = 0; j < Hfull.cols(); ++j) {
-      REQUIRE_THAT(Hres(i, j), Catch::Matchers::WithinAbs(Hfull(i, j), 1e-8));
+      REQUIRE_THAT(Hres(i, j), Catch::Matchers::WithinAbs(Hfull(i, j), 1e-6));
     }
   }
-  // successful finish removes checkpoint
   REQUIRE(!std::ifstream(ckpt).good());
 }
 

--- a/docs/newsfragments/357.fixed.md
+++ b/docs/newsfragments/357.fixed.md
@@ -1,0 +1,4 @@
+HessianJob FD eigen solve: ColMajor copy for SelfAdjointEigenSolver (avoids
+RowMajor segfaults on partial VTST blocks), finite-force/index guards, optional
+`[Hessian] atom_list` intersected with free atoms, and a stable mobile VectorXi
+copy so moving-atom Hessians match PHVA-class active sets.

--- a/docs/source/user_guide/hessian.md
+++ b/docs/source/user_guide/hessian.md
@@ -21,52 +21,53 @@ atomic coordinates) is used for:
 
 ## How It Works
 
-eOn computes the Hessian numerically via central finite differences:
+eOn computes the Hessian numerically with a selectable finite-difference scheme
+on the **mobile** (displaced) atoms: non-fixed atoms in `pos.con`, optionally
+restricted by `[Hessian] atom_list` (comma-separated indices, or `All`). That
+list is the hybrid/PHVA-class *active set* — atoms that are moved in FD, not
+the frozen environment (Li & Jensen, *Theor. Chem. Acc.* **107**, 211, 2002).
 
-$$H_{ij} = \frac{F_i(x + \delta e_j) - F_i(x - \delta e_j)}{2\delta}$$
+Step size is `Main.finite_difference` (historically also called finite-difference
+displacement; default \(0.01\,\text{Å}\)).
 
-where $\delta$ is the finite difference step size (`min_displacement`). This
-requires $2 \times 3N$ gradient evaluations for $N$ atoms (or $2 \times 3N_\text{free}$
-if some atoms are frozen).
+### FD schemes (`[Hessian] fd_scheme`)
 
-The Hessian is then mass-weighted:
+**one_sided** (default) — forward difference, \(\sim M\) force evaluations for
+\(M = 3 N_\text{mobile}\) active DOF (plus one base gradient):
 
-$$\tilde{H}_{ij} = \frac{H_{ij}}{\sqrt{m_i m_j}}$$
+$$H_{ij} \approx -\frac{F_j(x + h e_i) - F_j(x)}{h}$$
 
-and diagonalized to obtain vibrational frequencies $\nu_k = \sqrt{\lambda_k} / (2\pi)$.
+**central** — central difference, \(\sim 2M\) force evaluations:
+
+$$H_{ij} \approx -\frac{F_j(x + h e_i) - F_j(x - h e_i)}{2h}$$
+
+One-sided is preferred for classical EAM AKMC cost; central reduces \(O(h)\) bias
+when validating prefactors. The assembled matrix is symmetrized \((H+H^T)/2\)
+before diagonalization. Mass-weighting uses \(\tilde H_{ij} = H_{ij}/\sqrt{m_i m_j}\).
+
+### Column resume
+
+Long partial Hessians can checkpoint FD columns to `checkpoint_path` (e.g.
+`hessian.ckpt`) with `resume = true`. Interrupted jobs continue from the next
+column; a successful run removes the checkpoint.
 
 ## Usage
-
-The Hessian job computes and reports the vibrational frequencies:
 
 ```{code-block} ini
 [Main]
 job = hessian
+finite_difference = 0.01
 
 [Hessian]
-min_displacement = 0.001
+atom_list = All
+fd_scheme = one_sided
+# fd_scheme = central
+# resume = true
+# checkpoint_path = hessian.ckpt
+zero_freq_value = 1e-6
 ```
 
-The output `results.dat` contains the eigenvalues (squared frequencies) of the
-mass-weighted Hessian matrix.
-
-## Configuration
-
-```{code-block} ini
-[Hessian]
-```
-
-```{eval-rst}
-.. autopydantic_model:: eon.schema.HessianConfig
-```
-
-## References
-
-```{bibliography}
----
-style: alpha
-filter: docname in docnames
-labelprefix: HESS_
-keyprefix: hess-
----
-```
+The output `results.dat` records force-call counts; `hessian.dat` holds the
+mass-weighted matrix when `quiet = false`. Eigenvalues (squared frequencies)
+are obtained by diagonalizing the symmetrized matrix (ColMajor eigen solve in
+the client).

--- a/eon/config.yaml
+++ b/eon/config.yaml
@@ -1050,6 +1050,18 @@ Hessian:
             kind: float
             default: 1e-6
 
+        fd_scheme:
+            kind: string
+            default: one_sided
+
+        resume:
+            kind: bool
+            default: false
+
+        checkpoint_path:
+            kind: string
+            default: ""
+
 ################################################################################
 
 Lanczos:

--- a/eon/schema.py
+++ b/eon/schema.py
@@ -1843,10 +1843,31 @@ class HessianConfig(BaseModel):
     model_config = ConfigDict(use_attribute_docstrings=True)
     atom_list: Union[str, list[int]] = Field(
         default="All",
-        description="The atoms that will be displaced in the calculation of the Hessian: a comma delimited list of atom indices, e.g. 0,1,2. Default is 'All'.",
+        description=(
+            "Mobile/displaced atoms for FD Hessian (hybrid/PHVA-class active set): "
+            "comma-delimited indices, e.g. 0,1,2, or 'All' for every non-fixed atom. "
+            "Intersects with free flags in pos.con."
+        ),
     )
     zero_freq_value: float = Field(
         default=1e-6, description="The value assigned to zero frequencies."
+    )
+    fd_scheme: Literal["one_sided", "central"] = Field(
+        default="one_sided",
+        description=(
+            "Finite-difference scheme for Hessian columns. one_sided uses F(x+h)-F(x) "
+            "(~3M force calls for M active DOF); central uses F(x+h)-F(x-h) (~6M). "
+            "Step size is Main.finite_difference. Default one_sided matches historical "
+            "eOn client behavior and is preferred for classical EAM VTST cost."
+        ),
+    )
+    resume: bool = Field(
+        default=False,
+        description="Resume FD columns from checkpoint_path if the file exists.",
+    )
+    checkpoint_path: str = Field(
+        default="",
+        description="Path for FD column checkpoint (e.g. hessian.ckpt). Removed on success.",
     )
 
 


### PR DESCRIPTION
## Summary
- Run `SelfAdjointEigenSolver` on a **ColMajor** copy of the FD Hessian. eOn's `MatrixXd` is **RowMajor** (atom-block layout); solving on RowMajor led to **segfaults** in `Hessian::calculate` during VTST partial Hessians (size ~42) on portable/terra eonclient builds, with amsel falling back to a Cu-typical frequency.
- Validate atom indices, finite forces/Hessian entries, and `Eigen::Success` before accepting frequencies (clean failure instead of abort).
- Honor optional `[Hessian] atom_list` (intersected with non-fixed atoms); no-op with `results.dat` force_calls only when no free atoms.
- Unit test: out-of-range atom list returns empty frequencies.

## Context
Observed on `rg.terra` lever smokes: `[Hessian] Hessian size: 42` then SIGSEGV in `eonc::Hessian::calculate` / `getFreqs` while amsel VTST requested eigenmodes. Minimization and ARTn LAMMPS paths were fine; only the Hessian eigen solve crashed.

## Test plan
- [ ] `client` unit tests: `HessianTest` (symmetric, finite eigenvalues, OOB indices)
- [ ] Manual: HessianJob on a partially frozen `pos.con` (VTST-style 10–20 free atoms) with LAMMPS/LJ — should write `hessian.dat` and exit 0
- [ ] Re-run amsel VTST path; prefer real eigenmodes over `cu_typical_fallback_invcm` when this lands