### PR TITLE
feat(dimer): rotation_backend lanczos/davidson replaces IDimerRot

### DIFF
--- a/client/Dimer.cpp
+++ b/client/Dimer.cpp
@@ -52,9 +52,8 @@ void Dimer::compute(std::shared_ptr<Matter> matter,
   const std::string &rotBackend = params.dimer_options.rotation_backend;
   if (rotBackend == "lanczos" || rotBackend == "davidson") {
     if (rotBackend == "lanczos") {
-      QUILL_LOG_INFO(log,
-                     "[DimerRot] rotation_backend=lanczos (FD min-mode; "
-                     "skipping classical constrained rotation loop)");
+      QUILL_LOG_INFO(log, "[DimerRot] rotation_backend=lanczos (FD min-mode; "
+                          "skipping classical constrained rotation loop)");
       Lanczos solver(matter, params, pot);
       solver.compute(matter, direction);
       eigenvalue = solver.getEigenvalue();
@@ -62,9 +61,8 @@ void Dimer::compute(std::shared_ptr<Matter> matter,
       totalForceCalls += solver.totalForceCalls;
       statsRotations = solver.statsRotations;
     } else {
-      QUILL_LOG_INFO(log,
-                     "[DimerRot] rotation_backend=davidson (FD min-mode; "
-                     "skipping classical constrained rotation loop)");
+      QUILL_LOG_INFO(log, "[DimerRot] rotation_backend=davidson (FD min-mode; "
+                          "skipping classical constrained rotation loop)");
       Davidson solver(matter, params, pot);
       solver.compute(matter, direction);
       eigenvalue = solver.getEigenvalue();

--- a/client/Dimer.cpp
+++ b/client/Dimer.cpp
@@ -10,7 +10,9 @@
 ** https://github.com/TheochemUI/eOn
 */
 #include "Dimer.h"
+#include "Davidson.h"
 #include "HelperFunctions.h"
+#include "Lanczos.h"
 #include "SafeMath.h"
 
 #include <cassert>
@@ -43,6 +45,40 @@ void Dimer::compute(std::shared_ptr<Matter> matter,
                     AtomMatrix initialDirection) {
   *matterCenter = *matter;
 
+  eonc::safemath::safe_normalize_inplace(initialDirection);
+  direction = initialDirection;
+
+  // Optional: replace classical torque rotation with FD min-mode finder.
+  const std::string &rotBackend = params.dimer_options.rotation_backend;
+  if (rotBackend == "lanczos" || rotBackend == "davidson") {
+    if (rotBackend == "lanczos") {
+      QUILL_LOG_INFO(log,
+                     "[DimerRot] rotation_backend=lanczos (FD min-mode; "
+                     "skipping classical constrained rotation loop)");
+      Lanczos solver(matter, params, pot);
+      solver.compute(matter, direction);
+      eigenvalue = solver.getEigenvalue();
+      direction = solver.getEigenvector();
+      totalForceCalls += solver.totalForceCalls;
+      statsRotations = solver.statsRotations;
+    } else {
+      QUILL_LOG_INFO(log,
+                     "[DimerRot] rotation_backend=davidson (FD min-mode; "
+                     "skipping classical constrained rotation loop)");
+      Davidson solver(matter, params, pot);
+      solver.compute(matter, direction);
+      eigenvalue = solver.getEigenvalue();
+      direction = solver.getEigenvector();
+      totalForceCalls += solver.totalForceCalls;
+      statsRotations = solver.statsRotations;
+    }
+    eonc::safemath::safe_normalize_inplace(direction);
+    *matterCenter = *matter;
+    QUILL_LOG_INFO(log, "[DimerRot] hybrid mode estimate eigenvalue={:.6f}",
+                   eigenvalue);
+    return;
+  }
+
   long rotations = 0;
   long forceCallsCenter = matterCenter->getForceCalls();
   long forceCallsDimer = matterDimer->getForceCalls();
@@ -57,8 +93,6 @@ void Dimer::compute(std::shared_ptr<Matter> matter,
   rotationalForceOld.setZero();
   rotationalPlaneOld.setZero();
 
-  eonc::safemath::safe_normalize_inplace(initialDirection);
-  direction = initialDirection;
   statsAngle = 0;
   double lengthRotationalForceOld = 0.0;
 

--- a/client/ImprovedDimer.cpp
+++ b/client/ImprovedDimer.cpp
@@ -109,9 +109,8 @@ void ImprovedDimer::compute(std::shared_ptr<Matter> matter,
     AtomMatrix initMode =
         AtomMatrix::Map(tau.data(), matter->numberOfAtoms(), 3);
     if (rotBackend == "lanczos") {
-      QUILL_LOG_INFO(log,
-                     "[IDimerRot] rotation_backend=lanczos (FD min-mode; "
-                     "skipping classical constrained rotation loop)");
+      QUILL_LOG_INFO(log, "[IDimerRot] rotation_backend=lanczos (FD min-mode; "
+                          "skipping classical constrained rotation loop)");
       Lanczos solver(matter, params, pot);
       solver.compute(matter, initMode);
       C_tau = solver.getEigenvalue();
@@ -120,9 +119,8 @@ void ImprovedDimer::compute(std::shared_ptr<Matter> matter,
       totalForceCalls += solver.totalForceCalls;
       statsRotations = solver.statsRotations;
     } else {
-      QUILL_LOG_INFO(log,
-                     "[IDimerRot] rotation_backend=davidson (FD min-mode; "
-                     "skipping classical constrained rotation loop)");
+      QUILL_LOG_INFO(log, "[IDimerRot] rotation_backend=davidson (FD min-mode; "
+                          "skipping classical constrained rotation loop)");
       Davidson solver(matter, params, pot);
       solver.compute(matter, initMode);
       C_tau = solver.getEigenvalue();

--- a/client/ImprovedDimer.cpp
+++ b/client/ImprovedDimer.cpp
@@ -13,7 +13,9 @@
 // An attempt to keep to the variable names in their 2008 paper has been made.
 
 #include "ImprovedDimer.h"
+#include "Davidson.h"
 #include "HelperFunctions.h"
+#include "Lanczos.h"
 #include "LowestEigenmode.h"
 #include "SafeMath.h"
 #include "eonExceptions.hpp"
@@ -99,6 +101,50 @@ void ImprovedDimer::compute(std::shared_ptr<Matter> matter,
     x1->setPositionsV(x0_r + delta * tau);
     QUILL_LOG_DEBUG(
         log, "[IDimer] Initial tangent flipped due to high energy wall.");
+  }
+
+  // Optional: replace constrained rotation (IDimerRot) with FD min-mode finder.
+  const std::string &rotBackend = params.dimer_options.rotation_backend;
+  if (rotBackend == "lanczos" || rotBackend == "davidson") {
+    AtomMatrix initMode =
+        AtomMatrix::Map(tau.data(), matter->numberOfAtoms(), 3);
+    if (rotBackend == "lanczos") {
+      QUILL_LOG_INFO(log,
+                     "[IDimerRot] rotation_backend=lanczos (FD min-mode; "
+                     "skipping classical constrained rotation loop)");
+      Lanczos solver(matter, params, pot);
+      solver.compute(matter, initMode);
+      C_tau = solver.getEigenvalue();
+      AtomMatrix ev = solver.getEigenvector();
+      tau = VectorXd::Map(ev.data(), 3 * matter->numberOfAtoms());
+      totalForceCalls += solver.totalForceCalls;
+      statsRotations = solver.statsRotations;
+    } else {
+      QUILL_LOG_INFO(log,
+                     "[IDimerRot] rotation_backend=davidson (FD min-mode; "
+                     "skipping classical constrained rotation loop)");
+      Davidson solver(matter, params, pot);
+      solver.compute(matter, initMode);
+      C_tau = solver.getEigenvalue();
+      AtomMatrix ev = solver.getEigenvector();
+      tau = VectorXd::Map(ev.data(), 3 * matter->numberOfAtoms());
+      totalForceCalls += solver.totalForceCalls;
+      statsRotations = solver.statsRotations;
+    }
+    tau = tau.array() * matter->getFreeV().array();
+    if (tau.norm() > 1e-10) {
+      tau.normalize();
+    }
+    x0_r = matter->getPositionsV();
+    x0->setPositionsV(x0_r);
+    x1->setPositionsV(x0_r + delta * tau);
+    *matter = *x0;
+    rotationDidConverge = true;
+    foundNegativeCurvature = (C_tau < 0.0);
+    QUILL_LOG_INFO(log,
+                   "[IDimerRot] hybrid mode estimate C_tau={:.6f} backend={}",
+                   C_tau, rotBackend);
+    return;
   }
 
   if (params.dimer_options.opt_method == OPT_LBFGS) {

--- a/client/Parameters.h
+++ b/client/Parameters.h
@@ -228,6 +228,9 @@ public:
     double torque_max{1.0};
     double torque_min{0.1};
     bool remove_rotation{false};
+    // Mode estimation for dimer: classical rotation loop, or FD min-mode
+    // (Lanczos/Davidson) replacing constrained IDimerRot / Dimer::rotate.
+    std::string rotation_backend{"classical"}; // classical | lanczos | davidson
   } dimer_options;
 
   // [GPR Dimer] //

--- a/client/ParametersINI.cpp
+++ b/client/ParametersINI.cpp
@@ -363,6 +363,8 @@ int load_ini(INIReader &ini, Parameters &params) {
       ini.GetReal("Dimer", "torque_max", params.dimer_options.torque_max);
   params.dimer_options.remove_rotation = ini.GetBoolean(
       "Dimer", "remove_rotation", params.dimer_options.remove_rotation);
+  params.dimer_options.rotation_backend = toLowerCase(ini.Get(
+      "Dimer", "rotation_backend", params.dimer_options.rotation_backend));
 
   // GP Surrogate Parameters
   params.gp_surrogate_options.enabled =

--- a/docs/newsfragments/+dimer-rotation-backend.added.md
+++ b/docs/newsfragments/+dimer-rotation-backend.added.md
@@ -1,0 +1,1 @@
+Dimer supports `rotation_backend = classical|lanczos|davidson` so FD min-mode (Lanczos/Davidson) can replace constrained rotation while keeping dimer climb.

--- a/eon/config.yaml
+++ b/eon/config.yaml
@@ -552,6 +552,10 @@ Dimer:
             kind: boolean
             default: True
 
+        rotation_backend:
+            kind: string
+            default: classical
+
         remove_rotation:
             kind: boolean
             default: False

--- a/eon/schema.py
+++ b/eon/schema.py
@@ -1536,6 +1536,10 @@ class DimerConfig(BaseModel):
     dimer_remove_rotation: bool = Field(
         default=False, description="Indicates if the rotation should be removed."
     )
+    rotation_backend: Literal["classical", "lanczos", "davidson"] = Field(
+        default="classical",
+        description="Mode estimation under dimer: classical constrained rotation, or lanczos/davidson FD min-mode replacing IDimerRot.",
+    )
     """
     Implements the method of :cite:t:`dm-melanderRemovingExternalDegrees2015`
     """


### PR DESCRIPTION
Optional [Dimer] rotation_backend replaces IDimerRot with Lanczos/Davidson FD min-mode. OptBench evidence on rg.terra Pt_Heptamer_FrozenLayers N=20: hybrid+L slight mean win vs classical; hybrid+D costs more; standalone L cheapest. Default classical.