### PR TITLE
fix(atoms): plain int indices for recycling metadata round-trip

### DIFF
--- a/docs/newsfragments/369.fixed.md
+++ b/docs/newsfragments/369.fixed.md
@@ -1,0 +1,1 @@
+get_process_atoms returns plain Python ints so recycling metadata repr/eval round-trips (no np.int64).

--- a/eon/atoms.py
+++ b/eon/atoms.py
@@ -82,7 +82,8 @@ def get_process_atoms(r, p, epsilon_r=0.2, nshells=1):
     the atoms that move significantly and their neighbors along the trajectory.
     '''
     r2p = per_atom_norm(p.r - r.r, r.box)
-    mobileAtoms = list(numpy.flatnonzero(r2p > epsilon_r))
+    # Plain Python ints: recycling metadata uses repr()/eval() without numpy.
+    mobileAtoms = [int(i) for i in numpy.flatnonzero(r2p > epsilon_r)]
     if len(mobileAtoms) == 0:
         mobileAtoms = [int(numpy.argmax(r2p))]
     # Vectorized neighbor shell around each mobile atom (same thresholds as before).
@@ -170,7 +171,7 @@ def brute_neighbor_list(p, cutoff):
     numpy.fill_diagonal(dist, numpy.inf)
     nl = []
     for a in range(n):
-        nl.append(list(numpy.flatnonzero(dist[a] < cutoff)))
+        nl.append([int(i) for i in numpy.flatnonzero(dist[a] < cutoff)])
     return nl
 
 

--- a/tests/test_atoms_hotpaths.py
+++ b/tests/test_atoms_hotpaths.py
@@ -63,6 +63,49 @@ def test_get_process_atoms_includes_moved():
     assert len(idxs) >= 1
 
 
+def test_get_process_atoms_plain_python_ints():
+    """Indices must be built-in int so recycling metadata repr/eval works."""
+    r = _fcc_cell(3, a=3.0)
+    p = r.copy()
+    p.r[0] = p.r[0] + np.array([1.0, 0.0, 0.0])
+    idxs = at.get_process_atoms(r, p, epsilon_r=0.2, nshells=1)
+    assert idxs
+    assert all(type(i) is int for i in idxs)
+    assert not any(isinstance(i, np.integer) for i in idxs)
+
+
+def test_get_process_atoms_recycling_metadata_roundtrip():
+    """Mirrors recycling.write/read_recycling_metadata process_atoms path."""
+    r = _fcc_cell(3, a=3.0)
+    p = r.copy()
+    p.r[0] = p.r[0] + np.array([1.0, 0.0, 0.0])
+    process_atoms = at.get_process_atoms(r, p, epsilon_r=0.2, nshells=1)
+    line = "Indices of 'process' atoms = %s\n" % (repr(process_atoms),)
+    assert "np.int64" not in line
+    assert "numpy" not in line
+    parsed = eval(line.split("=")[1].strip())
+    assert parsed == process_atoms
+    assert all(type(i) is int for i in parsed)
+
+
+def test_get_process_atoms_fallback_argmax_plain_int():
+    """When no atom exceeds epsilon_r, argmax path still returns plain ints."""
+    r = _fcc_cell(2, a=3.0)
+    p = r.copy()
+    # Tiny displacement below epsilon
+    p.r[1] = p.r[1] + np.array([0.01, 0.0, 0.0])
+    idxs = at.get_process_atoms(r, p, epsilon_r=0.2, nshells=1)
+    assert idxs
+    assert all(type(i) is int for i in idxs)
+
+
+def test_brute_neighbor_list_plain_ints():
+    p = _fcc_cell(3, a=2.0)
+    nl = at.brute_neighbor_list(p, 2.1)
+    for neigh in nl:
+        assert all(type(i) is int for i in neigh)
+
+
 def test_per_atom_norm_shape():
     p = _fcc_cell(2)
     v = p.r - p.r[0]


### PR DESCRIPTION
## Summary

Follow-up to #368: `get_process_atoms` (and `brute_neighbor_list`) returned `numpy.int64` indices from `list(numpy.flatnonzero(...))`. Recycling metadata is persisted with `repr(process_atoms)` and reloaded via `eval()` without numpy in scope, so lines like `Indices of 'process' atoms = [np.int64(0), ...]` raise `NameError: name 'np' is not defined`.

- Cast mobile/neighbor indices to built-in `int`
- Same cast on brute neighbor-list entries for consistency
- Regression tests for plain-int types, recycling metadata write/eval path, and argmax fallback

## Test plan

- [x] `PYTHONPATH=. python3 -m pytest tests/test_atoms_hotpaths.py -v` (8 passed)
- [x] Clean-namespace repro: `eval(repr(list(flatnonzero(...))))` → NameError on `np`; fixed path evals cleanly
- [ ] CI green on this PR