### PR TITLE
test(server): golden masters for CPython surfaces and readcon fileio

### DIFF
--- a/docs/newsfragments/370.dev.md
+++ b/docs/newsfragments/370.dev.md
@@ -1,0 +1,1 @@
+Golden masters for CPython server atoms helpers vs pre-#368 scalar code; eon.fileio load/save/round-trip via live readcon fixtures; document chemfiles as optional and unused on server .con path.

--- a/tests/reference/atoms_pre_vectorization.py
+++ b/tests/reference/atoms_pre_vectorization.py
@@ -1,0 +1,64 @@
+"""Pre-#368 scalar atoms helpers, extracted from commit ee3012498 (parent of #368).
+
+These are the production implementations that shipped before vectorization.
+Golden tests compare live eon.atoms outputs to these functions on the same inputs.
+Do not edit algorithmically without re-extracting from git history.
+"""
+from __future__ import annotations
+
+import numpy
+
+from eon.atoms import elements, pbc, per_atom_norm
+
+
+def free_r_scalar(atoms) -> numpy.ndarray:
+    """Historical Atoms.free_r (ee3012498).
+
+    ``int(...)`` on the free count is required under current NumPy: ``sum`` on a
+    float free array yields ``numpy.float64``, which is not a valid shape dim.
+    Semantics match the pre-#368 loop (truthy free flags).
+    """
+    nfree = int(sum(atoms.free))
+    temp = numpy.zeros((nfree, 3))
+    index = 0
+    for i in range(len(atoms.r)):
+        if atoms.free[i]:
+            temp[index] = atoms.r[i]
+            index += 1
+    return temp
+
+
+def get_process_atoms_scalar(r, p, epsilon_r=0.2, nshells=1):
+    """Historical get_process_atoms (ee3012498)."""
+    mobileAtoms = []
+    r2p = per_atom_norm(p.r - r.r, r.box)
+    for i in range(len(r)):
+        if r2p[i] > epsilon_r:
+            mobileAtoms.append(i)
+    if len(mobileAtoms) == 0:
+        mobileAtoms.append(list(r2p).index(max(r2p)))
+    neighborAtoms = []
+    for atom in mobileAtoms:
+        r1 = elements[r.names[atom]]["radius"]
+        for i in range(len(r)):
+            if i in mobileAtoms or i in neighborAtoms:
+                continue
+            r2 = elements[r.names[i]]["radius"]
+            maxDist = (r1 + r2) * (1.0 + 0.2) * nshells
+            if numpy.linalg.norm(pbc(p.r[atom] - p.r[i], p.box)) < maxDist:
+                neighborAtoms.append(i)
+    return mobileAtoms + neighborAtoms
+
+
+def brute_neighbor_list_scalar(p, cutoff):
+    """Historical brute_neighbor_list (ee3012498)."""
+    nl = []
+    ibox = numpy.linalg.inv(p.box)
+    for a in range(len(p)):
+        nl.append([])
+        for b in range(len(p)):
+            if b != a:
+                dist = numpy.linalg.norm(pbc(p.r[a] - p.r[b], p.box, ibox))
+                if dist < cutoff:
+                    nl[a].append(b)
+    return nl

--- a/tests/test_atoms_golden.py
+++ b/tests/test_atoms_golden.py
@@ -1,0 +1,84 @@
+"""Golden masters: shipped vectorized atoms helpers vs pre-#368 scalar code.
+
+Reference implementations live in tests/reference/atoms_pre_vectorization.py
+and were extracted from git commit ee3012498 (last main before #368).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from eon import atoms as at
+from tests.reference.atoms_pre_vectorization import (
+    brute_neighbor_list_scalar,
+    free_r_scalar,
+    get_process_atoms_scalar,
+)
+
+
+def _fcc_cell(n=4, a=4.0):
+    pts = []
+    for i in range(n):
+        for j in range(n):
+            for k in range(n):
+                pts.append([i * a, j * a, k * a])
+    p = at.Atoms(len(pts))
+    p.r = np.asarray(pts, dtype=float)
+    p.box = np.eye(3) * (n * a)
+    p.free = np.ones(len(pts))
+    p.names = ["Cu"] * len(pts)
+    p.mass = np.full(len(pts), 63.5)
+    return p
+
+
+@pytest.mark.parametrize("n,free_stride", [(2, 2), (3, 3), (4, 1)])
+def test_free_r_matches_pre_vectorization(n, free_stride):
+    p = _fcc_cell(n)
+    p.free[::free_stride] = 0
+    live = p.free_r()
+    ref = free_r_scalar(p)
+    assert live.shape == ref.shape
+    np.testing.assert_allclose(live, ref, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("n,cutoff", [(2, 4.1), (3, 2.1), (3, 4.1)])
+def test_brute_neighbor_list_matches_pre_vectorization(n, cutoff):
+    p = _fcc_cell(n, a=2.0)
+    live = at.brute_neighbor_list(p, cutoff)
+    ref = brute_neighbor_list_scalar(p, cutoff)
+    assert len(live) == len(ref) == len(p)
+    for i in range(len(p)):
+        assert sorted(live[i]) == sorted(ref[i]), f"neighbors differ for atom {i}"
+        assert all(type(j) is int for j in live[i])
+
+
+@pytest.mark.parametrize(
+    "disp,eps,nshells",
+    [
+        (np.array([1.0, 0.0, 0.0]), 0.2, 1),
+        (np.array([0.5, 0.5, 0.0]), 0.2, 1),
+        (np.array([0.01, 0.0, 0.0]), 0.2, 1),  # argmax fallback path
+        (np.array([2.0, 0.0, 0.0]), 0.2, 2),
+    ],
+)
+def test_get_process_atoms_matches_pre_vectorization(disp, eps, nshells):
+    r = _fcc_cell(3, a=3.0)
+    p = r.copy()
+    p.r[0] = p.r[0] + disp
+    live = at.get_process_atoms(r, p, epsilon_r=eps, nshells=nshells)
+    ref = get_process_atoms_scalar(r, p, epsilon_r=eps, nshells=nshells)
+    assert sorted(live) == sorted(ref)
+    assert all(type(i) is int for i in live)
+
+
+def test_per_atom_norm_matches_pbc_scalar_loop():
+    """per_atom_norm was not rewritten in #368; pin against explicit pbc norm."""
+    p = _fcc_cell(3, a=2.5)
+    v = p.r - p.r[0]
+    live = at.per_atom_norm(v, p.box)
+    ibox = np.linalg.inv(p.box)
+    ref = np.array(
+        [np.linalg.norm(at.pbc(v[i], p.box, ibox)) for i in range(len(p))]
+    )
+    np.testing.assert_allclose(live, ref, rtol=1e-12, atol=1e-12)

--- a/tests/test_fileio_readcon.py
+++ b/tests/test_fileio_readcon.py
@@ -1,0 +1,185 @@
+"""Golden / integration tests: eon.fileio through live readcon on fixtures.
+
+Proves loadcon/savecon/loadcons call the readcon package (not a private parser)
+and that geometry / species / free flags / box round-trip correctly.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import numpy as np
+import pytest
+import readcon
+
+from eon import fileio as io
+
+DATA = Path(__file__).resolve().parent / "data"
+
+
+def _all_con_fixtures():
+    paths = sorted(DATA.rglob("*.con"))
+    assert paths, "expected tests/data/**/*.con fixtures"
+    return paths
+
+
+def _readable_con_fixtures():
+    """Fixtures that the live readcon package can parse (skip known bad NEB files)."""
+    good = []
+    for path in _all_con_fixtures():
+        try:
+            frames = readcon.read_con(str(path))
+            if frames:
+                good.append(path)
+        except OSError:
+            continue
+    assert good, "no readable .con fixtures under tests/data"
+    return good
+
+
+def test_fileio_imports_and_calls_readcon():
+    """Structural: shipped fileio binds the real readcon APIs (not a private parser)."""
+    src = Path(io.__file__).read_text(encoding="utf-8")
+    assert "import readcon" in src
+    for api in (
+        "readcon.read_con",
+        "readcon.read_con_string",
+        "readcon.write_con",
+        "readcon.write_con_string",
+        "readcon.Atom",
+        "readcon.ConFrame",
+    ):
+        assert api in src, f"fileio must use {api}"
+    # No chemfiles on the server .con path
+    assert "chemfiles" not in src.lower()
+    assert "read_chemfiles" not in src
+    # Not a hand-rolled tokenizer loop for coordinates
+    assert "Coordinates of component" not in src
+
+
+def test_readcon_version_and_chemfiles_status():
+    """Record readcon pin; eOn server I/O does not require chemfiles extra."""
+    ver = getattr(readcon, "__version__", None)
+    assert ver is not None
+    # eOn pyproject pins >=0.8.0; installed package must satisfy that
+    parts = tuple(int(x) for x in ver.split(".")[:2])
+    assert parts >= (0, 8), ver
+    has_cf = readcon.has_chemfiles_support()
+    # Default install (no [chemfiles] extra): False. Document either way.
+    assert isinstance(has_cf, bool)
+    # Server path must work without chemfiles
+    assert callable(readcon.read_con)
+    assert callable(readcon.write_con)
+
+
+def test_readcon_core_not_chemfiles_for_server_io():
+    """eOn does not import chemfiles-backed APIs for .con server I/O."""
+    assert not hasattr(io, "read_chemfiles")
+    src = inspect.getsource(io)
+    assert "read_chemfiles" not in src
+    # Live readcon core path works regardless of chemfiles extra
+    fixture = DATA / "server" / "Pt_Heptamer_oneLayer" / "pos.con"
+    frames = readcon.read_con(str(fixture))
+    assert len(frames) >= 1
+    assert len(frames[0]) > 0
+
+
+@pytest.mark.parametrize("path", _readable_con_fixtures(), ids=lambda p: str(p.relative_to(DATA)))
+def test_loadcon_matches_live_readcon_frame(path: Path):
+    """Primary observable: eon.fileio.loadcon == readcon frame geometry."""
+    frames = readcon.read_con(str(path))
+    assert frames
+    ref = frames[0]
+    atoms = io.loadcon(str(path))
+
+    assert len(atoms) == len(ref)
+    # Species
+    assert list(atoms.names) == [a.symbol for a in ref.atoms]
+    # Coordinates
+    ref_r = np.array([[a.x, a.y, a.z] for a in ref.atoms], dtype=float)
+    np.testing.assert_allclose(atoms.r, ref_r, rtol=0, atol=1e-9)
+    # Mass
+    ref_mass = np.array(
+        [a.mass if a.mass is not None else 0.0 for a in ref.atoms], dtype=float
+    )
+    np.testing.assert_allclose(atoms.mass, ref_mass, rtol=0, atol=1e-9)
+    # Free / fixed: free[i]==0 iff any fixed flag
+    for i, a in enumerate(ref.atoms):
+        expect_free = 0 if any(a.fixed) else 1
+        assert int(atoms.free[i]) == expect_free
+    # Box from cell lengths + angles
+    box_lens = np.linalg.norm(atoms.box, axis=1)
+    np.testing.assert_allclose(box_lens, np.array(list(ref.cell), dtype=float), rtol=1e-6, atol=1e-6)
+
+
+def test_loadcon_server_fixture_first_atom_content():
+    """Content check on a known fixture (not merely 'ran')."""
+    path = DATA / "server" / "Pt_Heptamer_oneLayer" / "pos.con"
+    atoms = io.loadcon(str(path))
+    # Cross-check first atom against live readcon (source of truth for the file)
+    ref = readcon.read_con(str(path))[0].atoms[0]
+    assert len(atoms) == 343
+    assert atoms.names[0] == "Pt" == ref.symbol
+    np.testing.assert_allclose(
+        atoms.r[0], [ref.x, ref.y, ref.z], rtol=0, atol=1e-9
+    )
+    # Explicit content from fixture (readcon-parsed): first Pt near heptamer layer
+    assert atoms.r[0, 2] > 14.0
+    assert float(atoms.mass[0]) == pytest.approx(195.084, abs=1e-6)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        DATA / "server" / "Pt_Heptamer_oneLayer" / "pos.con",
+        DATA / "client" / "oxadiazole" / "pos.con",
+        DATA / "client" / "mini_1Pt_oneLayer" / "pos.con",
+        DATA / "client" / "one_Pt_on_frozenSurface" / "pos.con",
+    ],
+    ids=lambda p: p.parent.name + "/" + p.name,
+)
+def test_loadcon_savecon_roundtrip(path: Path, tmp_path: Path):
+    """Round-trip positions, species, free flags, box via shipped savecon/loadcon."""
+    original = io.loadcon(str(path))
+    out = tmp_path / "roundtrip.con"
+    io.savecon(str(out), original)
+    again = io.loadcon(str(out))
+
+    assert len(again) == len(original)
+    assert list(again.names) == list(original.names)
+    np.testing.assert_allclose(again.r, original.r, rtol=0, atol=1e-6)
+    np.testing.assert_allclose(again.mass, original.mass, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(again.free.astype(int), original.free.astype(int))
+    np.testing.assert_allclose(again.box, original.box, rtol=1e-6, atol=1e-6)
+
+
+def test_loadcons_multi_frame_via_readcon(tmp_path: Path):
+    """loadcons returns one Atoms per frame written with multi-frame write_con."""
+    path = DATA / "client" / "oxadiazole" / "pos.con"
+    a = io.loadcon(str(path))
+    b = a.copy()
+    b.r = b.r + 0.1
+    multi = tmp_path / "multi.con"
+    # Build multi-frame file through readcon (same path savecon append uses)
+    f1 = io._atoms_to_frame(a)
+    f2 = io._atoms_to_frame(b)
+    readcon.write_con(str(multi), [f1, f2])
+    frames = io.loadcons(str(multi))
+    assert len(frames) == 2
+    assert len(frames[0]) == len(a)
+    np.testing.assert_allclose(frames[0].r, a.r, atol=1e-6)
+    np.testing.assert_allclose(frames[1].r, b.r, atol=1e-6)
+
+
+def test_savecon_append_mode(tmp_path: Path):
+    path = DATA / "client" / "oxadiazole" / "pos.con"
+    a = io.loadcon(str(path))
+    out = tmp_path / "append.con"
+    io.savecon(str(out), a, w="w")
+    shifted = a.copy()
+    shifted.r = shifted.r + 0.25
+    io.savecon(str(out), shifted, w="a")
+    frames = io.loadcons(str(out))
+    assert len(frames) == 2
+    np.testing.assert_allclose(frames[1].r, shifted.r, atol=1e-6)

--- a/tests/test_golden_server_surfaces.py
+++ b/tests/test_golden_server_surfaces.py
@@ -1,0 +1,42 @@
+"""Golden masters for CPython server packaging / job-dispatch surfaces."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+
+# Job keys registered by the shipped select_job_runner (see eon/server.py).
+# This is the public dispatch surface from #368, not a reimplementation.
+EXPECTED_JOB_KEYS = {
+    "akmc",
+    "parallel_replica",
+    "unbiased_parallel_replica",
+    "basin_hopping",
+    "escape_rate",
+}
+
+
+def test_select_job_runner_golden_keys():
+    from eon.server import select_job_runner
+
+    for key in EXPECTED_JOB_KEYS:
+        assert select_job_runner(key) is not None, key
+        assert callable(select_job_runner(key))
+    # Unknown → None (fallback single-job path)
+    assert select_job_runner("not_registered_xyz") is None
+    # Case fold
+    assert select_job_runner("AKMC") is not None
+
+
+def test_console_script_and_main_chain():
+    text = (REPO / "pyproject.toml").read_text(encoding="utf-8")
+    assert 'eon-server = "eon.server:main"' in text
+    from eon.server import main, server
+
+    assert main.__module__ == "eon.server"
+    assert server.__module__ == "eon.server"
+    # main is the thin console wrapper
+    assert main.__doc__ is not None


### PR DESCRIPTION
## Summary

Closes the golden-master / integration gap after #368/#369:

- **Atoms vs pre-#368**: committed scalar reference extracted from `ee3012498`; live `free_r`, `get_process_atoms`, `brute_neighbor_list` must match on lattices (incl. argmax fallback + plain ints).
- **`eon.fileio` + readcon**: `loadcon` matches live `readcon.read_con` on all readable `tests/data/**/*.con` fixtures; load/save/multi-frame/append round-trips; structural assert that fileio uses `readcon.read_con` / `write_con` (no private parser, no chemfiles).
- **readcon-chemfiles**: documented and tested — server `.con` I/O depends only on core readcon (`has_chemfiles_support` may be false; chemfiles is an optional extra and unused by `eon.fileio`).
- **Packaging / dispatch**: golden job keys + `eon-server` → `eon.server:main`.

## Test plan

- [x] `PYTHONPATH=. pytest tests/test_atoms_golden.py tests/test_atoms_hotpaths.py tests/test_fileio_readcon.py tests/test_golden_server_surfaces.py tests/test_server_dispatch.py -v` → 54 passed
- [x] Import chain `import readcon; import eon.fileio; loadcon(server pos.con)` → 343 Pt atoms, content check
- [ ] CI green