### PR TITLE
release: eOn v2.17.2 (green packaging + eon-akmc/pyeonclient)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,9 +115,21 @@ jobs:
     - name: Install build frontend
       run: python3 -m pip install --upgrade pip build
     - name: Install sdist build deps
-      # meson-python's sdist path runs a full meson setup; Eigen3 is the only
-      # hard dependency the runner image lacks (wrap fallbacks cover the rest).
-      run: sudo apt-get update && sudo apt-get install -y libeigen3-dev
+      # meson-python sdist runs full meson setup of the client tree. Eigen is
+      # apt; quill/capnp/cbindgen match pyeonclient manylinux (no wrap for quill).
+      run: |-
+        set -euo pipefail
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends libeigen3-dev gfortran ninja-build cmake pkg-config zlib1g-dev build-essential
+        bash scripts/pyeonclient_manylinux_deps.sh
+        echo "/usr/local/lib" | sudo tee /etc/ld.so.conf.d/usr-local.conf
+        echo "/usr/local/lib64" | sudo tee -a /etc/ld.so.conf.d/usr-local.conf
+        sudo ldconfig
+        echo "LD_LIBRARY_PATH=/usr/local/lib64:/usr/local/lib:${LD_LIBRARY_PATH:-}" >> "$GITHUB_ENV"
+        echo "PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:${PKG_CONFIG_PATH:-}" >> "$GITHUB_ENV"
+        echo "CMAKE_PREFIX_PATH=/usr/local" >> "$GITHUB_ENV"
+        pkg-config --modversion quill
+        pkg-config --modversion eigen3 || true
     - name: Build sdist (meson-python)
       # sdist only: a runner-built wheel would carry a non-manylinux linux tag
       # that PyPI rejects; binary distribution stays on conda-forge.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 <!-- towncrier release notes start -->
 
+## [2.17.2](https://github.com/TheochemUI/eOn/tree/2.17.2) - 2026-07-17
+
+### Added
+
+- pyeonclient 0.3.3: in-memory ``path_frames`` / ``to_conframes`` for NEB (same stamps as writePathCon), ``Matter.relax(retain_frames=…)`` movie frames, and ``MinModeSaddleSearch.run_retain_frames`` climb frames. ([#pyeonclient-path-frames](https://github.com/TheochemUI/eOn/issues/pyeonclient-path-frames))
+- Dimer supports `rotation_backend = classical|lanczos|davidson|lor` (Leng et al. JCP 2013 LOR for softest-mode with force translation; Lanczos/Davidson FD min-mode; classical constrained rotation). Climb remains on the dimer path.
+- Optional Superbasin gate via amsel.discover_decide_status ([amsel] / amsel_discover_decide) before MCAMC; rejected_no_metastable_basin falls back to AKMC.
+
+### Fixed
+
+- HessianJob FD eigen solve: ColMajor copy for SelfAdjointEigenSolver (avoids
+  RowMajor segfaults on partial VTST blocks), finite-force/index guards, optional
+  `[Hessian] atom_list` intersected with free atoms, and a stable mobile VectorXi
+  copy so moving-atom Hessians match PHVA-class active sets. ([#357](https://github.com/TheochemUI/eOn/issues/357))
+- Release CI installs quill/capnp so ``eon-akmc`` sdist and pyeonclient wheels configure cleanly on GitHub runners. ([#418](https://github.com/TheochemUI/eOn/issues/418))
+
+
 ## [2.17.1](https://github.com/TheochemUI/eOn/tree/2.17.1) - 2026-07-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   `[Hessian] atom_list` intersected with free atoms, and a stable mobile VectorXi
   copy so moving-atom Hessians match PHVA-class active sets. ([#357](https://github.com/TheochemUI/eOn/issues/357))
 - Release CI installs quill/capnp so ``eon-akmc`` sdist and pyeonclient wheels configure cleanly on GitHub runners. ([#418](https://github.com/TheochemUI/eOn/issues/418))
+- Republish pyeonclient as **0.3.4** with the full wheel matrix (abi3 + freethreading) after incomplete 0.3.3 tag CI.
 
 
 ## [2.17.1](https://github.com/TheochemUI/eOn/tree/2.17.1) - 2026-07-17

--- a/ci/gha/release.ncl
+++ b/ci/gha/release.ncl
@@ -157,15 +157,25 @@ let job_pypi = {
     S.checkout_full,
     S.setup_python_default,
     S.run_script "Install build frontend" "python3 -m pip install --upgrade pip build",
-    S.run_script "Build sdist/wheel (meson-python)" m%"
+    S.run_script "Install sdist build deps" m%"
+      set -euo pipefail
+      sudo apt-get update
+      sudo apt-get install -y --no-install-recommends libeigen3-dev gfortran ninja-build cmake pkg-config zlib1g-dev build-essential
+      bash scripts/pyeonclient_manylinux_deps.sh
+      echo "/usr/local/lib" | sudo tee /etc/ld.so.conf.d/usr-local.conf
+      echo "/usr/local/lib64" | sudo tee -a /etc/ld.so.conf.d/usr-local.conf
+      sudo ldconfig
+      echo "LD_LIBRARY_PATH=/usr/local/lib64:/usr/local/lib:${LD_LIBRARY_PATH:-}" >> "$GITHUB_ENV"
+      echo "PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:${PKG_CONFIG_PATH:-}" >> "$GITHUB_ENV"
+      echo "CMAKE_PREFIX_PATH=/usr/local" >> "$GITHUB_ENV"
+      pkg-config --modversion quill
+    "%,
+    S.run_script "Build sdist (meson-python)" m%"
+      set -o pipefail
       python3 scripts/release_assert.py "${{ needs.gate.outputs.version }}" --require-changelog
-      if python3 -m build 2>&1 | tee "${RUNNER_TEMP}/pypi-build.log"; then
-        echo "build ok"
-      else
-        echo "::warning::python -m build failed (native deps missing on runner). Trying sdist via pip wheel isolation off."
-        exit 1
-      fi
+      python3 -m build --sdist 2>&1 | tee "${RUNNER_TEMP}/pypi-build.log"
       ls -la dist/
+      test -n "$(find dist -name '*.tar.gz' -print -quit)"
     "%,
     S.pypi_publish_step "${{ secrets.PYPI_API_TOKEN }}",
   ],

--- a/client/ConFileIO.h
+++ b/client/ConFileIO.h
@@ -119,8 +119,8 @@ void set_write_con_forces(bool enabled) noexcept;
 matterToConFrame(Matter &m, const ConFrameMetadata *metadata = nullptr);
 
 /**
- * Build NEB band ConFrames without writing (clone builder path of writeNebPath).
- * Empty vector on invalid input.
+ * Build NEB band ConFrames without writing (clone builder path of
+ * writeNebPath). Empty vector on invalid input.
  *
  * @param path length must equal metadata_per_image (endpoints included)
  */

--- a/client/GPSurrogateJob.cpp
+++ b/client/GPSurrogateJob.cpp
@@ -125,8 +125,9 @@ GPSurrogateJob::runFromMatter(std::shared_ptr<Matter> initial,
   // Keep a shared view for the caller before saveData takes ownership of unique
   std::shared_ptr<NudgedElasticBand> out(neb.release());
   // saveData expects unique_ptr - rebuild unique from shared is unsafe.
-  // Write results without consuming: call saveData on a temporary unique wrap fails.
-  // Instead write via a clone path: only return the band; file artifacts optional.
+  // Write results without consuming: call saveData on a temporary unique wrap
+  // fails. Instead write via a clone path: only return the band; file artifacts
+  // optional.
   return out;
 }
 

--- a/client/MinModeSaddleSearch.cpp
+++ b/client/MinModeSaddleSearch.cpp
@@ -281,8 +281,7 @@ int MinModeSaddleSearch::run(long max_iterations_override) {
       metadata.scalars.push_back({"angle", angle});
       metadata.scalars.push_back({"rotations", static_cast<double>(rotations)});
       if (retain_climb_frames_) {
-        climb_frames_.push_back(
-            eonc::io::matterToConFrame(*matter, &metadata));
+        climb_frames_.push_back(eonc::io::matterToConFrame(*matter, &metadata));
       }
       if (params.debug_options.write_movies) {
         if (!eonc::io::io_ok(

--- a/client/NEBSplineExtrema.cpp
+++ b/client/NEBSplineExtrema.cpp
@@ -252,8 +252,7 @@ std::vector<readcon::ConFrame> pathToConFrames(
     const std::vector<std::shared_ptr<Matter>> &path,
     const std::vector<std::shared_ptr<AtomMatrix>> &tangent,
     const std::vector<std::shared_ptr<EigenmodeStrategy>> &eigenmode_solvers,
-    long numImages, bool estimateEigenvalues,
-    std::optional<size_t> bandIndex) {
+    long numImages, bool estimateEigenvalues, std::optional<size_t> bandIndex) {
   const size_t nframes = static_cast<size_t>(numImages) + 2;
   if (path.size() < nframes) {
     return {};

--- a/client/NbGuard.h
+++ b/client/NbGuard.h
@@ -2,12 +2,14 @@
 ** Interpreter init without pybind11.
 **
 ** Polarity:
-**   * Preferred: Python owns the process (eon-server + pyeonclient). Interpreter
+**   * Preferred: Python owns the process (eon-server + pyeonclient).
+*Interpreter
 **     already exists; ensure_interpreter() is a no-op.
 **   * Fallback: standalone eonclient needs a pot that calls into Python (ASE).
 **     Use Py_InitializeEx — do NOT depend on pybind11::embed.
 **
-** Object/array marshalling for pots should use nanobind (nb::object, nb::ndarray)
+** Object/array marshalling for pots should use nanobind (nb::object,
+*nb::ndarray)
 ** once the interpreter is up, matching pyeonclient.
 */
 #pragma once

--- a/client/ParallelReplicaJob.cpp
+++ b/client/ParallelReplicaJob.cpp
@@ -10,13 +10,13 @@
 ** https://github.com/TheochemUI/eOn
 */
 #include "ParallelReplicaJob.h"
-#include <stdexcept>
 #include "BaseStructures.h"
 #include "BondBoost.h"
 #include "Dynamics.h"
 #include "ForceCallTimer.h"
 #include "HelperFunctions.h"
 #include "Matter.h"
+#include <stdexcept>
 
 #include <cmath>
 #include <format>
@@ -166,7 +166,8 @@ ParallelReplicaJob::runFromMatter(std::shared_ptr<Matter> initial) {
             snapshotIndex = static_cast<int>(mdSnapshots.size()) - 1;
 
           transitionTime = mdTimes[static_cast<size_t>(snapshotIndex)];
-          transitionStructure = *mdSnapshots[static_cast<size_t>(snapshotIndex)];
+          transitionStructure =
+              *mdSnapshots[static_cast<size_t>(snapshotIndex)];
         } else {
           transitionStructure = *trajectory;
           transitionTime = simulationTime;
@@ -256,7 +257,6 @@ ParallelReplicaJob::runFromMatter(std::shared_ptr<Matter> initial) {
   }
 
   return trajectory;
-
 }
 
 void ParallelReplicaJob::dephase(Matter &trajectory) {
@@ -268,8 +268,8 @@ void ParallelReplicaJob::dephase(Matter &trajectory) {
                                   0.5));
   if (dephaseSteps < 1)
     dephaseSteps = 1;
-  const long maxLoops = std::max(
-      1L, params.parallel_replica_options.dephase_loop_max);
+  const long maxLoops =
+      std::max(1L, params.parallel_replica_options.dephase_loop_max);
   QUILL_LOG_DEBUG(log, "[ParallelReplica] Dephasing: {} steps (max {} loops)",
                   dephaseSteps, maxLoops);
 

--- a/client/ParametersINI.cpp
+++ b/client/ParametersINI.cpp
@@ -248,16 +248,16 @@ int load_ini(INIReader &ini, Parameters &params) {
         sec, "extensions_directory", params.rgpot_options.extensions_directory);
     params.rgpot_options.check_consistency = ini.GetBoolean(
         sec, "check_consistency", params.rgpot_options.check_consistency);
-    params.rgpot_options.uncertainty_threshold = ini.GetReal(
-        sec, "uncertainty_threshold",
-        params.rgpot_options.uncertainty_threshold);
-    params.rgpot_options.torch_determinism_strict = ini.GetBoolean(
-        sec, "torch_determinism_strict",
-        params.rgpot_options.torch_determinism_strict);
+    params.rgpot_options.uncertainty_threshold =
+        ini.GetReal(sec, "uncertainty_threshold",
+                    params.rgpot_options.uncertainty_threshold);
+    params.rgpot_options.torch_determinism_strict =
+        ini.GetBoolean(sec, "torch_determinism_strict",
+                       params.rgpot_options.torch_determinism_strict);
     // XTB dlopen knobs (also accept [XTBPot] when backend=xtb)
-    params.rgpot_options.xtb_paramset =
-        ini.Get(sec, "paramset",
-                ini.Get(sec, "xtb_paramset", params.rgpot_options.xtb_paramset));
+    params.rgpot_options.xtb_paramset = ini.Get(
+        sec, "paramset",
+        ini.Get(sec, "xtb_paramset", params.rgpot_options.xtb_paramset));
     params.rgpot_options.xtb_accuracy = ini.GetReal(
         sec, "accuracy",
         ini.GetReal(sec, "xtb_accuracy", params.rgpot_options.xtb_accuracy));
@@ -270,21 +270,19 @@ int load_ini(INIReader &ini, Parameters &params) {
         ini.GetInteger(sec, "xtb_max_iterations",
                        params.rgpot_options.xtb_max_iterations)));
     params.rgpot_options.xtb_charge = ini.GetReal(
-        sec, "xtb_charge",
-        static_cast<double>(params.rgpot_options.charge));
-    params.rgpot_options.xtb_uhf = static_cast<int>(
-        ini.GetInteger(sec, "uhf",
-                       ini.GetInteger(sec, "xtb_uhf",
-                                      params.rgpot_options.xtb_uhf)));
+        sec, "xtb_charge", static_cast<double>(params.rgpot_options.charge));
+    params.rgpot_options.xtb_uhf = static_cast<int>(ini.GetInteger(
+        sec, "uhf",
+        ini.GetInteger(sec, "xtb_uhf", params.rgpot_options.xtb_uhf)));
     const std::string be = toLowerCase(params.rgpot_options.backend);
     if (be == "xtb" || be == "xtbpot" || be == "gfn" || be == "gfnxtb") {
       params.rgpot_options.xtb_paramset =
           ini.Get("XTBPot", "paramset", params.rgpot_options.xtb_paramset);
       params.rgpot_options.xtb_accuracy =
           ini.GetReal("XTBPot", "accuracy", params.rgpot_options.xtb_accuracy);
-      params.rgpot_options.xtb_electronic_temperature = ini.GetReal(
-          "XTBPot", "electronic_temperature",
-          params.rgpot_options.xtb_electronic_temperature);
+      params.rgpot_options.xtb_electronic_temperature =
+          ini.GetReal("XTBPot", "electronic_temperature",
+                      params.rgpot_options.xtb_electronic_temperature);
       params.rgpot_options.xtb_max_iterations = static_cast<int>(ini.GetInteger(
           "XTBPot", "max_iterations", params.rgpot_options.xtb_max_iterations));
       params.rgpot_options.xtb_uhf = static_cast<int>(

--- a/client/ParametersSSOT.cpp
+++ b/client/ParametersSSOT.cpp
@@ -21,7 +21,6 @@ const std::unordered_set<std::string> &field_index() {
   return idx;
 }
 
-
 JobType job_from_ssot(std::string_view j) {
   if (j == "process_search")
     return JobType::Process_Search;

--- a/client/ReplicaDynamicsJob.cpp
+++ b/client/ReplicaDynamicsJob.cpp
@@ -10,11 +10,11 @@
 ** https://github.com/TheochemUI/eOn
 */
 #include "ReplicaDynamicsJob.h"
-#include <stdexcept>
 #include "BaseStructures.h"
 #include "Dynamics.h"
 #include "ForceCallTimer.h"
 #include "HelperFunctions.h"
+#include <stdexcept>
 
 #include <format>
 #include <fstream>

--- a/client/meson.build
+++ b/client/meson.build
@@ -240,7 +240,24 @@ if not eigen_dep.found()
 endif
 _deps += [eigen_dep]
 
-quill_dep = dependency('quill', required: true)
+# conda-forge ships quill.pc; source installs often only export CMake config.
+quill_dep = dependency('quill', required: false)
+if not quill_dep.found()
+    quill_dep = dependency(
+        'quill',
+        method: 'cmake',
+        modules: ['quill::quill'],
+        required: false,
+    )
+endif
+if not quill_dep.found()
+    quill_dep = dependency(
+        'Quill',
+        method: 'cmake',
+        modules: ['quill::quill'],
+        required: true,
+    )
+endif
 _deps += quill_dep
 _args += ['-DQUILL_DISABLE_NON_PREFIXED_MACROS']
 

--- a/client/meson.build
+++ b/client/meson.build
@@ -361,8 +361,17 @@ nwchempot_dep = disabler()
 cpmdpot_dep = disabler()
 _rgpot_from_pkg = false
 if get_option('with_rgpot') or get_option('with_serve')
-    # 1) installed module
-    _rgpot_pkg = dependency('rgpot', required: false)
+    # 1) installed module only (never wrap fallback).
+    # dependency('rgpot') with default allow_fallback configures the wrap
+    # once with *default* options (with_rpc_client_only=false) before we
+    # can pass eOn's client-only opts; get_variable('nwchempot_dep') then
+    # fails because NWChemPot was never built. Force pkg-config-only here.
+    _rgpot_pkg = dependency(
+        'rgpot',
+        method: 'pkg-config',
+        required: false,
+        allow_fallback: false,
+    )
     if _rgpot_pkg.found()
         message('rgpot: using pkg-config (installed), not subproject wrap')
         _rgpot_from_pkg = true

--- a/client/potentials/Metatomic/MetatomicCAbi.cpp
+++ b/client/potentials/Metatomic/MetatomicCAbi.cpp
@@ -8,8 +8,8 @@
 #define EON_MTA_BUILD
 #include "metatomic_c_abi.h"
 
-#include "MetatomicPotential.h"
 #include "../../Parameters.h"
+#include "MetatomicPotential.h"
 
 #include <cstdio>
 #include <exception>

--- a/client/potentials/Metatomic/MetatomicDynPot.cpp
+++ b/client/potentials/Metatomic/MetatomicDynPot.cpp
@@ -57,8 +57,9 @@ MetatomicDynPot::~MetatomicDynPot() {
 }
 
 void MetatomicDynPot::force(long nAtoms, const double *positions,
-                            const int *atomicNrs, double *forces, double *energy,
-                            double *variance, const double *box) {
+                            const int *atomicNrs, double *forces,
+                            double *energy, double *variance,
+                            const double *box) {
   auto &loader = MetatomicLoader::instance();
   const int rc = loader.force(m_handle, nAtoms, positions, atomicNrs, forces,
                               energy, variance, box);

--- a/client/potentials/Metatomic/MetatomicEngineAbi.cpp
+++ b/client/potentials/Metatomic/MetatomicEngineAbi.cpp
@@ -1,11 +1,12 @@
 /*
-** libmetatomic_engine.so — C ABI for RGPOT-metatomic (wraps MetatomicPotential).
+** libmetatomic_engine.so — C ABI for RGPOT-metatomic (wraps
+*MetatomicPotential).
 ** Fat eOn still uses MetatomicPotential directly via potential=Metatomic.
 */
 #define RGPOT_MTA_ENGINE_BUILD
+#include "../../Parameters.h"
 #include "../Rgpot/metatomic_c_abi.h"
 #include "MetatomicPotential.h"
-#include "../../Parameters.h"
 #include <cstdio>
 #include <cstring>
 #include <exception>

--- a/client/potentials/Rgpot/MetatomicEngineLoader.cpp
+++ b/client/potentials/Rgpot/MetatomicEngineLoader.cpp
@@ -30,7 +30,8 @@ void *load_sym(void *h, const char *n) {
 }
 } // namespace
 
-MetatomicEngineLoader::MetatomicEngineLoader(const MetatomicEngineOptions &opt) {
+MetatomicEngineLoader::MetatomicEngineLoader(
+    const MetatomicEngineOptions &opt) {
   std::vector<std::string> paths;
   if (!opt.engine_path.empty())
     paths.push_back(opt.engine_path);
@@ -73,17 +74,18 @@ MetatomicEngineLoader::MetatomicEngineLoader(const MetatomicEngineOptions &opt) 
 #endif
   }
   if (!m_lib) {
-    std::string msg =
-        "RGPOT(metatomic): libmetatomic_engine.so not found "
-        "(set RGPOT_METATOMIC_ENGINE or EON_POTENTIALS_PATH)";
+    std::string msg = "RGPOT(metatomic): libmetatomic_engine.so not found "
+                      "(set RGPOT_METATOMIC_ENGINE or EON_POTENTIALS_PATH)";
     if (!last_dlerr.empty())
       msg += std::string("; last dlerror: ") + last_dlerr;
     throw std::runtime_error(msg);
   }
 
-  auto abi = reinterpret_cast<int (*)()>(load_sym(m_lib, "rgpot_mta_abi_version"));
+  auto abi =
+      reinterpret_cast<int (*)()>(load_sym(m_lib, "rgpot_mta_abi_version"));
   m_create = reinterpret_cast<create_fn>(load_sym(m_lib, "rgpot_mta_create"));
-  m_destroy = reinterpret_cast<destroy_fn>(load_sym(m_lib, "rgpot_mta_destroy"));
+  m_destroy =
+      reinterpret_cast<destroy_fn>(load_sym(m_lib, "rgpot_mta_destroy"));
   m_force = reinterpret_cast<force_fn>(load_sym(m_lib, "rgpot_mta_force"));
   if (!abi || !m_create || !m_destroy || !m_force ||
       abi() != RGPOT_MTA_ABI_VERSION) {
@@ -125,8 +127,8 @@ void MetatomicEngineLoader::force(long N, const double *R, const int *atomicNrs,
   if (!m_pot || !m_force)
     throw std::runtime_error("RGPOT(metatomic): engine not available");
   double var = 0.0;
-  const int rc = m_force(m_pot, N, R, atomicNrs, F, U, variance ? variance : &var,
-                         box);
+  const int rc =
+      m_force(m_pot, N, R, atomicNrs, F, U, variance ? variance : &var, box);
   if (rc != 0)
     throw std::runtime_error("RGPOT(metatomic): force failed");
 }

--- a/client/potentials/Rgpot/RGPotEngine.cpp
+++ b/client/potentials/Rgpot/RGPotEngine.cpp
@@ -12,10 +12,10 @@
 
 #include <capnp/message.h>
 
-#include "rgpot/CPMDPot/CPMDPot.hpp"
-#include "rgpot/NWChemPot/NWChemPot.hpp"
 #include "MetatomicEngineLoader.h"
 #include "XTBEngineLoader.h"
+#include "rgpot/CPMDPot/CPMDPot.hpp"
+#include "rgpot/NWChemPot/NWChemPot.hpp"
 #include "rgpot/rpc/Potentials.capnp.h"
 
 namespace {
@@ -189,9 +189,8 @@ RGPotEngine::RGPotEngine(const RGPotEngineOptions &opt)
           "RGPOT(xtb): engine not available (set RGPOT_XTB_ENGINE or "
           "[RgpotPot] engine_path to libxtb_engine.so)");
   } else {
-    throw std::runtime_error(
-        "RGPOT: unknown backend '" + opt.backend +
-        "' (expected nwchemc, cpmdc, metatomic, or xtb)");
+    throw std::runtime_error("RGPOT: unknown backend '" + opt.backend +
+                             "' (expected nwchemc, cpmdc, metatomic, or xtb)");
   }
 }
 

--- a/client/potentials/Rgpot/RgpotPot.cpp
+++ b/client/potentials/Rgpot/RgpotPot.cpp
@@ -96,9 +96,10 @@ RgpotPot::RgpotPot(const Parameters &p)
 
   impl_ = std::make_unique<RGPotEngine>(opt);
   backend_ = impl_->backend();
-  std::cout << "RgpotPot: in-process rgpot backend=" << backend_
-            << " (dlopen: libnwchemc/libcpmdc/libmetatomic_engine/libxtb_engine)"
-            << std::endl;
+  std::cout
+      << "RgpotPot: in-process rgpot backend=" << backend_
+      << " (dlopen: libnwchemc/libcpmdc/libmetatomic_engine/libxtb_engine)"
+      << std::endl;
 }
 
 RgpotPot::~RgpotPot() = default;

--- a/client/potentials/Rgpot/XTBEngineLoader.cpp
+++ b/client/potentials/Rgpot/XTBEngineLoader.cpp
@@ -78,9 +78,8 @@ XTBEngineLoader::XTBEngineLoader(const XTBEngineOptions &opt) {
 #endif
   }
   if (!m_lib) {
-    std::string msg =
-        "RGPOT(xtb): libxtb_engine.so not found "
-        "(set RGPOT_XTB_ENGINE or [RgpotPot] engine_path)";
+    std::string msg = "RGPOT(xtb): libxtb_engine.so not found "
+                      "(set RGPOT_XTB_ENGINE or [RgpotPot] engine_path)";
     if (!last_dlerr.empty())
       msg += std::string("; last dlerror: ") + last_dlerr;
     throw std::runtime_error(msg);
@@ -89,7 +88,8 @@ XTBEngineLoader::XTBEngineLoader(const XTBEngineOptions &opt) {
   auto abi =
       reinterpret_cast<int (*)()>(load_sym(m_lib, "rgpot_xtb_abi_version"));
   m_create = reinterpret_cast<create_fn>(load_sym(m_lib, "rgpot_xtb_create"));
-  m_destroy = reinterpret_cast<destroy_fn>(load_sym(m_lib, "rgpot_xtb_destroy"));
+  m_destroy =
+      reinterpret_cast<destroy_fn>(load_sym(m_lib, "rgpot_xtb_destroy"));
   m_force = reinterpret_cast<force_fn>(load_sym(m_lib, "rgpot_xtb_force"));
   if (!abi || !m_create || !m_destroy || !m_force ||
       abi() != RGPOT_XTB_ABI_VERSION) {
@@ -129,8 +129,8 @@ void XTBEngineLoader::force(long N, const double *R, const int *atomicNrs,
   if (!m_pot || !m_force)
     throw std::runtime_error("RGPOT(xtb): engine not available");
   double var = 0.0;
-  const int rc = m_force(m_pot, N, R, atomicNrs, F, U,
-                         variance ? variance : &var, box);
+  const int rc =
+      m_force(m_pot, N, R, atomicNrs, F, U, variance ? variance : &var, box);
   if (rc != 0)
     throw std::runtime_error("RGPOT(xtb): force failed");
 }

--- a/client/python/bind/bind_analysis.cpp
+++ b/client/python/bind/bind_analysis.cpp
@@ -103,8 +103,7 @@ void bind_analysis(nb::module_ &m) {
         return vectori_to_numpy(atoms);
       },
       nb::arg("parameters"), nb::arg("min1"), nb::arg("saddle"),
-      nb::arg("min2"),
-      "Atom indices selected by prefactor filter (int64 1-d)");
+      nb::arg("min2"), "Atom indices selected by prefactor filter (int64 1-d)");
 
   m.def(
       "all_free_atoms",

--- a/client/python/bind/bind_ase.cpp
+++ b/client/python/bind/bind_ase.cpp
@@ -4,8 +4,8 @@
 #include "Matter.h"
 #include "Parameters.h"
 #include "Potential.h"
-#include "eigen_numpy.hpp"
 #include "bind_helpers.hpp"
+#include "eigen_numpy.hpp"
 
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
@@ -53,14 +53,11 @@ void bind_ase(nb::module_ &m) {
         }
         auto np = nb::module_::import_("numpy");
 
-        nb::object pos_o =
-            np_contig(atoms.attr("get_positions")(), "float64");
+        nb::object pos_o = np_contig(atoms.attr("get_positions")(), "float64");
         nb::object cell_o =
             np_contig(np.attr("asarray")(atoms.attr("get_cell")()), "float64");
-        nb::object mass_o =
-            np_contig(atoms.attr("get_masses")(), "float64");
-        nb::object z_o =
-            np_contig(atoms.attr("get_atomic_numbers")(), "int32");
+        nb::object mass_o = np_contig(atoms.attr("get_masses")(), "float64");
+        nb::object z_o = np_contig(atoms.attr("get_atomic_numbers")(), "int32");
 
         ArrF64 pos = nb::cast<ArrF64>(pos_o);
         ArrF64 cell = nb::cast<ArrF64>(cell_o);
@@ -164,9 +161,9 @@ void bind_ase(nb::module_ &m) {
         }
 
         nb::object atoms =
-            Atoms(nb::arg("numbers") = numbers, nb::arg("positions") = positions,
-                  nb::arg("cell") = cell, nb::arg("pbc") = use_pbc,
-                  nb::arg("masses") = masses);
+            Atoms(nb::arg("numbers") = numbers,
+                  nb::arg("positions") = positions, nb::arg("cell") = cell,
+                  nb::arg("pbc") = use_pbc, nb::arg("masses") = masses);
 
         nb::list fixed_idx;
         for (long i = 0; i < n; ++i) {

--- a/client/python/bind/bind_eigenmode.cpp
+++ b/client/python/bind/bind_eigenmode.cpp
@@ -1,6 +1,8 @@
 /*
-** Min-mode: chemist-facing Dimer(method=..., accelerant=...) plus low-level classes.
-** Default method is "improved". accelerant="gp" routes to AtomicGPDimer (WITH_GPRD).
+** Min-mode: chemist-facing Dimer(method=..., accelerant=...) plus low-level
+*classes.
+** Default method is "improved". accelerant="gp" routes to AtomicGPDimer
+*(WITH_GPRD).
 */
 #include "Davidson.h"
 #include "Dimer.h"
@@ -52,8 +54,8 @@ eonc::Parameters route_minmode_params(eonc::Parameters params,
 
   if (!acc.empty() && acc != "none" && acc != "gp") {
     throw std::runtime_error(
-        "Dimer: accelerant must be None/\"\" or \"gp\", got \"" + accelerant_in +
-        "\"");
+        "Dimer: accelerant must be None/\"\" or \"gp\", got \"" +
+        accelerant_in + "\"");
   }
   const bool want_gp = (acc == "gp");
 
@@ -135,9 +137,7 @@ struct PyDimer {
     eonc::eigenmodeCompute(*strategy, std::move(m), direction);
   }
 
-  double eigenvalue() const {
-    return eonc::eigenmodeGetEigenvalue(*strategy);
-  }
+  double eigenvalue() const { return eonc::eigenmodeGetEigenvalue(*strategy); }
 
   auto eigenvector() const {
     return matrix_to_numpy(eonc::eigenmodeGetEigenvector(*strategy));
@@ -187,8 +187,7 @@ nb::class_<Class> &bind_minmode_common(nb::class_<Class> &cls) {
            new (self) Class(std::move(matter), params, std::move(pot));
          },
          nb::arg("matter"), nb::arg("parameters"), nb::arg("potential"),
-         nb::keep_alive<1, 2>(), nb::keep_alive<1, 3>(),
-         nb::keep_alive<1, 4>(),
+         nb::keep_alive<1, 2>(), nb::keep_alive<1, 3>(), nb::keep_alive<1, 4>(),
          "Low-level solver: Matter + Parameters + Potential")
       .def(
           "compute",
@@ -260,10 +259,8 @@ void bind_eigenmode(nb::module_ &m) {
            "Converge lowest eigenmode. direction: float64 (n_atoms, 3)")
       .def_prop_ro("eigenvalue", &PyDimer::eigenvalue)
       .def_prop_ro("eigenvector", &PyDimer::eigenvector, nb::rv_policy::move)
-      .def_prop_ro("method",
-                   [](const PyDimer &d) { return d.method; })
-      .def_prop_ro("accelerant",
-                   [](const PyDimer &d) { return d.accelerant; })
+      .def_prop_ro("method", [](const PyDimer &d) { return d.method; })
+      .def_prop_ro("accelerant", [](const PyDimer &d) { return d.accelerant; })
       .def_prop_ro("total_force_calls", &PyDimer::total_force_calls)
       .def_prop_ro("total_iterations", &PyDimer::total_iterations)
       .def_prop_ro("stats_torque", &PyDimer::stats_torque)
@@ -297,10 +294,9 @@ void bind_eigenmode(nb::module_ &m) {
            nb::arg("mode"),
            "Lock rotation reference mode (OCI / mode tracking); (n,3) or 3n")
         .def("clear_reference_mode", &eonc::ImprovedDimer::clearReferenceMode)
-        .def_prop_ro("rotation_did_converge",
-                     [](const eonc::ImprovedDimer &s) {
-                       return s.rotationDidConverge;
-                     })
+        .def_prop_ro(
+            "rotation_did_converge",
+            [](const eonc::ImprovedDimer &s) { return s.rotationDidConverge; })
         .def_prop_ro("found_negative_curvature",
                      [](const eonc::ImprovedDimer &s) {
                        return s.foundNegativeCurvature;

--- a/client/python/bind/bind_enums.cpp
+++ b/client/python/bind/bind_enums.cpp
@@ -22,8 +22,9 @@ void bind_enums(nb::module_ &m) {
       .value("InvalidArgument", eonc::io::IoStatus::InvalidArgument)
       .export_values();
 
-  m.def("io_ok", [](eonc::io::IoStatus s) { return eonc::io::io_ok(s); },
-        nb::arg("status"));
+  m.def(
+      "io_ok", [](eonc::io::IoStatus s) { return eonc::io::io_ok(s); },
+      nb::arg("status"));
   m.def(
       "io_status_name",
       [](eonc::io::IoStatus s) {

--- a/client/python/bind/bind_jobs.cpp
+++ b/client/python/bind/bind_jobs.cpp
@@ -31,7 +31,8 @@ namespace eonc::pybind {
 namespace nb = nanobind;
 
 void bind_jobs(nb::module_ &m) {
-  nb::class_<eonc::Job>(m, "Job", "Abstract eOn client job (Minimization, NEB, …)")
+  nb::class_<eonc::Job>(m, "Job",
+                        "Abstract eOn client job (Minimization, NEB, …)")
       .def("get_type", &eonc::Job::getType)
       .def(
           "run",
@@ -87,7 +88,8 @@ void bind_jobs(nb::module_ &m) {
          double system_time) {
         std::ofstream out(path, std::ios::app);
         if (!out.is_open())
-          throw std::runtime_error("append_results_timing: cannot open " + path);
+          throw std::runtime_error("append_results_timing: cannot open " +
+                                   path);
         out << "time_seconds " << elapsed_seconds << "\n";
 #ifndef _WIN32
         out << "user_time " << user_time << "\n";

--- a/client/python/bind/bind_matter.cpp
+++ b/client/python/bind/bind_matter.cpp
@@ -6,10 +6,10 @@
 
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
+#include <nanobind/stl/array.h>
 #include <nanobind/stl/shared_ptr.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/tuple.h>
-#include <nanobind/stl/array.h>
 
 #include <memory>
 #include <stdexcept>
@@ -26,8 +26,7 @@ void bind_matter(nb::module_ &m) {
   nb::class_<Matter>(m, "Matter",
                      "Atomic structure + potential (eOn C++ client core)")
       .def(nb::init<std::shared_ptr<Potential>, const Parameters &>(),
-           nb::arg("potential"), nb::arg("parameters"),
-           nb::keep_alive<1, 2>(),
+           nb::arg("potential"), nb::arg("parameters"), nb::keep_alive<1, 2>(),
            nb::keep_alive<1, 3>(),
            "Create empty Matter bound to a potential and parameters "
            "(Parameters must outlive Matter)")
@@ -44,7 +43,8 @@ void bind_matter(nb::module_ &m) {
             return view_n3(matter_positions_ptr(self), self.numberOfAtoms());
           },
           [](Matter &self, const NpF64 &arr) {
-            matter_set_positions_buf(self, require_n3(arr, self.numberOfAtoms()),
+            matter_set_positions_buf(self,
+                                     require_n3(arr, self.numberOfAtoms()),
                                      self.numberOfAtoms());
           },
           nb::rv_policy::reference_internal,
@@ -55,11 +55,12 @@ void bind_matter(nb::module_ &m) {
             return matrix_to_numpy(self.getPositionsFree());
           },
           nb::rv_policy::move)
-      .def("set_positions_free",
-           [](Matter &self, const NpF64 &arr) {
-             self.setPositionsFree(atom_matrix_from_numpy(arr));
-           },
-           nb::arg("positions"))
+      .def(
+          "set_positions_free",
+          [](Matter &self, const NpF64 &arr) {
+            self.setPositionsFree(atom_matrix_from_numpy(arr));
+          },
+          nb::arg("positions"))
 
       // cell: getCell() is by value — small owned copy; set via Map
       .def_prop_rw(
@@ -79,9 +80,9 @@ void bind_matter(nb::module_ &m) {
             return matrix_to_numpy(self.getVelocities());
           },
           [](Matter &self, const NpF64 &arr) {
-            matter_set_velocities_buf(
-                self, require_n3(arr, self.numberOfAtoms()),
-                self.numberOfAtoms());
+            matter_set_velocities_buf(self,
+                                      require_n3(arr, self.numberOfAtoms()),
+                                      self.numberOfAtoms());
           },
           nb::rv_policy::move)
 
@@ -119,17 +120,16 @@ void bind_matter(nb::module_ &m) {
             return matrix_to_numpy(free_forces);
           },
           nb::rv_policy::move)
-      .def("set_forces",
-           [](Matter &self, const NpF64 &arr) {
-             self.setForces(atom_matrix_from_numpy(arr));
-           },
-           nb::arg("forces"))
+      .def(
+          "set_forces",
+          [](Matter &self, const NpF64 &arr) {
+            self.setForces(atom_matrix_from_numpy(arr));
+          },
+          nb::arg("forces"))
 
       .def_prop_rw(
           "masses",
-          [](const Matter &self) {
-            return vector_to_numpy(self.getMasses());
-          },
+          [](const Matter &self) { return vector_to_numpy(self.getMasses()); },
           [](Matter &self, const NpF64 &arr) {
             if (arr.ndim() != 1 ||
                 static_cast<long>(arr.shape(0)) != self.numberOfAtoms()) {
@@ -146,8 +146,8 @@ void bind_matter(nb::module_ &m) {
           },
           [](Matter &self, nb::object obj) {
             auto np = nb::module_::import_("numpy");
-            nb::object cont = np.attr("ascontiguousarray")(
-                obj, nb::arg("dtype") = "int32");
+            nb::object cont =
+                np.attr("ascontiguousarray")(obj, nb::arg("dtype") = "int32");
             auto arr = nb::cast<NpI32>(cont);
             if (arr.ndim() != 1 ||
                 static_cast<long>(arr.shape(0)) != self.numberOfAtoms()) {
@@ -180,8 +180,8 @@ void bind_matter(nb::module_ &m) {
           },
           [](Matter &self, nb::object obj) {
             auto np = nb::module_::import_("numpy");
-            nb::object cont = np.attr("ascontiguousarray")(
-                obj, nb::arg("dtype") = "int32");
+            nb::object cont =
+                np.attr("ascontiguousarray")(obj, nb::arg("dtype") = "int32");
             auto arr = nb::cast<NpI32>(cont);
             if (arr.ndim() != 1 ||
                 static_cast<long>(arr.shape(0)) != self.numberOfAtoms()) {
@@ -197,11 +197,8 @@ void bind_matter(nb::module_ &m) {
       // --- free mask ---
       .def_prop_ro(
           "free_mask",
-          [](const Matter &self) {
-            return matrix_to_numpy(self.getFree());
-          },
-          nb::rv_policy::move,
-          "Nx3 free mask (1 free, 0 fixed)")
+          [](const Matter &self) { return matrix_to_numpy(self.getFree()); },
+          nb::rv_policy::move, "Nx3 free mask (1 free, 0 fixed)")
 
       // --- energy / mechanics ---
       .def_prop_ro(
@@ -273,8 +270,8 @@ void bind_matter(nb::module_ &m) {
                 ok = self.relax(quiet, write_movie, checkpoint, prefix_movie,
                                 prefix_checkpoint, retain_frames);
               }
-              return nb::make_tuple(
-                  nb::cast(self, nb::rv_policy::reference), ok);
+              return nb::make_tuple(nb::cast(self, nb::rv_policy::reference),
+                                    ok);
             }
             Matter out(self);
             bool ok = false;
@@ -295,9 +292,7 @@ void bind_matter(nb::module_ &m) {
           "Returns (Matter, converged: bool).")
       .def(
           "movie_frames",
-          [](Matter &self) {
-            return con_frames_to_python(self.movieFrames());
-          },
+          [](Matter &self) { return con_frames_to_python(self.movieFrames()); },
           "list[readcon.ConFrame] retained by relax(retain_frames=True).")
       .def(
           "take_movie_frames",
@@ -306,8 +301,7 @@ void bind_matter(nb::module_ &m) {
           },
           "Take ownership of retained movie frames (clears storage).")
       .def(
-          "clear_movie_frames",
-          [](Matter &self) { self.clearMovieFrames(); },
+          "clear_movie_frames", [](Matter &self) { self.clearMovieFrames(); },
           "Drop retained minimization movie frames.")
 
       // --- I/O (same ConFileIO / readcon path as CLI client) ---
@@ -352,9 +346,8 @@ void bind_matter(nb::module_ &m) {
       .def("get_atom_index", &Matter::getAtomIndex, nb::arg("atom"))
       .def("set_atom_index", &Matter::setAtomIndex, nb::arg("atom"),
            nb::arg("index"))
-      .def_prop_ro(
-          "header_con",
-          [](const Matter &self) { return self.getHeaderCon(); })
+      .def_prop_ro("header_con",
+                   [](const Matter &self) { return self.getHeaderCon(); })
       .def(
           "set_header_con_line",
           [](Matter &self, size_t i, const std::string &line) {

--- a/client/python/bind/bind_neb.cpp
+++ b/client/python/bind/bind_neb.cpp
@@ -1,5 +1,6 @@
 /*
-** NudgedElasticBand + path init helpers — first-class NEB surface for pyeonclient.
+** NudgedElasticBand + path init helpers — first-class NEB surface for
+*pyeonclient.
 */
 #include "ConFileIO.h"
 #include "Matter.h"
@@ -7,8 +8,8 @@
 #include "NEBSplineExtrema.h"
 #include "NudgedElasticBand.h"
 #include "Parameters.h"
-#include "Potential.h"
 #include "PotRegistry.h"
+#include "Potential.h"
 #include "bind_helpers.hpp"
 #ifdef WITH_GP_SURROGATE
 #include "GPSurrogateJob.h"
@@ -51,9 +52,10 @@ void bind_neb(nb::module_ &m) {
       .value("MAX_UNCERTAINTY", NudgedElasticBand::NEBStatus::MAX_UNCERTAINTY)
       .export_values();
 
-  nb::class_<NudgedElasticBand>(m, "NudgedElasticBand",
-                                "NEB band: path images, compute, forces, extrema")
-      // --- construct from endpoints (linear / IDPP / FILE init via Parameters) ---
+  nb::class_<NudgedElasticBand>(
+      m, "NudgedElasticBand", "NEB band: path images, compute, forces, extrema")
+      // --- construct from endpoints (linear / IDPP / FILE init via Parameters)
+      // ---
       .def(
           "__init__",
           [](NudgedElasticBand *self, std::shared_ptr<Matter> initial,
@@ -66,8 +68,7 @@ void bind_neb(nb::module_ &m) {
                                   params, std::move(pot));
           },
           nb::arg("initial"), nb::arg("final"), nb::arg("parameters"),
-          nb::arg("potential"),
-          nb::keep_alive<1, 2>(), nb::keep_alive<1, 3>(),
+          nb::arg("potential"), nb::keep_alive<1, 2>(), nb::keep_alive<1, 3>(),
           nb::keep_alive<1, 4>(), nb::keep_alive<1, 5>(),
           "Build NEB from reactant/product Matter; path init follows "
           "Parameters.neb_options.initialization")
@@ -97,7 +98,8 @@ void bind_neb(nb::module_ &m) {
             nb::gil_scoped_release release;
             self.updateForces(ci_active);
           },
-          nb::arg("ci_active"), "Recompute projected forces; ci_active toggles CI")
+          nb::arg("ci_active"),
+          "Recompute projected forces; ci_active toggles CI")
       .def(
           "update_forces",
           [](NudgedElasticBand &self) {
@@ -105,7 +107,8 @@ void bind_neb(nb::module_ &m) {
             self.updateForces();
           },
           "Recompute projected forces with current CI flag")
-      .def("set_ci_enabled", &NudgedElasticBand::setCIEnabled, nb::arg("enabled"))
+      .def("set_ci_enabled", &NudgedElasticBand::setCIEnabled,
+           nb::arg("enabled"))
       .def("convergence_force", &NudgedElasticBand::convergenceForce)
       .def("find_extrema", &NudgedElasticBand::findExtrema)
       .def("print_image_data", &NudgedElasticBand::printImageData,
@@ -145,8 +148,7 @@ void bind_neb(nb::module_ &m) {
           nb::arg("i"), nb::rv_policy::reference_internal,
           "Shared Matter at path index i (0=reactant, -1/last=product)")
       .def(
-          "path_images",
-          [](NudgedElasticBand &n) { return n.path; },
+          "path_images", [](NudgedElasticBand &n) { return n.path; },
           nb::rv_policy::reference_internal,
           "Full path as list of shared Matter (endpoints + intermediates)")
       .def(
@@ -181,9 +183,8 @@ void bind_neb(nb::module_ &m) {
       .def_prop_ro(
           "extremum_positions",
           [](const NudgedElasticBand &n) { return n.extremumPosition; })
-      .def_prop_ro(
-          "extremum_energies",
-          [](const NudgedElasticBand &n) { return n.extremumEnergy; })
+      .def_prop_ro("extremum_energies",
+                   [](const NudgedElasticBand &n) { return n.extremumEnergy; })
       .def_prop_ro(
           "extremum_curvatures",
           [](const NudgedElasticBand &n) { return n.extremumCurvature; })
@@ -210,12 +211,11 @@ void bind_neb(nb::module_ &m) {
             }
             return con_frames_to_python(std::move(frames));
           },
-          nb::arg("band_index") = nb::none(),
-          "Alias of path_frames().")
+          nb::arg("band_index") = nb::none(), "Alias of path_frames().")
       .def("__repr__", [](NudgedElasticBand &n) {
         return "<NudgedElasticBand images=" + std::to_string(n.numImages) +
-               " status=" +
-               std::to_string(static_cast<int>(n.getStatus())) + ">";
+               " status=" + std::to_string(static_cast<int>(n.getStatus())) +
+               ">";
       });
 
   // --- path init helpers (same as NEBJob / NudgedElasticBand internals) ---
@@ -234,8 +234,8 @@ void bind_neb(nb::module_ &m) {
 
   m.def(
       "neb_load_path_from_files",
-      [](const std::vector<std::string> &files,
-         std::shared_ptr<Potential> pot, const Parameters &params) {
+      [](const std::vector<std::string> &files, std::shared_ptr<Potential> pot,
+         const Parameters &params) {
         if (files.size() < 2)
           throw std::invalid_argument(
               "neb_load_path_from_files needs >= 2 frames");
@@ -255,7 +255,8 @@ void bind_neb(nb::module_ &m) {
 
   m.def(
       "neb_linear_path",
-      [](const Matter &initial, const Matter &final_state, long n_intermediate) {
+      [](const Matter &initial, const Matter &final_state,
+         long n_intermediate) {
         return eonc::helpers::neb_paths::linearPath(
             initial, final_state, static_cast<size_t>(n_intermediate));
       },
@@ -311,16 +312,16 @@ void bind_neb(nb::module_ &m) {
         switch (method) {
         case NEBInit::IDPP:
           return eonc::helpers::neb_paths::idppPath(initial, final_state, n,
-                                                   params, false);
+                                                    params, false);
         case NEBInit::IDPP_COLLECTIVE:
           return eonc::helpers::neb_paths::idppCollectivePath(
               initial, final_state, n, params, false);
         case NEBInit::SIDPP:
           return eonc::helpers::neb_paths::sidppPath(initial, final_state, n,
-                                                    params, false);
+                                                     params, false);
         case NEBInit::SIDPP_ZBL:
           return eonc::helpers::neb_paths::sidppPath(initial, final_state, n,
-                                                    params, true);
+                                                     params, true);
         case NEBInit::FILE:
           throw std::runtime_error(
               "neb_initial_path: FILE init needs neb_load_path_from_files / "
@@ -336,8 +337,8 @@ void bind_neb(nb::module_ &m) {
       "(LINEAR / IDPP / IDPP_COLLECTIVE / SIDPP / SIDPP_ZBL). "
       "Same engines NudgedElasticBand uses for endpoint construction.");
 
-
-  // Chemist-facing NEB: optional accelerant="gp" (GPSurrogateJob), else plain NEB.
+  // Chemist-facing NEB: optional accelerant="gp" (GPSurrogateJob), else plain
+  // NEB.
   struct PyNEB {
     eonc::Parameters params;
     std::shared_ptr<eonc::Potential> pot;
@@ -357,30 +358,39 @@ void bind_neb(nb::module_ &m) {
     PyNEB(std::shared_ptr<eonc::Matter> init, std::shared_ptr<eonc::Matter> fin,
           const eonc::Parameters &p, std::shared_ptr<eonc::Potential> pot_in,
           std::string acc)
-        : params(p), pot(std::move(pot_in)), initial(std::move(init)),
-          final_state(std::move(fin)), accelerant(lower(std::move(acc))) {
+        : params(p),
+          pot(std::move(pot_in)),
+          initial(std::move(init)),
+          final_state(std::move(fin)),
+          accelerant(lower(std::move(acc))) {
       if (!initial || !final_state)
         throw std::runtime_error("NEB: initial and final Matter required");
       if (!pot)
         pot = initial->getPotential();
       if (accelerant != "" && accelerant != "none" && accelerant != "gp")
         throw std::runtime_error(
-            "NEB: accelerant must be \"\" or \"gp\", got \"" + accelerant + "\"");
+            "NEB: accelerant must be \"\" or \"gp\", got \"" + accelerant +
+            "\"");
     }
 
     PyNEB(const std::vector<eonc::Matter> &path_in, const eonc::Parameters &p,
           std::shared_ptr<eonc::Potential> pot_in, std::string acc)
-        : params(p), pot(std::move(pot_in)), path(path_in), has_path(true),
+        : params(p),
+          pot(std::move(pot_in)),
+          path(path_in),
+          has_path(true),
           accelerant(lower(std::move(acc))) {
       if (path.size() < 2)
         throw std::runtime_error("NEB: path needs >= 2 frames");
       if (!pot) {
         // path holds Matter by value; potential must be passed explicitly
-        throw std::runtime_error("NEB: potential required for path constructor");
+        throw std::runtime_error(
+            "NEB: potential required for path constructor");
       }
       if (accelerant != "" && accelerant != "none" && accelerant != "gp")
         throw std::runtime_error(
-            "NEB: accelerant must be \"\" or \"gp\", got \"" + accelerant + "\"");
+            "NEB: accelerant must be \"\" or \"gp\", got \"" + accelerant +
+            "\"");
     }
 
     eonc::NudgedElasticBand::NEBStatus compute() {
@@ -408,7 +418,7 @@ void bind_neb(nb::module_ &m) {
         band = std::make_shared<eonc::NudgedElasticBand>(path, params, pot);
       } else {
         band = std::make_shared<eonc::NudgedElasticBand>(initial, final_state,
-                                                        params, pot);
+                                                         params, pot);
       }
       eonc::NudgedElasticBand::NEBStatus st;
       {
@@ -429,7 +439,8 @@ void bind_neb(nb::module_ &m) {
           [](PyNEB *self, std::shared_ptr<eonc::Matter> initial,
              std::shared_ptr<eonc::Matter> final_state,
              const eonc::Parameters &params,
-             std::shared_ptr<eonc::Potential> pot, const std::string &accelerant) {
+             std::shared_ptr<eonc::Potential> pot,
+             const std::string &accelerant) {
             nb::gil_scoped_release release;
             new (self) PyNEB(std::move(initial), std::move(final_state), params,
                              std::move(pot), accelerant);
@@ -443,7 +454,8 @@ void bind_neb(nb::module_ &m) {
           "__init__",
           [](PyNEB *self, const std::vector<eonc::Matter> &path,
              const eonc::Parameters &params,
-             std::shared_ptr<eonc::Potential> pot, const std::string &accelerant) {
+             std::shared_ptr<eonc::Potential> pot,
+             const std::string &accelerant) {
             nb::gil_scoped_release release;
             new (self) PyNEB(path, params, std::move(pot), accelerant);
           },
@@ -457,7 +469,8 @@ void bind_neb(nb::module_ &m) {
           "find_extrema",
           [](PyNEB &self) {
             if (!self.band)
-              throw std::runtime_error("NEB.find_extrema: call compute() first");
+              throw std::runtime_error(
+                  "NEB.find_extrema: call compute() first");
             nb::gil_scoped_release release;
             self.band->findExtrema();
           },
@@ -470,22 +483,21 @@ void bind_neb(nb::module_ &m) {
             return self.band;
           },
           "Underlying NudgedElasticBand after compute().")
-      .def_prop_ro("accelerant",
-                   [](const PyNEB &s) { return s.accelerant; })
-      .def_prop_ro(
-          "status",
-          [](PyNEB &self) {
-            if (!self.band)
-              throw std::runtime_error("NEB.status: call compute() first");
-            return self.band->getStatus();
-          })
-      .def(
-          "path_images",
-          [](PyNEB &self) {
-            if (!self.band)
-              throw std::runtime_error("NEB.path_images: call compute() first");
-            return self.band->path;
-          })
+      .def_prop_ro("accelerant", [](const PyNEB &s) { return s.accelerant; })
+      .def_prop_ro("status",
+                   [](PyNEB &self) {
+                     if (!self.band)
+                       throw std::runtime_error(
+                           "NEB.status: call compute() first");
+                     return self.band->getStatus();
+                   })
+      .def("path_images",
+           [](PyNEB &self) {
+             if (!self.band)
+               throw std::runtime_error(
+                   "NEB.path_images: call compute() first");
+             return self.band->path;
+           })
       .def(
           "path_frames",
           [](PyNEB &self, std::optional<size_t> band_index) {
@@ -504,7 +516,8 @@ void bind_neb(nb::module_ &m) {
           "to_conframes",
           [](PyNEB &self, std::optional<size_t> band_index) {
             if (!self.band)
-              throw std::runtime_error("NEB.to_conframes: call compute() first");
+              throw std::runtime_error(
+                  "NEB.to_conframes: call compute() first");
             std::vector<readcon::ConFrame> frames;
             {
               nb::gil_scoped_release release;
@@ -512,18 +525,14 @@ void bind_neb(nb::module_ &m) {
             }
             return con_frames_to_python(std::move(frames));
           },
-          nb::arg("band_index") = nb::none(),
-          "Alias of path_frames().")
-      .def_prop_ro(
-          "n_path",
-          [](PyNEB &self) {
-            if (!self.band)
-              return 0L;
-            return static_cast<long>(self.band->path.size());
-          });
+          nb::arg("band_index") = nb::none(), "Alias of path_frames().")
+      .def_prop_ro("n_path", [](PyNEB &self) {
+        if (!self.band)
+          return 0L;
+        return static_cast<long>(self.band->path.size());
+      });
 
-
-    // Full NEBJob::saveData artifact set (callable as a Python step).
+  // Full NEBJob::saveData artifact set (callable as a Python step).
   m.def(
       "neb_write_results",
       [](NudgedElasticBand &neb, const Parameters &params,
@@ -532,7 +541,8 @@ void bind_neb(nb::module_ &m) {
         {
           std::ofstream out("results.dat", std::ios::binary);
           if (!out)
-            throw std::runtime_error("neb_write_results: cannot open results.dat");
+            throw std::runtime_error(
+                "neb_write_results: cannot open results.dat");
           auto status = neb.getStatus();
           out << std::format("{} termination_reason\n",
                              static_cast<int>(status));
@@ -548,11 +558,11 @@ void bind_neb(nb::module_ &m) {
                              neb.path[0]->getPotentialEnergy());
           out << std::format("{} number_of_images\n", neb.numImages);
           for (long i = 0; i <= neb.numImages + 1; i++) {
-            out << std::format("{:f} image{}_energy\n",
-                               neb.path[static_cast<size_t>(i)]
-                                       ->getPotentialEnergy() -
-                                   neb.path[0]->getPotentialEnergy(),
-                               i);
+            out << std::format(
+                "{:f} image{}_energy\n",
+                neb.path[static_cast<size_t>(i)]->getPotentialEnergy() -
+                    neb.path[0]->getPotentialEnergy(),
+                i);
             out << std::format(
                 "{:f} image{}_force\n",
                 neb.path[static_cast<size_t>(i)]->getForces().norm(), i);
@@ -586,8 +596,7 @@ void bind_neb(nb::module_ &m) {
 
         // Discrete saddle
         const std::string sp = "sp.con";
-        if (!eonc::io::io_ok(
-                neb.path[neb.maxEnergyImage]->matter2con(sp)))
+        if (!eonc::io::io_ok(neb.path[neb.maxEnergyImage]->matter2con(sp)))
           throw std::runtime_error("neb_write_results: failed sp.con");
         returnFiles.push_back(sp);
 
@@ -595,9 +604,8 @@ void bind_neb(nb::module_ &m) {
         if (params.neb_options.mmf_peaks.enabled && neb.numExtrema > 0) {
           int peakCount = 0;
           for (long i = 0; i < neb.numExtrema; i++) {
-            double relativeEnergy =
-                neb.extremumEnergy[static_cast<size_t>(i)] -
-                neb.path[0]->getPotentialEnergy();
+            double relativeEnergy = neb.extremumEnergy[static_cast<size_t>(i)] -
+                                    neb.path[0]->getPotentialEnergy();
             if (!(neb.extremumCurvature[static_cast<size_t>(i)] < 0 &&
                   relativeEnergy > params.neb_options.mmf_peaks.tolerance))
               continue;
@@ -640,8 +648,7 @@ void bind_neb(nb::module_ &m) {
         neb.printImageData(true, std::numeric_limits<size_t>::max());
         return returnFiles;
       },
-      nb::arg("neb"), nb::arg("parameters"),
-      nb::arg("force_calls_neb") = 0,
+      nb::arg("neb"), nb::arg("parameters"), nb::arg("force_calls_neb") = 0,
       "Write full NEBJob::saveData artifact set: results.dat, neb.con, "
       "sp.con, peaks, neb.dat");
 

--- a/client/python/bind/bind_parameters.cpp
+++ b/client/python/bind/bind_parameters.cpp
@@ -31,8 +31,7 @@ void bind_parameters(nb::module_ &m) {
       .def("to_json", &eonc::Parameters::to_json)
       // --- Main ---
       .def_prop_rw(
-          "job",
-          [](const eonc::Parameters &s) { return s.main_options.job; },
+          "job", [](const eonc::Parameters &s) { return s.main_options.job; },
           [](eonc::Parameters &s, eonc::JobType j) { s.main_options.job = j; })
       .def_prop_rw(
           "potential",
@@ -126,14 +125,18 @@ void bind_parameters(nb::module_ &m) {
           })
       .def_prop_rw(
           "opt_max_move",
-          [](const eonc::Parameters &s) { return s.optimizer_options.max_move; },
+          [](const eonc::Parameters &s) {
+            return s.optimizer_options.max_move;
+          },
           [](eonc::Parameters &s, double v) {
             s.optimizer_options.max_move = v;
           })
       // --- Debug ---
       .def_prop_rw(
           "write_movies",
-          [](const eonc::Parameters &s) { return s.debug_options.write_movies; },
+          [](const eonc::Parameters &s) {
+            return s.debug_options.write_movies;
+          },
           [](eonc::Parameters &s, bool v) { s.debug_options.write_movies = v; })
       // --- Metatomic ---
       .def_prop_rw(
@@ -180,17 +183,13 @@ void bind_parameters(nb::module_ &m) {
           [](const eonc::Parameters &s) {
             return static_cast<long>(s.neb_options.image_count);
           },
-          [](eonc::Parameters &s, long v) {
-            s.neb_options.image_count = v;
-          })
+          [](eonc::Parameters &s, long v) { s.neb_options.image_count = v; })
       .def_prop_rw(
           "neb_max_iterations",
           [](const eonc::Parameters &s) {
             return static_cast<long>(s.neb_options.max_iterations);
           },
-          [](eonc::Parameters &s, long v) {
-            s.neb_options.max_iterations = v;
-          })
+          [](eonc::Parameters &s, long v) { s.neb_options.max_iterations = v; })
       .def_prop_rw(
           "neb_force_tolerance",
           [](const eonc::Parameters &s) {
@@ -363,9 +362,7 @@ void bind_parameters(nb::module_ &m) {
           })
       .def_prop_rw(
           "rgpot_length_unit",
-          [](const eonc::Parameters &s) {
-            return s.rgpot_options.length_unit;
-          },
+          [](const eonc::Parameters &s) { return s.rgpot_options.length_unit; },
           [](eonc::Parameters &s, const std::string &v) {
             s.rgpot_options.length_unit = v;
           })
@@ -528,15 +525,11 @@ void bind_parameters(nb::module_ &m) {
       .def_prop_rw(
           "dimer_torque_max",
           [](const eonc::Parameters &s) { return s.dimer_options.torque_max; },
-          [](eonc::Parameters &s, double v) {
-            s.dimer_options.torque_max = v;
-          })
+          [](eonc::Parameters &s, double v) { s.dimer_options.torque_max = v; })
       .def_prop_rw(
           "dimer_torque_min",
           [](const eonc::Parameters &s) { return s.dimer_options.torque_min; },
-          [](eonc::Parameters &s, double v) {
-            s.dimer_options.torque_min = v;
-          })
+          [](eonc::Parameters &s, double v) { s.dimer_options.torque_min = v; })
       .def_prop_rw(
           "dimer_remove_rotation",
           [](const eonc::Parameters &s) {
@@ -548,9 +541,7 @@ void bind_parameters(nb::module_ &m) {
       // --- Hessian ---
       .def_prop_rw(
           "hessian_atom_list",
-          [](const eonc::Parameters &s) {
-            return s.hessian_options.atom_list;
-          },
+          [](const eonc::Parameters &s) { return s.hessian_options.atom_list; },
           [](eonc::Parameters &s, const std::string &v) {
             s.hessian_options.atom_list = v;
           })
@@ -565,9 +556,7 @@ void bind_parameters(nb::module_ &m) {
       // --- Prefactor ---
       .def_prop_rw(
           "prefactor_rate",
-          [](const eonc::Parameters &s) {
-            return s.prefactor_options.rate;
-          },
+          [](const eonc::Parameters &s) { return s.prefactor_options.rate; },
           [](eonc::Parameters &s, const std::string &v) {
             s.prefactor_options.rate = v;
           },
@@ -630,7 +619,6 @@ void bind_parameters(nb::module_ &m) {
             s.prefactor_options.all_free_atoms = v;
           })
 
-
       // --- Dynamics / MC / BH ---
       .def_prop_rw(
           "dynamics_steps",
@@ -649,9 +637,7 @@ void bind_parameters(nb::module_ &m) {
           })
       .def_prop_rw(
           "monte_carlo_steps",
-          [](const eonc::Parameters &s) {
-            return s.monte_carlo_options.steps;
-          },
+          [](const eonc::Parameters &s) { return s.monte_carlo_options.steps; },
           [](eonc::Parameters &s, int v) { s.monte_carlo_options.steps = v; })
       .def_prop_rw(
           "monte_carlo_step_size",
@@ -687,7 +673,6 @@ void bind_parameters(nb::module_ &m) {
           })
 
       // --- Structure comparison ---
-
 
       .def_prop_rw(
           "comp_eps_r",

--- a/client/python/bind/bind_potential.cpp
+++ b/client/python/bind/bind_potential.cpp
@@ -1,13 +1,13 @@
-#include "Matter.h"
-#include "bind_helpers.hpp"
-#include "Parameters.h"
-#include "Potential.h"
-#include "HelperFunctions.h"
 #include "BaseStructures.h"
 #include "Eigen.h"
-#include <nanobind/ndarray.h>
+#include "HelperFunctions.h"
+#include "Matter.h"
+#include "Parameters.h"
+#include "Potential.h"
+#include "bind_helpers.hpp"
 #include <algorithm>
 #include <cstring>
+#include <nanobind/ndarray.h>
 
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/shared_ptr.h>
@@ -21,7 +21,6 @@
 
 namespace eonc::pybind {
 namespace nb = nanobind;
-
 
 namespace {
 
@@ -153,8 +152,8 @@ class AseCalcPotential final : public eonc::Potential {
     try {
       auto farr =
           nb::cast<nb::ndarray<nb::numpy, double, nb::device::cpu>>(forces_obj);
-      if (farr.ndim() == 2 &&
-          static_cast<long>(farr.shape(0)) == nAtoms && farr.shape(1) == 3) {
+      if (farr.ndim() == 2 && static_cast<long>(farr.shape(0)) == nAtoms &&
+          farr.shape(1) == 3) {
         if (farr.stride(0) == 3 && farr.stride(1) == 1) {
           std::memcpy(F, farr.data(), n3 * sizeof(double));
           return;
@@ -171,15 +170,14 @@ class AseCalcPotential final : public eonc::Potential {
     } catch (const nb::cast_error &) {
     }
     auto np = nb::module_::import_("numpy");
-    nb::object cont = np.attr("ascontiguousarray")(
-        forces_obj, nb::arg("dtype") = "float64");
+    nb::object cont =
+        np.attr("ascontiguousarray")(forces_obj, nb::arg("dtype") = "float64");
     auto farr =
         nb::cast<nb::ndarray<nb::numpy, double, nb::c_contig, nb::device::cpu>>(
             cont);
     if (farr.ndim() != 2 || static_cast<long>(farr.shape(0)) != nAtoms ||
         farr.shape(1) != 3) {
-      throw std::runtime_error(
-          "ASE forces must be shape (n_atoms, 3) float64");
+      throw std::runtime_error("ASE forces must be shape (n_atoms, 3) float64");
     }
     std::memcpy(F, farr.data(), n3 * sizeof(double));
   }
@@ -199,7 +197,8 @@ class AseCalcPotential final : public eonc::Potential {
 
 public:
   explicit AseCalcPotential(nb::object calc)
-      : eonc::Potential(eonc::PotType::ASE_POT), calc_(std::move(calc)) {
+      : eonc::Potential(eonc::PotType::ASE_POT),
+        calc_(std::move(calc)) {
     if (!calc_.is_valid() || calc_.is_none()) {
       throw std::invalid_argument(
           "make_potential_from_ase: calculator is None");
@@ -256,15 +255,13 @@ public:
     nb::gil_scoped_acquire gil;
     try {
       ensure_modules();
-      const bool pbc =
-          linked_ ? linked_->getPeriodic() : true;
+      const bool pbc = linked_ ? linked_->getPeriodic() : true;
       ensure_atoms(nAtoms, atomicNrs, pbc);
 
       // Linked when force is driven by Matter::computePotential (R is
       // Matter positions storage). Cache is binding-local only.
-      const bool from_linked =
-          linked_ && nAtoms == linked_->numberOfAtoms() &&
-          R == matter_positions_ptr(*linked_);
+      const bool from_linked = linked_ && nAtoms == linked_->numberOfAtoms() &&
+                               R == matter_positions_ptr(*linked_);
 
       bool first = !ever_calculated_;
       bool pos_changed = true;
@@ -326,7 +323,8 @@ public:
       throw std::runtime_error(std::string("ASE calculator Python error: ") +
                                e.what());
     } catch (const std::exception &e) {
-      throw std::runtime_error(std::string("ASE calculator error: ") + e.what());
+      throw std::runtime_error(std::string("ASE calculator error: ") +
+                               e.what());
     }
   }
 
@@ -351,11 +349,10 @@ void bind_potential(nb::module_ &m) {
   nb::class_<eonc::Potential>(m, "Potential",
                               "Abstract potential (force + energy)")
       .def_prop_ro("type", &eonc::Potential::getType)
-      .def_prop_ro(
-          "force_call_counter",
-          [](const eonc::Potential &self) {
-            return self.forceCallCounter.load();
-          })
+      .def_prop_ro("force_call_counter",
+                   [](const eonc::Potential &self) {
+                     return self.forceCallCounter.load();
+                   })
       .def("is_surrogate", &eonc::Potential::isSurrogate)
       .def("requires_isolated_molecule_layout",
            &eonc::Potential::requiresIsolatedMoleculeLayout)
@@ -365,7 +362,8 @@ void bind_potential(nb::module_ &m) {
           [](eonc::Potential &self,
              nb::ndarray<nb::numpy, double, nb::c_contig, nb::device::cpu> pos,
              nb::ndarray<nb::numpy, int64_t, nb::c_contig, nb::device::cpu> z,
-             nb::ndarray<nb::numpy, double, nb::c_contig, nb::device::cpu> box) {
+             nb::ndarray<nb::numpy, double, nb::c_contig, nb::device::cpu>
+                 box) {
             if (pos.ndim() != 2 || pos.shape(1) != 3)
               throw std::invalid_argument("pos must be (n,3)");
             if (z.ndim() != 1 || z.shape(0) != pos.shape(0))
@@ -373,8 +371,8 @@ void bind_potential(nb::module_ &m) {
             if (box.ndim() != 2 || box.shape(0) != 3 || box.shape(1) != 3)
               throw std::invalid_argument("box must be (3,3)");
             const auto n = static_cast<Eigen::Index>(pos.shape(0));
-            AtomMatrix R = AtomMatrix::Map(
-                const_cast<double *>(pos.data()), n, 3);
+            AtomMatrix R =
+                AtomMatrix::Map(const_cast<double *>(pos.data()), n, 3);
             Matrix3d cell = Matrix3d::Map(const_cast<double *>(box.data()));
             VectorXi atmnrs(n);
             for (Eigen::Index i = 0; i < n; ++i)
@@ -402,9 +400,10 @@ void bind_potential(nb::module_ &m) {
                                  "ASE Calculator bound as eOn Potential. "
                                  "Use bind_matter(m) so MD/relax hit shared "
                                  "geometry + system_changes caching.")
-      .def("bind_matter", &AsePotentialHandle::bind_matter, nb::arg("matter"),
-           nb::keep_alive<1, 2>(),
-           "Wire ASE peer Atoms to this Matter (shared positions when possible)")
+      .def(
+          "bind_matter", &AsePotentialHandle::bind_matter, nb::arg("matter"),
+          nb::keep_alive<1, 2>(),
+          "Wire ASE peer Atoms to this Matter (shared positions when possible)")
       .def("unbind_matter", &AsePotentialHandle::unbind_matter)
       .def_prop_ro("is_bound", &AsePotentialHandle::is_bound)
       .def_prop_ro("potential", &AsePotentialHandle::as_potential,
@@ -449,8 +448,7 @@ void bind_potential(nb::module_ &m) {
         }
         return pot;
       },
-      nb::arg("parameters"),
-      "Construct a Potential from Parameters.potential");
+      nb::arg("parameters"), "Construct a Potential from Parameters.potential");
 
   // ASE Calculator → Potential (runtime ASE; no -Dwith_ase compile flag).
   m.def(
@@ -459,7 +457,8 @@ void bind_potential(nb::module_ &m) {
         return std::make_shared<AseCalcPotential>(std::move(calculator));
       },
       nb::arg("calculator"),
-      "Wrap ASE Calculator as Potential. Prefer ase_potential() + bind_matter.");
+      "Wrap ASE Calculator as Potential. Prefer ase_potential() + "
+      "bind_matter.");
 
   m.def(
       "ase_potential",

--- a/client/python/bind/bind_saddle.cpp
+++ b/client/python/bind/bind_saddle.cpp
@@ -36,20 +36,15 @@ void bind_saddle(nb::module_ &m) {
              MinModeSaddleSearch::STATUS_BAD_MAX_CONCAVE_ITERATIONS)
       .value("BAD_MAX_ITERATIONS",
              MinModeSaddleSearch::STATUS_BAD_MAX_ITERATIONS)
-      .value("BAD_NOT_CONNECTED",
-             MinModeSaddleSearch::STATUS_BAD_NOT_CONNECTED)
+      .value("BAD_NOT_CONNECTED", MinModeSaddleSearch::STATUS_BAD_NOT_CONNECTED)
       .value("BAD_PREFACTOR", MinModeSaddleSearch::STATUS_BAD_PREFACTOR)
       .value("BAD_HIGH_BARRIER", MinModeSaddleSearch::STATUS_BAD_HIGH_BARRIER)
       .value("BAD_MINIMA", MinModeSaddleSearch::STATUS_BAD_MINIMA)
-      .value("FAILED_PREFACTOR",
-             MinModeSaddleSearch::STATUS_FAILED_PREFACTOR)
-      .value("POTENTIAL_FAILED",
-             MinModeSaddleSearch::STATUS_POTENTIAL_FAILED)
-      .value("NONNEGATIVE_ABORT",
-             MinModeSaddleSearch::STATUS_NONNEGATIVE_ABORT)
+      .value("FAILED_PREFACTOR", MinModeSaddleSearch::STATUS_FAILED_PREFACTOR)
+      .value("POTENTIAL_FAILED", MinModeSaddleSearch::STATUS_POTENTIAL_FAILED)
+      .value("NONNEGATIVE_ABORT", MinModeSaddleSearch::STATUS_NONNEGATIVE_ABORT)
       .value("NONLOCAL_ABORT", MinModeSaddleSearch::STATUS_NONLOCAL_ABORT)
-      .value("NEGATIVE_BARRIER",
-             MinModeSaddleSearch::STATUS_NEGATIVE_BARRIER)
+      .value("NEGATIVE_BARRIER", MinModeSaddleSearch::STATUS_NEGATIVE_BARRIER)
       .value("BAD_MD_TRAJECTORY_TOO_SHORT",
              MinModeSaddleSearch::STATUS_BAD_MD_TRAJECTORY_TOO_SHORT)
       .value("BAD_NO_NEGATIVE_MODE_AT_SADDLE",
@@ -103,9 +98,9 @@ void bind_saddle(nb::module_ &m) {
             AtomMatrix mode_am = atom_matrix_from_numpy(mode);
             // Always construct on a private working copy; run(inplace) decides.
             auto work = std::make_shared<Matter>(*matter);
-            new (self) MinModeSaddleSearch(std::move(work), mode_am,
-                                           reactant_energy, params,
-                                           std::move(pot));
+            new (self)
+                MinModeSaddleSearch(std::move(work), mode_am, reactant_energy,
+                                    params, std::move(pot));
             // stash original shared_ptr for inplace path via custom holder?
             // Keep simple: store only working copy; run returns that.
           },
@@ -160,22 +155,18 @@ void bind_saddle(nb::module_ &m) {
       .def_prop_ro(
           "status",
           [](const MinModeSaddleSearch &self) { return self.getStatus(); })
-      .def_prop_ro(
-          "status_message",
-          [](const MinModeSaddleSearch &self) {
-            return std::string(
-                MinModeSaddleSearch::statusMessage(self.getStatus()));
-          })
-      .def_prop_ro(
-          "iteration",
-          [](const MinModeSaddleSearch &self) {
-            return self.getIterationCount();
-          })
+      .def_prop_ro("status_message",
+                   [](const MinModeSaddleSearch &self) {
+                     return std::string(
+                         MinModeSaddleSearch::statusMessage(self.getStatus()));
+                   })
+      .def_prop_ro("iteration",
+                   [](const MinModeSaddleSearch &self) {
+                     return self.getIterationCount();
+                   })
       .def_prop_ro(
           "force_calls",
-          [](const MinModeSaddleSearch &self) {
-            return self.getForceCalls();
-          })
+          [](const MinModeSaddleSearch &self) { return self.getForceCalls(); })
       .def_prop_ro(
           "eigenvalue",
           [](MinModeSaddleSearch &self) { return self.getEigenvalue(); })
@@ -187,8 +178,8 @@ void bind_saddle(nb::module_ &m) {
           nb::rv_policy::move)
       .def("__repr__", [](const MinModeSaddleSearch &self) {
         return "<MinModeSaddleSearch status=" +
-               std::to_string(self.getStatus()) + " iter=" +
-               std::to_string(self.getIterationCount()) + ">";
+               std::to_string(self.getStatus()) +
+               " iter=" + std::to_string(self.getIterationCount()) + ">";
       });
 }
 

--- a/client/python/bind/bind_sampling.cpp
+++ b/client/python/bind/bind_sampling.cpp
@@ -6,8 +6,8 @@
 #include "Matter.h"
 #include "MinModeSaddleSearch.h"
 #include "MonteCarlo.h"
-#include "Parameters.h"
 #include "ParallelReplicaJob.h"
+#include "Parameters.h"
 #include "Potential.h"
 #include "ReplicaExchangeJob.h"
 #include "SafeHyperJob.h"
@@ -47,8 +47,7 @@ void ensure_dynamics_steps(eonc::Parameters &params, long default_steps) {
     params.dynamics_options.time_step =
         params.dynamics_options.time_step_input / params.constants.timeUnit;
     if (params.dynamics_options.time_step <= 0.0)
-      params.dynamics_options.time_step =
-          1.0 / params.constants.timeUnit;
+      params.dynamics_options.time_step = 1.0 / params.constants.timeUnit;
   }
 }
 
@@ -109,7 +108,9 @@ struct SeededAlgo {
 
   SeededAlgo(std::shared_ptr<eonc::Matter> m, eonc::Parameters p,
              std::shared_ptr<eonc::Potential> pot_in)
-      : seed(std::move(m)), params(std::move(p)), pot(std::move(pot_in)) {
+      : seed(std::move(m)),
+        params(std::move(p)),
+        pot(std::move(pot_in)) {
     if (!seed)
       throw std::runtime_error("matter is required");
     if (!pot)
@@ -213,9 +214,10 @@ void bind_sampling(nb::module_ &m) {
         nsteps = 5;
       double max_disp = params.basin_hopping_options.displacement;
       double kT = params.constants.kB * params.main_options.temperature;
-      std::mt19937_64 rng(params.main_options.randomSeed >= 0
-                              ? static_cast<uint64_t>(params.main_options.randomSeed)
-                              : 0xC0FFEEULL);
+      std::mt19937_64 rng(
+          params.main_options.randomSeed >= 0
+              ? static_cast<uint64_t>(params.main_options.randomSeed)
+              : 0xC0FFEEULL);
       std::uniform_real_distribution<double> uni(0.0, 1.0);
       std::normal_distribution<double> gauss(0.0, 1.0);
       {
@@ -276,8 +278,10 @@ void bind_sampling(nb::module_ &m) {
 
     PyProcessSearch(std::shared_ptr<Matter> m, const NpF64 &mode_np,
                     Parameters p, std::shared_ptr<Potential> pot_in)
-        : seed(std::move(m)), mode(atom_matrix_from_numpy(mode_np)),
-          params(std::move(p)), pot(std::move(pot_in)) {
+        : seed(std::move(m)),
+          mode(atom_matrix_from_numpy(mode_np)),
+          params(std::move(p)),
+          pot(std::move(pot_in)) {
       if (!seed)
         throw std::runtime_error("ProcessSearch: matter required");
       if (!pot)
@@ -310,16 +314,15 @@ void bind_sampling(nb::module_ &m) {
     }
   };
 
-  nb::class_<PyProcessSearch>(
-      m, "ProcessSearch",
-      "Min-mode process search. run(inplace=False) -> (reactant, saddle, status).")
+  nb::class_<PyProcessSearch>(m, "ProcessSearch",
+                              "Min-mode process search. run(inplace=False) -> "
+                              "(reactant, saddle, status).")
       .def(nb::init<std::shared_ptr<Matter>, const NpF64 &, Parameters,
                     std::shared_ptr<Potential>>(),
            nb::arg("matter"), nb::arg("mode"), nb::arg("parameters"),
            nb::arg("potential"), nb::keep_alive<1, 2>(), nb::keep_alive<1, 5>())
       .def("run", &PyProcessSearch::run, nb::arg("inplace") = false)
-      .def_prop_ro("status",
-                   [](const PyProcessSearch &s) { return s.status; });
+      .def_prop_ro("status", [](const PyProcessSearch &s) { return s.status; });
 
   // --- Structure helpers (free is fine — pure predicates) ---
   m.def(

--- a/client/python/bind/eigen_numpy.hpp
+++ b/client/python/bind/eigen_numpy.hpp
@@ -18,12 +18,9 @@
 namespace eonc::pybind {
 namespace nb = nanobind;
 
-using NpF64 =
-    nb::ndarray<nb::numpy, double, nb::c_contig, nb::device::cpu>;
-using NpI32 =
-    nb::ndarray<nb::numpy, int32_t, nb::c_contig, nb::device::cpu>;
-using NpI64 =
-    nb::ndarray<nb::numpy, int64_t, nb::c_contig, nb::device::cpu>;
+using NpF64 = nb::ndarray<nb::numpy, double, nb::c_contig, nb::device::cpu>;
+using NpI32 = nb::ndarray<nb::numpy, int32_t, nb::c_contig, nb::device::cpu>;
+using NpI64 = nb::ndarray<nb::numpy, int64_t, nb::c_contig, nb::device::cpu>;
 
 /// Zero-copy (n, 3) float64 view of external/row-major AtomMatrix storage.
 inline nb::ndarray<nb::numpy, double, nb::c_contig, nb::device::cpu>
@@ -68,8 +65,7 @@ inline const double *require_n3(const NpF64 &arr, long expected_n = -1) {
   }
   if (expected_n >= 0 && static_cast<long>(arr.shape(0)) != expected_n) {
     throw std::invalid_argument("expected n=" + std::to_string(expected_n) +
-                                " rows, got " +
-                                std::to_string(arr.shape(0)));
+                                " rows, got " + std::to_string(arr.shape(0)));
   }
   return arr.data();
 }
@@ -129,9 +125,9 @@ matrix_to_numpy(const EigenT &m) {
   double *buf = new double[rows * cols];
   std::copy(m.data(), m.data() + rows * cols, buf);
   // capsule deletes the buffer
-  nb::capsule owner(buf, [](void *p) noexcept { delete[] static_cast<double *>(p); });
-  return nb::ndarray<nb::numpy, double, nb::c_contig>(
-      buf, {rows, cols}, owner);
+  nb::capsule owner(
+      buf, [](void *p) noexcept { delete[] static_cast<double *>(p); });
+  return nb::ndarray<nb::numpy, double, nb::c_contig>(buf, {rows, cols}, owner);
 }
 
 template <typename Derived>
@@ -142,7 +138,8 @@ vector_to_numpy(const Eigen::MatrixBase<Derived> &v) {
   for (size_t i = 0; i < n; ++i) {
     buf[i] = static_cast<double>(v(static_cast<Eigen::Index>(i)));
   }
-  nb::capsule owner(buf, [](void *p) noexcept { delete[] static_cast<double *>(p); });
+  nb::capsule owner(
+      buf, [](void *p) noexcept { delete[] static_cast<double *>(p); });
   return nb::ndarray<nb::numpy, double, nb::c_contig>(buf, {n}, owner);
 }
 
@@ -153,7 +150,8 @@ vectori_to_numpy(const VectorXi &v) {
   for (size_t i = 0; i < n; ++i) {
     buf[i] = static_cast<int64_t>(v(static_cast<Eigen::Index>(i)));
   }
-  nb::capsule owner(buf, [](void *p) noexcept { delete[] static_cast<int64_t *>(p); });
+  nb::capsule owner(
+      buf, [](void *p) noexcept { delete[] static_cast<int64_t *>(p); });
   return nb::ndarray<nb::numpy, int64_t, nb::c_contig>(buf, {n}, owner);
 }
 

--- a/client/python/bind/module.cpp
+++ b/client/python/bind/module.cpp
@@ -27,7 +27,7 @@ NB_MODULE(_core, m) {
       "MinModeSaddleSearch, Hessian, Prefactor, Dynamics/MC/BH/process_search, "
       "ASE bulk matter_from_ase/matter_to_ase. "
       "Stable ABI (abi3) or free-threaded.";
-  m.attr("__version__") = "0.3.3";
+  m.attr("__version__") = "0.3.4";
 
   m.def(
       "built_with_metatomic",

--- a/client/unit_tests/MetatomicEngineAbiTest.cpp
+++ b/client/unit_tests/MetatomicEngineAbiTest.cpp
@@ -3,7 +3,8 @@
 #include <dlfcn.h>
 #include <string>
 
-// Structural + optional live check: libmetatomic_engine exports rgpot_mta_* ABI.
+// Structural + optional live check: libmetatomic_engine exports rgpot_mta_*
+// ABI.
 TEST_CASE("metatomic engine C ABI symbols present when engine is loadable",
           "[metatomic][rgpot][engine]") {
   const char *env = std::getenv("RGPOT_METATOMIC_ENGINE");
@@ -19,7 +20,8 @@ TEST_CASE("metatomic engine C ABI symbols present when engine is loadable",
         d = d.substr(0, pos);
       if (!d.empty() && d.back() != '/')
         d += '/';
-      h = dlopen((d + "libmetatomic_engine.so").c_str(), RTLD_NOW | RTLD_GLOBAL);
+      h = dlopen((d + "libmetatomic_engine.so").c_str(),
+                 RTLD_NOW | RTLD_GLOBAL);
     }
   }
   if (!h) {

--- a/client/unit_tests/ParametersSSOTTest.cpp
+++ b/client/unit_tests/ParametersSSOTTest.cpp
@@ -1,5 +1,5 @@
-#include "Parameters.h"
 #include "ParametersSSOT.h"
+#include "Parameters.h"
 #include "TestUtils.hpp"
 #include "catch2/catch_amalgamated.hpp"
 

--- a/client/unit_tests/xtb_ship_bench.cpp
+++ b/client/unit_tests/xtb_ship_bench.cpp
@@ -15,9 +15,9 @@ using SteadyClock = std::chrono::steady_clock;
 using eonc::Parameters;
 using eonc::PotType;
 
-static const double water_pos[] = {
-    0.00000000, 0.00000000,  0.11779000, 0.00000000, 0.75545000,
-    -0.47116000, 0.00000000, -0.75545000, -0.47116000};
+static const double water_pos[] = {0.00000000, 0.00000000,  0.11779000,
+                                   0.00000000, 0.75545000,  -0.47116000,
+                                   0.00000000, -0.75545000, -0.47116000};
 static const int water_atmnrs[] = {8, 1, 1};
 static const double water_box[9] = {100, 0, 0, 0, 100, 0, 0, 0, 100};
 

--- a/docs/newsfragments/+amsel-discover-decide-superbasin.added.md
+++ b/docs/newsfragments/+amsel-discover-decide-superbasin.added.md
@@ -1,1 +1,0 @@
-Optional Superbasin gate via amsel.discover_decide_status ([amsel] / amsel_discover_decide) before MCAMC; rejected_no_metastable_basin falls back to AKMC.

--- a/docs/newsfragments/+dimer-rotation-backend.added.md
+++ b/docs/newsfragments/+dimer-rotation-backend.added.md
@@ -1,1 +1,0 @@
-Dimer supports `rotation_backend = classical|lanczos|davidson|lor` (Leng et al. JCP 2013 LOR for softest-mode with force translation; Lanczos/Davidson FD min-mode; classical constrained rotation). Climb remains on the dimer path.

--- a/docs/newsfragments/357.fixed.md
+++ b/docs/newsfragments/357.fixed.md
@@ -1,4 +1,0 @@
-HessianJob FD eigen solve: ColMajor copy for SelfAdjointEigenSolver (avoids
-RowMajor segfaults on partial VTST blocks), finite-force/index guards, optional
-`[Hessian] atom_list` intersected with free atoms, and a stable mobile VectorXi
-copy so moving-atom Hessians match PHVA-class active sets.

--- a/docs/newsfragments/pyeonclient-path-frames.added.md
+++ b/docs/newsfragments/pyeonclient-path-frames.added.md
@@ -1,1 +1,0 @@
-pyeonclient 0.3.3: in-memory ``path_frames`` / ``to_conframes`` for NEB (same stamps as writePathCon), ``Matter.relax(retain_frames=…)`` movie frames, and ``MinModeSaddleSearch.run_retain_frames`` climb frames.

--- a/eon/meson.build
+++ b/eon/meson.build
@@ -3,6 +3,7 @@ py.install_sources(
         'akmc.py',
         'akmcstatelist.py',
         'akmcstate.py',
+        'amsel_superbasin_gate.py',
         'askmc.py',
         'atoms.py',
         'basinhopping.py',
@@ -16,6 +17,7 @@ py.install_sources(
         'explorer.py',
         'fileio.py',
         '__init__.py',
+        '__main__.py',
         'locking.py',
         'server.py',
         'structure.py',
@@ -32,6 +34,8 @@ py.install_sources(
         'movie.py',
         'mpiwait.py',
         'parallelreplica.py',
+        'params_ssot.py',
+        '_params_ssot_catalog.py',
         'pyeonclient_bridge.py',
         'prstatelist.py',
         'prstate.py',
@@ -44,6 +48,10 @@ py.install_sources(
     ],
     pure: false,  # install next to compiled extension
     subdir: 'eon',
+    # Nested packages (geometry/, mcamc/) must keep their relative paths;
+    # without this meson flattens into site-packages/eon/ and
+    # `import eon.geometry` fails after meson install (CI server smoke).
+    preserve_path: true,
 )
 
 

--- a/eon/structure.py
+++ b/eon/structure.py
@@ -162,4 +162,3 @@ def _structure_from_ase(cls, atoms):
 
 
 Structure.from_ase = classmethod(_structure_from_ase)  # type: ignore[attr-defined, assignment]
-

--- a/packages/eon-schema/PUBLISHING.md
+++ b/packages/eon-schema/PUBLISHING.md
@@ -85,7 +85,7 @@ twine upload dist/*
 # or Trusted Publishing / uv publish
 ```
 
-Optional monorepo tag for archaeology only: `eon-schema-v0.2.0`  
+Optional monorepo tag for archaeology only: `eon-schema-v0.2.0`
 (do **not** use this tag as the feedstock source — feedstock wants the **fat**
 `eon-v*` archive).
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -5,7 +5,7 @@ name = "eOn"
 # NOTE: not every platform has 100% support other than Linux
 # e.g. LAMMPS and NWChem do not have builds for Windows
 platforms = ["linux-64", "osx-64", "osx-arm64", "win-64"]
-version = "2.17.1"
+version = "2.17.2"
 
 [tasks]
 gen-ref = { cmd = "cd scripts/regression && snakemake -c4", description = "Generate SVN regression reference data (default: svn-Jul_01_2024)" }

--- a/pyproject-pyeonclient.toml
+++ b/pyproject-pyeonclient.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyeonclient"
-version = "0.3.3"
+version = "0.3.4"
 description = "Nanobind bindings to the eOn C++ client (Matter, Parameters, Potential, Jobs, NEB, RGPOT)"
 authors = [
     {name = "Rohit Goswami", email = "rgoswami@ieee.org"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "eon-akmc"
-version = "2.17.1"
+version = "2.17.2"
 description = "eOn kinetic Monte Carlo / AKMC (PyPI: eon-akmc; import eon)"
 authors = [
     {name = "Rohit Goswami", email = "rgoswami@ieee.org"},

--- a/scripts/pyeonclient_manylinux_deps.sh
+++ b/scripts/pyeonclient_manylinux_deps.sh
@@ -68,6 +68,25 @@ if ! pkg-config --exists quill 2>/dev/null; then
     -DQUILL_BUILD_EXAMPLES=OFF
   cmake --build /tmp/quill-build -j"$(nproc 2>/dev/null || echo 2)"
   "${SUDO[@]}" cmake --install /tmp/quill-build
+  # Upstream quill often installs CMake config only; meson prefers pkg-config.
+  if ! pkg-config --exists quill 2>/dev/null; then
+    for d in "${PREFIX}/lib64/pkgconfig" "${PREFIX}/lib/pkgconfig"; do
+      "${SUDO[@]}" mkdir -p "$d"
+    done
+    pc="${PREFIX}/lib/pkgconfig/quill.pc"
+    if [[ ! -d "${PREFIX}/lib/pkgconfig" && -d "${PREFIX}/lib64/pkgconfig" ]]; then
+      pc="${PREFIX}/lib64/pkgconfig/quill.pc"
+    fi
+    "${SUDO[@]}" tee "$pc" >/dev/null <<EOF
+prefix=${PREFIX}
+includedir=\${prefix}/include
+Name: quill
+Description: Asynchronous Low Latency C++ Logging Library
+Version: 11.0.2
+Cflags: -I\${includedir}
+EOF
+  fi
 fi
+export PKG_CONFIG_PATH="${PREFIX}/lib64/pkgconfig:${PREFIX}/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
 pkg-config --modversion quill
 echo "pyeonclient_manylinux_deps: OK"

--- a/tests/test_config_metadata.py
+++ b/tests/test_config_metadata.py
@@ -1,4 +1,4 @@
-"""Guard against drift between eon.schema and eon/config.yaml."""
+"""Guard against drift between eon-schema models and eon/config.yaml."""
 
 from __future__ import annotations
 
@@ -9,7 +9,11 @@ import unittest
 from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-SCHEMA_PATH = REPO_ROOT / "eon/schema.py"
+# Authoritative L1 models live in eon-schema; eon/schema.py is a re-export stub
+# (star-import only) so AST drift checks must parse models.py, not the stub.
+SCHEMA_PATH = (
+    REPO_ROOT / "packages" / "eon-schema" / "src" / "eon_schema" / "config" / "models.py"
+)
 
 
 def _load_module(module_name: str, relative_path: str):

--- a/tests/test_params_ssot.py
+++ b/tests/test_params_ssot.py
@@ -422,4 +422,3 @@ def test_parity_nested_optimizer_model_defaults_match_ssot():
             assert fdefault == exp or (
                 isinstance(exp, float) and float(fdefault) == float(exp)
             ), f"{model_name}.{fname} default {fdefault!r} != SSoT {exp!r}"
-

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -3,7 +3,7 @@
 # (avoids numpy/native deps in CI/release-prepare). cog/bump passes --version explicitly.
 name = "eon"
 # Keep in sync with pyproject.toml on cuts; draft-only if this lags (cog passes --version).
-version = "2.17.1"
+version = "2.17.2"
 directory = "docs/newsfragments"
 filename = "CHANGELOG.md"
 start_string = "<!-- towncrier release notes start -->\n"


### PR DESCRIPTION
## Summary

Proper packaging cut after incomplete **v2.17.0** / **v2.17.1** (tag + partial GH release without green CI / eon-akmc PyPI / full pyeonclient wheels).

### Fixes
- **Lints**: prek trailing whitespace, EOF, clang-format on the v2.17.1 tip
- **eon-akmc sdist**: `release.yml` installs quill/capnp (via `scripts/pyeonclient_manylinux_deps.sh`); client meson falls back to CMake `quill::quill` when `.pc` is missing
- **pyeonclient**: manylinux deps write a `quill.pc` when upstream only exports CMake config

### Version surfaces
| Surface | Version |
|---------|---------|
| eOn / eon-akmc | **2.17.2** |
| pyeonclient | **0.3.4** |
| eon-schema | 0.2.2 (already on PyPI; no bump) |

### Release checklist (after merge to main, green CI)
1. Tag **`v2.17.2`** → `release.yml` (GH release + tarball + eon-akmc sdist)
2. Tag **`pyeonclient-v0.3.4`** → full wheel matrix + PyPI
3. eon-schema: leave at `eon-schema-v0.2.2` unless schema changes
4. Confirm PyPI: `eon-akmc==2.17.2`, `pyeonclient==0.3.4`, `eon-schema==0.2.2`
5. Confirm GH release asset `eon-v2.17.2.tar.xz`

## Test plan
- [ ] CI green on this PR (lints, client builds, pyeonclient wheels path)
- [ ] `python3 scripts/release_assert.py 2.17.2 --require-changelog`
- [ ] After merge+tags: release workflow pypi job succeeds; pyeonclient publish succeeds