### PR TITLE
feat(client): RgpotPot — rgpot potserv client (NWChem/CPMD)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = []

--- a/client/BaseStructures.h
+++ b/client/BaseStructures.h
@@ -71,7 +71,8 @@ enum class PotType {
   ASE_NWCHEM,
   METATOMIC,
   ZBL,
-  SocketNWChem
+  SocketNWChem,
+  RGPOT
 };
 
 enum class JobType {

--- a/client/Parameters.h
+++ b/client/Parameters.h
@@ -120,6 +120,27 @@ public:
     bool make_template_input{true};
   } socket_nwchem_options;
 
+  // [RgpotPot] — in-process rgpot NWChemPot / CPMDPot (dlopen engines; no
+  // potserv)
+  struct rgpot_options_t {
+    /// "nwchemc" or "cpmdc" (also accepts nwchem / cpmd / NWChem / CPMD)
+    std::string backend{"nwchemc"};
+    std::string basis{"sto-3g"};
+    std::string theory{"scf"};
+    std::string scf_type{"rhf"};
+    std::string functional{"BLYP"};
+    double cutoff_ry{70.0};
+    int charge{0};
+    int multiplicity{1};
+    std::string engine_path{};
+    std::string engine_library{};
+    std::string engine_root{};
+    std::string title{};
+    int memory_mb{0};
+    std::string scratch_dir{};
+    std::string input_block{};
+  } rgpot_options;
+
   // [Structure Comparison] //
   struct structure_comparison_options_t {
     double distance_difference{0.1};

--- a/client/ParametersINI.cpp
+++ b/client/ParametersINI.cpp
@@ -191,6 +191,50 @@ int load_ini(INIReader &ini, Parameters &params) {
                        params.socket_nwchem_options.make_template_input);
   }
 
+  // [RgpotPot] — in-process NWChemPot/CPMDPot (also accept legacy [RGPot] keys)
+  if (params.potential_options.potential == PotType::RGPOT) {
+    const char *sec = "RgpotPot";
+    // Prefer [RgpotPot]; fall back to [RGPot] field names used by direct-link
+    // design
+    params.rgpot_options.backend =
+        ini.Get(sec, "backend", params.rgpot_options.backend);
+    params.rgpot_options.basis = ini.Get(
+        sec, "basis", ini.Get(sec, "nwchem_basis", params.rgpot_options.basis));
+    params.rgpot_options.theory =
+        ini.Get(sec, "theory",
+                ini.Get(sec, "nwchem_theory", params.rgpot_options.theory));
+    params.rgpot_options.scf_type =
+        ini.Get(sec, "scf_type",
+                ini.Get(sec, "nwchem_scf_type", params.rgpot_options.scf_type));
+    params.rgpot_options.functional = ini.Get(
+        sec, "functional",
+        ini.Get(sec, "cpmd_functional", params.rgpot_options.functional));
+    params.rgpot_options.cutoff_ry = ini.GetReal(
+        sec, "cutoff_ry",
+        ini.GetReal(sec, "cpmd_cut_off_ry", params.rgpot_options.cutoff_ry));
+    params.rgpot_options.charge = ini.GetInteger(
+        sec, "charge",
+        ini.GetInteger(sec, "nwchem_charge", params.rgpot_options.charge));
+    params.rgpot_options.multiplicity =
+        ini.GetInteger(sec, "multiplicity",
+                       ini.GetInteger(sec, "nwchem_multiplicity",
+                                      params.rgpot_options.multiplicity));
+    params.rgpot_options.engine_path =
+        ini.Get(sec, "engine_path", params.rgpot_options.engine_path);
+    params.rgpot_options.engine_library =
+        ini.Get(sec, "engine_library", params.rgpot_options.engine_library);
+    params.rgpot_options.engine_root =
+        ini.Get(sec, "engine_root", params.rgpot_options.engine_root);
+    params.rgpot_options.title =
+        ini.Get(sec, "title", params.rgpot_options.title);
+    params.rgpot_options.memory_mb =
+        ini.GetInteger(sec, "memory_mb", params.rgpot_options.memory_mb);
+    params.rgpot_options.scratch_dir =
+        ini.Get(sec, "scratch_dir", params.rgpot_options.scratch_dir);
+    params.rgpot_options.input_block =
+        ini.Get(sec, "input_block", params.rgpot_options.input_block);
+  }
+
   // [Debug] //
 
   params.debug_options.write_movies = ini.GetBoolean(

--- a/client/Potential.cpp
+++ b/client/Potential.cpp
@@ -38,6 +38,9 @@
 #include "potentials/Morse/Morse.h"
 #ifndef IS_WINDOWS
 #include "potentials/SocketNWChem/SocketNWChemPot.h"
+#ifdef WITH_RGPOT
+#include "potentials/Rgpot/RgpotPot.h"
+#endif
 #endif
 #include "potentials/ZBL/ZBLPot.h"
 
@@ -323,6 +326,12 @@ std::shared_ptr<Potential> makePotential(PotType ptype,
 #ifndef IS_WINDOWS
   case PotType::SocketNWChem: {
     return (std::make_shared<SocketNWChemPot>(params));
+    break;
+  }
+#endif
+#ifdef WITH_RGPOT
+  case PotType::RGPOT: {
+    return (std::make_shared<RgpotPot>(params));
     break;
   }
 #endif

--- a/client/meson.build
+++ b/client/meson.build
@@ -178,6 +178,7 @@ features_list = [
     ['WITH_ASE_NWCHEM', 'ASE-NWChem'],
     ['WITH_METATOMIC', 'Metatomic'],
     ['WITH_SERVE_MODE', 'Serve Mode'],
+    ['WITH_RGPOT', 'RGPOT direct in-process (NWChemPot/CPMDPot dlopen)'],
     ['EMBED_PYTHON', 'Embedded Python'],
 ]
 
@@ -317,6 +318,33 @@ if not is_windows
 endif
 subdir('potentials/NewPot')
 
+# rgpot roles (see docs/user_guide/rgpot_integration.md):
+#   with_rgpot  -> nwchempot_dep + cpmdpot_dep (direct dlopen engines in eOn)
+#   with_serve  -> ptlrpc_dep (eOn is Cap'n Proto RPC server)
+# potserv RPC *client* is not wired as an eOn Potential.
+_rgpot_proj = []
+ptlrpc_dep = disabler()
+if get_option('with_rgpot') or get_option('with_serve')
+    rgpot_opts = {
+        'with_rpc_client_only': true,
+        'pure_lib': true,
+        'with_tests': false,
+        'with_examples': false,
+    }
+    _rgpot_proj = subproject('rgpot', default_options: rgpot_opts)
+endif
+if get_option('with_serve')
+    serve_capnp_dep = dependency('capnp-rpc', required: true)
+    ptlrpc_dep = _rgpot_proj.get_variable('ptlrpc_dep')
+endif
+if get_option('with_rgpot') and not is_windows
+    nwchempot_dep = _rgpot_proj.get_variable('nwchempot_dep')
+    cpmdpot_dep = _rgpot_proj.get_variable('cpmdpot_dep')
+    _deps += [nwchempot_dep, cpmdpot_dep]
+    _args += ['-DWITH_RGPOT']
+    subdir('potentials/Rgpot')
+endif
+
 potentials = [
     eam,
     emt,
@@ -330,6 +358,9 @@ potentials = [
 ]
 if not is_windows
     potentials += [socket_nwchem]
+endif
+if get_option('with_rgpot') and not is_windows
+    potentials += [rgpot_pot]
 endif
 
 eonclib_sources = [
@@ -859,19 +890,10 @@ if get_option('with_ira')
 endif
 
 if get_option('with_serve')
-    # rgpot-compatible RPC serve mode: wraps any eOn potential and serves it
-    # over Cap'n Proto RPC using the rgpot Potentials.capnp schema.
-    # Only links capnp-rpc and the generated schema (ptlrpc); does NOT link
-    # rgpot types to avoid the AtomMatrix name collision with eOn's Eigen.h.
-    serve_capnp_dep = dependency('capnp-rpc', required: true)
-    rgpot_serve_opts = {
-        'with_rpc_client_only': true,
-        'pure_lib': true,
-        'with_tests': false,
-        'with_examples': false,
-    }
-    rgpot_proj = subproject('rgpot', default_options: rgpot_serve_opts)
-    ptlrpc_dep = rgpot_proj.get_variable('ptlrpc_dep')
+    # eOn as rgpot-compatible RPC *server* (clients connect to eOn; not potserv client).
+    if ptlrpc_dep.found() == false
+        error('with_serve requires Cap\'n Proto / rgpot ptlrpc_dep')
+    endif
     _args += ['-DWITH_SERVE_MODE']
     eonclib_sources += ['ServeMode.cpp', 'ServeRpcServer.cpp']
     _deps += [serve_capnp_dep, ptlrpc_dep]
@@ -1108,6 +1130,27 @@ if get_option('with_tests')
         )
     else
         message('NWChem executable not found, skipping SocketNWChemPotTest.')
+    endif
+
+    if get_option('with_rgpot') and not is_windows
+        test_rgpot_exe = executable(
+            'test_rgpot_pot',
+            sources: [
+                'unit_tests/RgpotPotTest.cpp',
+                'thirdparty/catch2/catch_amalgamated.cpp',
+            ],
+            dependencies: test_deps,
+            include_directories: _incdirs,
+            cpp_args: test_args,
+            link_with: _linkto,
+        )
+        test(
+            'test_rgpot_pot',
+            test_rgpot_exe,
+            timeout: 120,
+            suite: 'rgpot',
+            is_parallel: false,
+        )
     endif
 
     # Benchmarks (not in default test suite -- run via: meson test --benchmark)

--- a/client/potentials/Rgpot/RGPotEngine.cpp
+++ b/client/potentials/Rgpot/RGPotEngine.cpp
@@ -1,0 +1,179 @@
+// Isolated TU: rgpot only (no eOn Potential.h) — avoids Cap'n Proto Potential
+// clash.
+#include "RGPotEngine.h"
+
+#include <array>
+#include <cctype>
+#include <cstdint>
+#include <cstdlib>
+#include <stdexcept>
+#include <vector>
+
+#include <capnp/message.h>
+
+#include "rgpot/CPMDPot/CPMDPot.hpp"
+#include "rgpot/NWChemPot/NWChemPot.hpp"
+#include "rgpot/rpc/Potentials.capnp.h"
+
+namespace {
+
+std::string to_lower(std::string s) {
+  for (char &c : s)
+    c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+  return s;
+}
+
+std::array<std::array<double, 3>, 3> box_from_row_major(const double *box) {
+  std::array<std::array<double, 3>, 3> out{};
+  for (int i = 0; i < 3; ++i)
+    for (int j = 0; j < 3; ++j)
+      out[static_cast<size_t>(i)][static_cast<size_t>(j)] = box[i * 3 + j];
+  return out;
+}
+
+bool looks_like_dft_xc(const std::string &s) {
+  if (s.empty())
+    return false;
+  static const char *k[] = {"b3lyp", "blyp", "pbe",    "pw91",    "bp86",
+                            "hcth",  "ft97", "hfexch", "xperpbe", nullptr};
+  for (int i = 0; k[i]; ++i) {
+    if (s.size() >= std::char_traits<char>::length(k[i]) &&
+        s.compare(0, std::char_traits<char>::length(k[i]), k[i]) == 0)
+      return true;
+  }
+  return false;
+}
+
+} // namespace
+
+struct RGPotEngine::Impl {
+  enum class Backend { Nwchemc, Cpmdc };
+  Backend backend{Backend::Nwchemc};
+  std::unique_ptr<rgpot::NWChemPot> nwchem;
+  std::unique_ptr<rgpot::CPMDPot> cpmd;
+};
+
+RGPotEngine::RGPotEngine(const RGPotEngineOptions &opt)
+    : impl_(std::make_unique<Impl>()) {
+  backend_ = to_lower(opt.backend);
+  if (backend_ == "nwchem" || backend_ == "nwchemc" ||
+      backend_ == "nwchempot") {
+    backend_ = "nwchemc";
+    impl_->backend = Impl::Backend::Nwchemc;
+    ::capnp::MallocMessageBuilder msg;
+    auto params = msg.initRoot<::NWChemParams>();
+    params.setBasis(opt.basis);
+    params.setTheory(opt.theory);
+    params.setScfType(opt.scf_type);
+    params.setCharge(opt.charge);
+    params.setMultiplicity(opt.multiplicity);
+    if (!opt.engine_path.empty())
+      params.setEnginePath(opt.engine_path);
+    else if (!opt.engine_library.empty())
+      params.setEnginePath(opt.engine_library);
+    if (!opt.engine_root.empty())
+      params.setNwchemRoot(opt.engine_root);
+    if (!opt.title.empty())
+      params.setTitle(opt.title);
+    if (opt.memory_mb > 0)
+      params.setMemoryMb(static_cast<uint32_t>(opt.memory_mb));
+    if (!opt.scratch_dir.empty())
+      params.setScratchDir(opt.scratch_dir);
+    // DFT XC as inputBlocks when theory=dft and scfType is an XC label
+    std::string block = opt.input_block;
+    if (block.empty()) {
+      if (const char *env = std::getenv("RGPOT_NWCHEM_INPUT_BLOCK"))
+        block = env;
+    }
+    if (block.empty() && (opt.theory == "dft" || opt.theory == "DFT") &&
+        looks_like_dft_xc(opt.scf_type)) {
+      block = "dft\n  xc " + opt.scf_type + "\n  mult " +
+              std::to_string(opt.multiplicity) + "\nend";
+    } else if (block.empty() && looks_like_dft_xc(opt.theory)) {
+      block = "dft\n  xc " + opt.theory + "\n  mult " +
+              std::to_string(opt.multiplicity) + "\nend";
+    }
+    if (!block.empty()) {
+      auto blocks = params.initInputBlocks(1);
+      blocks.set(0, block);
+    }
+    impl_->nwchem = std::make_unique<rgpot::NWChemPot>(params.asReader());
+    if (!impl_->nwchem->available())
+      throw std::runtime_error(
+          "RGPOT(nwchemc): engine not available (set NWCHEMC_LIBRARY / "
+          "RGPOT_NWCHEMC_ENGINE or [RgpotPot] engine_path)");
+  } else if (backend_ == "cpmd" || backend_ == "cpmdc" ||
+             backend_ == "cpmdpot") {
+    backend_ = "cpmdc";
+    impl_->backend = Impl::Backend::Cpmdc;
+    ::capnp::MallocMessageBuilder msg;
+    auto params = msg.initRoot<::CPMDParams>();
+    params.setFunctional(opt.functional);
+    params.setCutOffRy(opt.cutoff_ry);
+    params.setCharge(opt.charge);
+    params.setMultiplicity(opt.multiplicity);
+    if (!opt.engine_path.empty())
+      params.setEnginePath(opt.engine_path);
+    else if (!opt.engine_library.empty())
+      params.setEnginePath(opt.engine_library);
+    if (!opt.engine_root.empty())
+      params.setCpmdRoot(opt.engine_root);
+    if (!opt.title.empty())
+      params.setTitle(opt.title);
+    if (opt.memory_mb > 0)
+      params.setMemoryMb(static_cast<uint32_t>(opt.memory_mb));
+    if (!opt.scratch_dir.empty())
+      params.setScratchDir(opt.scratch_dir);
+    impl_->cpmd = std::make_unique<rgpot::CPMDPot>(params.asReader());
+    if (!impl_->cpmd->available())
+      throw std::runtime_error(
+          "RGPOT(cpmdc): engine not available (set CPMDC_LIBRARY / "
+          "RGPOT_CPMDC_ENGINE or [RgpotPot] engine_path)");
+  } else {
+    throw std::runtime_error("RGPOT: unknown backend '" + opt.backend +
+                             "' (expected nwchemc or cpmdc)");
+  }
+}
+
+RGPotEngine::~RGPotEngine() = default;
+
+bool RGPotEngine::available() const {
+  if (!impl_)
+    return false;
+  if (impl_->backend == Impl::Backend::Nwchemc && impl_->nwchem)
+    return impl_->nwchem->available();
+  if (impl_->backend == Impl::Backend::Cpmdc && impl_->cpmd)
+    return impl_->cpmd->available();
+  return false;
+}
+
+void RGPotEngine::force(long N, const double *R, const int *atomicNrs,
+                        double *F, double *U, const double *box) const {
+  if (N <= 0)
+    throw std::runtime_error("RGPotEngine::force called with N <= 0");
+
+  AtomMatrix positions(static_cast<int>(N), 3);
+  for (long i = 0; i < N; ++i) {
+    const int ii = static_cast<int>(i);
+    positions(ii, 0) = R[3 * i + 0];
+    positions(ii, 1) = R[3 * i + 1];
+    positions(ii, 2) = R[3 * i + 2];
+  }
+  std::vector<int> atmtypes(atomicNrs, atomicNrs + N);
+  const auto cell = box_from_row_major(box);
+
+  std::pair<double, AtomMatrix> result;
+  if (impl_->backend == Impl::Backend::Nwchemc)
+    result = (*impl_->nwchem)(positions, atmtypes, cell);
+  else
+    result = (*impl_->cpmd)(positions, atmtypes, cell);
+
+  *U = result.first;
+  const auto &forces = result.second;
+  for (long i = 0; i < N; ++i) {
+    const int ii = static_cast<int>(i);
+    F[3 * i + 0] = forces(ii, 0);
+    F[3 * i + 1] = forces(ii, 1);
+    F[3 * i + 2] = forces(ii, 2);
+  }
+}

--- a/client/potentials/Rgpot/RGPotEngine.h
+++ b/client/potentials/Rgpot/RGPotEngine.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+struct RGPotEngineOptions {
+  std::string backend;
+  std::string basis{"sto-3g"};
+  std::string theory{"scf"};
+  std::string scf_type{"rhf"};
+  std::string functional{"BLYP"};
+  double cutoff_ry{70.0};
+  int charge{0};
+  int multiplicity{1};
+  std::string engine_path;
+  std::string engine_library;
+  std::string engine_root;
+  std::string title;
+  int memory_mb{0};
+  std::string scratch_dir;
+  std::string input_block; // optional NWChem inputBlocks text
+};
+
+/** Opaque rgpot-backed engine (nwchemc / cpmdc). No eOn Potential.h here. */
+class RGPotEngine {
+public:
+  explicit RGPotEngine(const RGPotEngineOptions &opt);
+  ~RGPotEngine();
+  RGPotEngine(const RGPotEngine &) = delete;
+  RGPotEngine &operator=(const RGPotEngine &) = delete;
+
+  [[nodiscard]] const std::string &backend() const noexcept { return backend_; }
+  [[nodiscard]] bool available() const;
+  void force(long N, const double *R, const int *atomicNrs, double *F,
+             double *U, const double *box) const;
+
+private:
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+  std::string backend_;
+};

--- a/client/potentials/Rgpot/RgpotPot.cpp
+++ b/client/potentials/Rgpot/RgpotPot.cpp
@@ -1,0 +1,58 @@
+/*
+** This file is part of eOn.
+*/
+#include "RgpotPot.h"
+#include "RGPotEngine.h"
+
+#include <cstdlib>
+#include <iostream>
+
+RgpotPot::RgpotPot(const Parameters &p)
+    : Potential(PotType::RGPOT, p) {
+  RGPotEngineOptions opt;
+  const auto &o = p.rgpot_options;
+  opt.backend = o.backend;
+  opt.basis = o.basis;
+  opt.theory = o.theory;
+  opt.scf_type = o.scf_type;
+  opt.functional = o.functional;
+  opt.cutoff_ry = o.cutoff_ry;
+  opt.charge = o.charge;
+  opt.multiplicity = o.multiplicity;
+  opt.engine_path = o.engine_path;
+  opt.engine_library = o.engine_library;
+  opt.engine_root = o.engine_root;
+  opt.title = o.title;
+  opt.memory_mb = o.memory_mb;
+  opt.scratch_dir = o.scratch_dir;
+  opt.input_block = o.input_block;
+
+  // Env overrides (CI / benchmarks)
+  if (const char *e = std::getenv("RGPOT_BACKEND"))
+    opt.backend = e;
+  if (const char *e = std::getenv("RGPOT_NWCHEM_BASIS"))
+    opt.basis = e;
+  if (const char *e = std::getenv("RGPOT_NWCHEM_THEORY"))
+    opt.theory = e;
+  if (const char *e = std::getenv("RGPOT_NWCHEM_SCF_TYPE"))
+    opt.scf_type = e;
+  if (const char *e = std::getenv("NWCHEMC_LIBRARY"))
+    opt.engine_path = e;
+  else if (const char *e = std::getenv("RGPOT_NWCHEMC_ENGINE"))
+    opt.engine_path = e;
+
+  impl_ = std::make_unique<RGPotEngine>(opt);
+  backend_ = impl_->backend();
+  std::cout << "RgpotPot: in-process rgpot backend=" << backend_
+            << " (dlopen libnwchemc/libcpmdc, no potserv RPC)" << std::endl;
+}
+
+RgpotPot::~RgpotPot() = default;
+
+bool RgpotPot::engineAvailable() const { return impl_ && impl_->available(); }
+
+void RgpotPot::force(long N, const double *R, const int *atomicNrs, double *F,
+                     double *U, double *variance, const double *box) {
+  (void)variance;
+  impl_->force(N, R, atomicNrs, F, U, box);
+}

--- a/client/potentials/Rgpot/RgpotPot.h
+++ b/client/potentials/Rgpot/RgpotPot.h
@@ -1,0 +1,43 @@
+/*
+** This file is part of eOn.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Copyright (c) 2010--present, eOn Development Team
+** All rights reserved.
+**
+** Repo:
+** https://github.com/TheochemUI/eOn
+*/
+#pragma once
+
+#include "../../Potential.h"
+#include <memory>
+#include <string>
+
+class RGPotEngine;
+
+/**
+ * Potential backed by rgpot NWChemPot / CPMDPot (in-process dlopen of
+ * libnwchemc / libcpmdc). Not potserv RPC. Configure via [RgpotPot] INI;
+ * energy eV, forces eV/Angstrom.
+ */
+class RgpotPot final : public Potential {
+public:
+  explicit RgpotPot(const Parameters &p);
+  ~RgpotPot() override;
+
+  RgpotPot(const RgpotPot &) = delete;
+  RgpotPot &operator=(const RgpotPot &) = delete;
+
+  void force(long N, const double *R, const int *atomicNrs, double *F,
+             double *U, double *variance, const double *box) override;
+
+  [[nodiscard]] bool isThreadSafe() const noexcept override { return false; }
+  [[nodiscard]] const std::string &backend() const noexcept { return backend_; }
+  [[nodiscard]] bool engineAvailable() const;
+
+private:
+  std::unique_ptr<RGPotEngine> impl_;
+  std::string backend_;
+};

--- a/client/potentials/Rgpot/meson.build
+++ b/client/potentials/Rgpot/meson.build
@@ -1,0 +1,8 @@
+rgpot_pot = library(
+    'rgpot_pot',
+    sources: ['RgpotPot.cpp', 'RGPotEngine.cpp'],
+    include_directories: _incdirs,
+    dependencies: _deps,
+    link_with: _linkto,
+    install: true,
+)

--- a/client/unit_tests/RgpotPotTest.cpp
+++ b/client/unit_tests/RgpotPotTest.cpp
@@ -1,0 +1,67 @@
+#include "../MatrixHelpers.hpp"
+#include "Matter.h"
+#include "catch2/catch_amalgamated.hpp"
+#include <cmath>
+#include <cstdlib>
+#include <memory>
+
+using namespace Catch::Matchers;
+
+namespace tests {
+
+namespace {
+
+bool env_nonempty(const char *name) {
+  const char *v = std::getenv(name);
+  return v != nullptr && v[0] != '\0';
+}
+
+} // namespace
+
+TEST_CASE("RgpotPot in-process nwchemc force (no potserv)",
+          "[PotTest][RGPOT][nwchemc]") {
+#ifndef WITH_RGPOT
+  SKIP("built without WITH_RGPOT");
+#else
+  REQUIRE(env_nonempty("NWCHEMC_LIBRARY") ||
+          env_nonempty("RGPOT_NWCHEMC_ENGINE") ||
+          env_nonempty("RGPOT_NWCHEM_ENGINE"));
+
+  Parameters params{};
+  params.potential_options.potential = PotType::RGPOT;
+  params.rgpot_options.backend = "nwchemc";
+  params.rgpot_options.basis = "sto-3g";
+  params.rgpot_options.theory = "scf";
+  params.rgpot_options.scf_type = "rhf";
+  params.rgpot_options.charge = 0;
+  params.rgpot_options.multiplicity = 1;
+
+  auto pot =
+      eonc::helpers::makePotential(params.potential_options.potential, params);
+  REQUIRE(pot != nullptr);
+  REQUIRE(pot->getType() == PotType::RGPOT);
+
+  auto matter = std::make_shared<Matter>(pot, params);
+  REQUIRE(matter->con2matter("pos.con"));
+  REQUIRE(matter->numberOfAtoms() == 9);
+
+  double energy = 0.0;
+  AtomMatrix forces = MatrixXd::Zero(matter->numberOfAtoms(), 3);
+  pot->force(matter->numberOfAtoms(), matter->getPositions().data(),
+             matter->getAtomicNrs().data(), forces.data(), &energy, nullptr,
+             matter->getCell().data());
+
+  REQUIRE(std::isfinite(energy));
+  REQUIRE(std::abs(energy) > 1e-6);
+
+  // Two successive forces must both succeed (warm multi-call path)
+  double energy2 = 0.0;
+  pot->force(matter->numberOfAtoms(), matter->getPositions().data(),
+             matter->getAtomicNrs().data(), forces.data(), &energy2, nullptr,
+             matter->getCell().data());
+  REQUIRE(std::isfinite(energy2));
+  REQUIRE(std::abs(energy - energy2) < 1e-4);
+#endif
+}
+
+} // namespace tests

--- a/docs/newsfragments/+rgpot-potential.added.md
+++ b/docs/newsfragments/+rgpot-potential.added.md
@@ -1,0 +1,1 @@
+In-process RgpotPot for NWChem/CPMD via rgpot (optional build); user guide and examples for BLYP/DFT XC blocks.

--- a/docs/source/install/index.md
+++ b/docs/source/install/index.md
@@ -31,7 +31,9 @@ features enabled:
 
 - [Metatomic](project:../user_guide/metatomic_pot.md) (machine-learned potentials via libtorch)
 - [xTB](https://xtb-docs.readthedocs.io/) (semi-empirical tight-binding)
-- [Serve mode](project:../user_guide/serve_mode.md) (rgpot-compatible RPC server)
+- [rgpot integration](project:../user_guide/rgpot_integration.md) (direct dlopen vs serve vs potserv client)
+- [RgpotPot / RGPOT](project:../user_guide/rgpot_pot.md) (`-Dwith_rgpot`: in-process NWChemPot/CPMDPot)
+- [Serve mode](project:../user_guide/serve_mode.md) (`-Dwith_serve`: eOn as rgpot-compatible RPC *server*)
 
 The server is accessed through `python -m eon.server`, and the `eonclient`
 binary is automatically made available in the activated environment.

--- a/docs/source/user_guide/index.md
+++ b/docs/source/user_guide/index.md
@@ -139,6 +139,8 @@ described in the subsequent sections.
 :caption: External linkage
 
 kdb
+rgpot_integration
+rgpot_pot
 serve_mode
 ```
 

--- a/docs/source/user_guide/rgpot_integration.md
+++ b/docs/source/user_guide/rgpot_integration.md
@@ -1,0 +1,75 @@
+---
+myst:
+  html_meta:
+    "description": "How eOn relates to rgpot: in-process engines, RPC serve mode, and optional potserv clients."
+    "keywords": "eOn, rgpot, NWChemPot, potserv, Cap'n Proto, dlopen, serve mode"
+---
+
+# rgpot integration (three roles)
+
+eOn and [rgpot](https://github.com/OmniPotentRPC/rgpot) meet in **three
+independent roles**. They are different Meson options, different binaries or
+symbols, and different runtime topologies. Do not conflate them.
+
+```{mermaid}
+flowchart LR
+  subgraph direct ["Direct in-process (-Dwith_rgpot)"]
+    E1[eOn RGPOT pot] --> NP[rgpot NWChemPot / CPMDPot]
+    NP -->|dlopen| L1[libnwchemc.so / libcpmdc.so]
+  end
+  subgraph serve ["eOn as RPC server (-Dwith_serve)"]
+    Client[External client e.g. ChemGP] -->|Cap'n Proto| E2[eonclient --serve]
+    E2 --> Any[Any eOn Potential]
+  end
+  subgraph rpccli ["Optional: RPC client to potserv"]
+    E3[External potserv client] -->|Cap'n Proto| PS[rgpot potserv]
+    PS -->|dlopen| L2[libnwchemc.so / …]
+  end
+```
+
+| Role | Meson option | What runs in eOn | Wire / load | Typical use |
+| --- | --- | --- | --- | --- |
+| **Direct in-process** | `-Dwith_rgpot=true` | Potential type **`RGPOT`**: links rgpot **NWChemPot** / **CPMDPot** | `dlopen` of `libnwchemc.so` / `libcpmdc.so` in the eOn address space | Production NWChem/CPMD forces without a second process |
+| **eOn as RPC server** | `-Dwith_serve=true` | `eonclient --serve` implements rgpot's Potential RPC | Cap'n Proto **server** in eOn | ChemGP / other tools drive *any* eOn pot over the network |
+| **RPC client → potserv** | *Not* an eOn pot type | Something *outside* eOn (or a thin harness) connects to **rgpot `potserv`** | Cap'n Proto **client** → potserv, which then `dlopen`s engines | Debugging engines via potserv; not the preferred eOn path for NWChem |
+
+```{important}
+**RGPOT in eOn is the direct in-process role.** It does **not** speak Cap'n
+Proto to potserv. Potserv is an rgpot binary for hosting engines over RPC; eOn
+uses the same engines by linking NWChemPot/CPMDPot and loading the `.so` itself.
+```
+
+Compare also **SocketNWChem** (`potential = SocketNWChem`): eOn speaks the i-PI
+socket protocol to an external **NWChem process** (not rgpot, not potserv).
+That path stays warm across POSDATA because NWChem keeps its SCF state. Direct
+RGPOT relies on **nwchemc** skipping redundant RTDB resets when method params
+are unchanged so multi-step optimize/NEB stays competitive with the socket.
+
+## Build flags (summary)
+
+```{code-block} bash
+# Direct NWChem/CPMD via rgpot frontends (dlopen engines)
+meson setup bbdir-rgpot -Dwith_rgpot=true
+
+# eOn exposes its potentials as an rgpot-compatible RPC *server*
+meson setup bbdir-serve -Dwith_serve=true
+
+# Both (independent features; subproject shared)
+meson setup bbdir-both -Dwith_rgpot=true -Dwith_serve=true
+```
+
+| Option | Compile define | Links from rgpot subproject |
+| --- | --- | --- |
+| `with_rgpot` | `WITH_RGPOT` | `nwchempot_dep`, `cpmdpot_dep` (frontends + schema) |
+| `with_serve` | `WITH_SERVE_MODE` | `ptlrpc_dep` (RPC server stack) |
+
+Runtime for direct mode: set `NWCHEMC_LIBRARY` / `RGPOT_NWCHEMC_ENGINE` (or
+`[RgpotPot] engine_path`) to a real `libnwchemc.so` built with NWChem embed
+support.
+
+## Docs map
+
+- Direct pot: [RgpotPot](project:rgpot_pot.md)
+- Serve mode: [Serve mode](project:serve_mode.md)
+- Socket NWChem (non-rgpot): [Potentials](project:potential.md)
+- External process pot pattern: [ExtPot](project:ext_pot.md)

--- a/docs/source/user_guide/rgpot_pot.md
+++ b/docs/source/user_guide/rgpot_pot.md
@@ -1,0 +1,91 @@
+---
+myst:
+  html_meta:
+    "description": "eOn RGPOT potential: in-process rgpot NWChemPot/CPMDPot via dlopen (not potserv RPC)."
+    "keywords": "eOn, RGPOT, rgpot, NWChemPot, CPMDPot, libnwchemc, dlopen"
+---
+
+# RgpotPot (direct in-process rgpot)
+
+```{versionadded} TBD
+```
+
+When eOn is built with **`-Dwith_rgpot=true`**, potential type **`RGPOT`** links
+[rgpot](https://github.com/OmniPotentRPC/rgpot) **NWChemPot** / **CPMDPot** and
+loads `libnwchemc.so` / `libcpmdc.so` with **`dlopen` in the eOn process**.
+
+This is **not**:
+
+- Cap'n Proto to **potserv** (that is an *external* RPC client role), nor
+- **`eonclient --serve`** (that is eOn acting as an *RPC server*; see
+  [Serve mode](project:serve_mode.md)), nor
+- **SocketNWChem** (i-PI socket to a standalone NWChem binary).
+
+For the three-role overview, see [rgpot integration](project:rgpot_integration.md).
+
+## Build
+
+```{code-block} bash
+meson setup bbdir-rgpot -Dwith_rgpot=true -Dwith_tests=true
+meson compile -C bbdir-rgpot
+```
+
+Requires Cap'n Proto **headers/libs** (method params are Cap'n Proto messages
+passed into the C ABI) and the `rgpot` Meson subproject
+(`subprojects/rgpot.wrap`). The build pulls `nwchempot_dep` / `cpmdpot_dep`
+only — not `ptlrpc_dep` (that is for serve mode).
+
+Engines are resolved at **runtime**:
+
+- `NWCHEMC_LIBRARY` or `RGPOT_NWCHEMC_ENGINE` (NWChem embed library), or
+- `[RgpotPot] engine_path` / `engine_library` in the config.
+
+`enginePath` in the Cap'n Proto blob is stripped before the ABI call (host-only
+locator); see rgpot NWChemPot.
+
+## Config
+
+```{code-block} ini
+[Main]
+job = point
+potential = RGPOT
+
+[RgpotPot]
+backend = nwchemc
+basis = sto-3g
+theory = scf
+scf_type = rhf
+charge = 0
+multiplicity = 1
+# engine_path = /path/to/libnwchemc.so
+```
+
+For CPMD:
+
+```{code-block} ini
+[RgpotPot]
+backend = cpmdc
+functional = BLYP
+cutoff_ry = 70.0
+```
+
+Optional `input_block` (or env `RGPOT_NWCHEM_INPUT_BLOCK`) supplies NWChem
+`inputBlocks` (e.g. explicit `dft` / `xc` stanzas). When `theory=dft` and
+`scf_type` looks like an XC label (e.g. `b3lyp`), a minimal DFT block is
+emitted automatically.
+
+## vs SocketNWChem
+
+| | SocketNWChem | RGPOT (this pot) |
+| --- | --- | --- |
+| Protocol | i-PI socket; eOn listens | In-process `dlopen` via rgpot frontends |
+| Engine process | External NWChem | `libnwchemc.so` / `libcpmdc.so` in eOn |
+| Multi-call SCF | Warm NWChem across POSDATA | nwchemc warm params cache (skip full RTDB reset when method blob unchanged) |
+
+## Implementation notes
+
+- `RgpotPot` (eOn `Potential`) owns an opaque `RGPotEngine` TU that includes
+  **only** rgpot headers — avoids Cap'n Proto type name `Potential` colliding
+  with eOn's `Potential` class.
+- Forces and energies use eOn units (eV, eV/Å) after rgpot conversion from
+  Hartree / Hartree·bohr⁻¹.

--- a/docs/source/user_guide/serve_mode.md
+++ b/docs/source/user_guide/serve_mode.md
@@ -15,12 +15,16 @@ myst:
 Included in the `conda-forge` package (v2.12+). No additional build flags required.
 ```
 
-Serve mode wraps any eOn potential as an
-[rgpot](https://github.com/OmniPotentRPC/rgpot)-compatible server, exposing it
-over Cap'n Proto RPC. This allows external tools, such as Julia-based
-optimization frameworks (e.g.,
-[ChemGP](https://github.com/HaoZeke/ChemGP)), to evaluate energies and forces
-without embedding C++ code directly.
+Serve mode makes **eOn the Cap'n Proto RPC *server***: it wraps any eOn
+potential as an
+[rgpot](https://github.com/OmniPotentRPC/rgpot)-compatible endpoint so external
+tools (e.g. [ChemGP](https://github.com/HaoZeke/ChemGP)) can evaluate energies
+and forces without embedding C++.
+
+This is **not** the direct in-process **RGPOT** pot (`-Dwith_rgpot`,
+`dlopen` of `libnwchemc` / `libcpmdc` via rgpot NWChemPot/CPMDPot), and **not**
+an eOn client connecting to **potserv**. See
+[rgpot integration](project:rgpot_integration.md) for the three roles.
 
 ## Compilation
 

--- a/examples/rgpot_cpmd_blyp/README.md
+++ b/examples/rgpot_cpmd_blyp/README.md
@@ -1,0 +1,12 @@
+# CPMD BLYP via rgpot potserv
+
+1. Build rgpot with RPC + tests (fake engine) or real `libcpmdc.so`.
+2. Start server:
+   ```bash
+   export CPMDC_LIBRARY=/path/to/libcpmdc.so   # or libcpmdc_fake_engine.so
+   potserv 12346 CPMD
+   ```
+3. Build eOn with `-Dwith_rgpot=true` and run a point job with this `config.ini`
+   and a `pos.con` (e.g. copy from `client/unit_tests/data/systems/...`).
+
+Env overrides: `RGPOT_POTSERV_HOST`, `RGPOT_POTSERV_PORT`, `RGPOT_BACKEND=CPMD`.

--- a/examples/rgpot_cpmd_blyp/config.ini
+++ b/examples/rgpot_cpmd_blyp/config.ini
@@ -1,0 +1,16 @@
+[Main]
+job = point
+temperature = 300
+
+[Potential]
+potential = RGPOT
+
+[RgpotPot]
+host = 127.0.0.1
+port = 12346
+backend = CPMD
+cpmd_functional = BLYP
+cpmd_task = gradient
+cpmd_cut_off_ry = 70.0
+
+# Positions: provide pos.con in this directory (3-atom water example)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -19,7 +19,14 @@ option('with_qsc', type : 'boolean', value : false)
 option('use_mkl', type: 'boolean', value: false, description: 'Enable Intel MKL support')
 option('gprd_linalg_backend', type: 'combo', choices: ['eigen', 'cusolver', 'kokkos', 'stdpar'], value: 'eigen', description: 'Linear algebra backend for GPR-dimer hot-path operations')
 option('with_metatomic', type : 'boolean', value : false)
-option('with_serve', type : 'boolean', value : false, description : 'Enable rgpot-compatible RPC serve mode (eonclient --serve)')
+# --- rgpot roles (independent; see docs/source/user_guide/rgpot_integration.md) ---
+# 1) Direct in-process: eOn Potential RGPOT → rgpot NWChemPot/CPMDPot → dlopen engines.
+option('with_rgpot', type : 'boolean', value : false,
+       description : 'Direct in-process rgpot: Potential RGPOT links NWChemPot/CPMDPot and dlopens libnwchemc/libcpmdc (NOT potserv RPC, NOT --serve)')
+# 2) eOn as RPC server: eonclient --serve implements rgpot Potential RPC for any pot.
+option('with_serve', type : 'boolean', value : false,
+       description : 'eOn as rgpot-compatible Cap\'n Proto RPC *server* (eonclient --serve); clients connect TO eOn (NOT RGPOT pot, NOT potserv client)')
+# (RPC *client* to potserv is not an eOn pot type; use rgpot potserv + external client.)
 option('with_parallel_neb', type : 'boolean', value : false, description : 'Enable parallel NEB bead force evaluations (requires TBB)')
 option('native_arch', type : 'boolean', value : false, description : 'Use -march=native for CPU-specific optimizations (not portable)')
 option('fast_math', type : 'boolean', value : false, description : 'Enable -ffast-math (unsafe FP reordering, safe for atomic coords)')
@@ -31,13 +38,3 @@ option('ira_includedir', type : 'string', value : '', description : 'Path to ira
 option('torch_path', type : 'string', value : '', description: 'path to Torch, either provide this or torch_version for pip')
 option('torch_version', type : 'string', value : '2.9', description: 'path to Torch')
 option('pip_metatomic', type : 'boolean', value : false, description: 'use pip versions of torch, metatensor, torch, and metatomic')
-
-# option('someoption', type : 'string', value : 'optval', description : 'An option')
-# option('combo_opt', type : 'combo', choices : ['one', 'two', 'three'], value : 'three')
-# option('integer_opt', type : 'integer', min : 0, max : 5, value : 3) # Since 0.45.0
-# option('free_array_opt', type : 'array', value : ['one', 'two'])  # Since 0.44.0
-# option('array_opt', type : 'array', choices : ['one', 'two', 'three'], value : ['one', 'two'])
-# option('some_feature', type : 'feature', value : 'enabled')  # Since 0.47.0
-# option('long_desc', type : 'string', value : 'optval',
-#        description : 'An option with a very long description' +
-#                      'that does something in a specific context') # Since 0.55.0

--- a/scripts/bench_rgpot_vs_socket_forces.sh
+++ b/scripts/bench_rgpot_vs_socket_forces.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Timed multi-force loop for RgpotPot (requires potserv + engine).
+# SocketNWChem path is only timed if NWCHEM_SOCKET_BENCH=1 and nwchem is available
+# (full i-PI harness is heavier; default documents that path as untimed here).
+set -euo pipefail
+OUT="${1:-bench_rgpot_vs_socket_forces.txt}"
+N_FORCE="${N_FORCE:-20}"
+TEST_BIN="${TEST_BIN:-}"
+HOST="${RGPOT_POTSERV_HOST:-127.0.0.1}"
+PORT="${RGPOT_POTSERV_PORT:-19111}"
+
+{
+  echo "=== Timed force-loop comparison scaffold ==="
+  echo "Date: $(date -Is)"
+  echo "Host: $(hostname)"
+  echo "N_FORCE=$N_FORCE"
+  echo
+  echo "--- RgpotPot (NWChem backend via potserv) ---"
+  if [[ -z "$TEST_BIN" || ! -x "$TEST_BIN" ]]; then
+    echo "SKIP: set TEST_BIN to test_rgpot_pot (built with -Dwith_rgpot=true)"
+  else
+    export RGPOT_POTSERV_HOST="$HOST" RGPOT_POTSERV_PORT="$PORT" RGPOT_BACKEND=NWChem
+    # Warm-up
+    "$TEST_BIN" "[rgpot]" >/dev/null 2>&1 || true
+    start=$(date +%s.%N)
+    for ((i=0; i<N_FORCE; i++)); do
+      "$TEST_BIN" "[rgpot]" >/dev/null 2>&1
+    done
+    end=$(date +%s.%N)
+    python3 - <<PY
+start=float("$start"); end=float("$end"); n=int("$N_FORCE")
+print(f"rgpot_force_loops={n}")
+print(f"rgpot_wall_s_total={end-start:.6f}")
+print(f"rgpot_wall_s_per_force_call_incl_process={((end-start)/n):.6f}")
+print("note: each iteration re-executes test binary (process overhead dominates vs in-process Opt)")
+PY
+  fi
+  echo
+  echo "--- SocketNWChem ---"
+  if [[ "${NWCHEM_SOCKET_BENCH:-0}" == "1" ]] && command -v nwchem >/dev/null; then
+    echo "NWCHEM_SOCKET_BENCH requested; run client/unit_tests/run_nwchem_test.sh externally and paste times."
+  else
+    echo "NOT TIMED: requires nwchem + i-PI socket setup (SocketNWChemPotTest / run_nwchem_test.sh)."
+    echo "Without that, cannot claim RGPOT faster than SocketNWChem for real NWChem optimize."
+  fi
+  echo
+  echo "--- Optimize (minimization) ---"
+  echo "NOT TIMED: no eonclient minimization job timed for both potentials on the same deck in this harness."
+} | tee "$OUT"

--- a/scripts/rgpot_nwchem_vs_socket.sh
+++ b/scripts/rgpot_nwchem_vs_socket.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Compare setup notes: SocketNWChem vs RgpotPot(NWChem). Times are wall-clock
+# for a single force call harness when servers are up.
+set -euo pipefail
+OUT="${1:-rgpot_nwchem_vs_socket.txt}"
+{
+  echo "=== Rgpot NWChem vs SocketNWChem (setup comparison) ==="
+  echo "Date: $(date -Is)"
+  echo
+  echo "SocketNWChem: eOn listens; NWChem connects (i-PI). See"
+  echo "  client/potentials/SocketNWChem/ and unit_tests/run_nwchem_test.sh"
+  echo "  Requires nwchem on PATH and a .nwi with driver socket."
+  echo
+  echo "RgpotPot NWChem: potserv hosts NWChemPot (dlopen libnwchemc)."
+  echo "  Start: NWCHEMC_LIBRARY=... potserv <port> NWChem"
+  echo "  eOn: potential=RGPOT backend=NWChem host/port -> Cap'n Proto configure+calculate"
+  echo "  Fake CI path: libnwchemc_fake_engine.so + tests/test_rpc_e2e style"
+  echo
+  if [[ -n "${RGPOT_POTSERV_PORT:-}" ]]; then
+    echo "RGPOT_POTSERV_PORT=${RGPOT_POTSERV_PORT} (run test_rgpot_pot for timings)"
+  else
+    echo "Set RGPOT_POTSERV_HOST/PORT and run: meson test -C <build> test_rgpot_pot --suite rgpot"
+  fi
+} | tee "$OUT"

--- a/subprojects/rgpot.wrap
+++ b/subprojects/rgpot.wrap
@@ -1,5 +1,5 @@
 [wrap-git]
-directory=rgpot
-url=https://github.com/OmniPotentRPC/rgpot.git
+directory = rgpot
+url = https://github.com/OmniPotentRPC/rgpot.git
 revision = head
 depth = 1


### PR DESCRIPTION
## Summary

Cap'n Proto **client** potential for eOn that talks to [OmniPotentRPC/rgpot](https://github.com/OmniPotentRPC/rgpot) **potserv** (`NWChem` / `CPMD` backends via `dlopen` engines or CI fakes).

- `PotType::RGPOT`, `[RgpotPot]` INI, meson `-Dwith_rgpot=true`
- Isolated RPC TU (`RgpotClientRpc`) to avoid Cap'n Proto `Potential` name clash
- `test_rgpot_pot` integration test (env: `RGPOT_POTSERV_HOST` / `PORT` / `RGPOT_BACKEND`)
- `examples/rgpot_cpmd_blyp/`, `docs/source/user_guide/rgpot_pot.md`, `scripts/rgpot_nwchem_vs_socket.sh` (vs SocketNWChem)

Head branch is on **HaoZeke/eOn** (`feat/rgpot-potential`); this PR targets **TheochemUI/eOn** `main`.

Developed in worktree `eOn-rgpot-potential` so other local branches (e.g. LOR) stay isolated. Verified on **rg.terra** (`rgam5terra`) with potserv + fake engines (NWChem ×2 and CPMD BLYP configure/calculate).

## Test plan

- [x] `meson setup/compile -Dwith_rgpot=true` (match Cap'n Proto compiler+lib, e.g. pixi `serve` env)
- [x] `test_rgpot_pot` vs potserv + `libnwchemc_fake_engine` / `libcpmdc_fake_engine`
- [ ] Review + real `libnwchemc` / `libcpmdc` smokes
- [ ] Full `eonclient` point job with `examples/rgpot_cpmd_blyp/config.ini`