### PR TITLE
fix: Windows metatomic CI + DynLib ABI test + features_string

### DIFF
--- a/.github/workflows/ci_build_akmc.yml
+++ b/.github/workflows/ci_build_akmc.yml
@@ -51,7 +51,13 @@ jobs:
             --default-library=static -Dwith_fortran=true -Dwith_cuh2=true
           meson install -C bbdir
 
-      - name: Run tests
+      - name: Run Catch2 unit tests
+        shell: pixi run bash -e {0}
+        run: |
+          # with_tests defaults true; catch MSVC-only compile/link failures in
+          # unit tests that never run on the Unix-only feature workflows.
+          meson test -C bbdir --print-errorlogs
+      - name: Run server smoke tests
         shell: pixi run bash -e {0}
         run: |
           python tests/test_config_metadata.py

--- a/.github/workflows/ci_metatomic.yml
+++ b/.github/workflows/ci_metatomic.yml
@@ -10,8 +10,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO(rg): Handle the windows-2022 later, issues linking fmt
-        os: [ubuntu-22.04, macos-14]
+        # win-64 is in feature.metatomic platforms (pixi.toml). Feedstock win
+        # builds with_metatomic + default with_tests; GHA must exercise that
+        # surface so MSVC-only unit tests (e.g. MetatomicEngineAbiTest / DynLib)
+        # fail here instead of only on conda-forge.
+        os: [ubuntu-22.04, macos-14, windows-latest]
     steps:
       - uses: actions/checkout@v4
       - uses: prefix-dev/setup-pixi@v0.9.4
@@ -31,7 +34,11 @@ jobs:
           FC=$(find "$(brew --prefix gcc)/bin" -name 'gfortran-*' | head -1)
           echo "FC=$FC" >> "$GITHUB_ENV"
           echo "SDKROOT=$(xcrun --show-sdk-path)" >> "$GITHUB_ENV"
-      - name: Install eon
+      - name: Activate MSVC (Windows)
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1
+      - name: Install eon [unix]
+        if: runner.os != 'Windows'
         shell: pixi run bash -e {0}
         run: |
           meson setup --reconfigure bbdir  \
@@ -43,7 +50,25 @@ jobs:
           -Dwith_tests=True                \
           -Dpip_metatomic=True
           meson install -C bbdir
-      - name: Run tests
-        shell: bash -el {0}
+      - name: Install eon [windows]
+        if: runner.os == 'Windows'
+        shell: pixi run bash -e {0}
         run: |
-          meson test -C bbdir
+          # Git Bash puts GNU link.exe on PATH which shadows MSVC link.exe
+          export PATH=$(echo "$PATH" | tr ':' '\n' | grep -v '^/usr/bin$' | paste -sd:)
+          # Align with ci_build_akmc Windows + feedstock build.bat: static
+          # default-library for MSVC; pip_metatomic for torch/metatomic wheels.
+          meson setup bbdir \
+            --prefix=$CONDA_PREFIX \
+            --libdir=lib \
+            --buildtype release \
+            --default-library=static \
+            -Dwith_metatomic=True \
+            -Dtorch_version=2.10 \
+            -Dwith_tests=True \
+            -Dpip_metatomic=True
+          meson install -C bbdir
+      - name: Run tests
+        shell: pixi run bash -e {0}
+        run: |
+          meson test -C bbdir --print-errorlogs

--- a/client/meson.build
+++ b/client/meson.build
@@ -1206,12 +1206,8 @@ if get_option('with_tests')
     endif
     if get_option('with_metatomic')
         test_array += [['test_mta', 'MetatomicTest.cpp', 'lj38']]
-        # MetatomicEngineAbiTest uses POSIX dlopen/dlsym; client/DynLib.h is the
-        # Windows-safe loader for production paths. Skip the ABI unit test on
-        # MSVC until the test is rewritten against DynLib + .dll naming.
-        if not is_windows
-            test_array += [['test_mta_engine_abi', 'MetatomicEngineAbiTest.cpp', '']]
-        endif
+        # DynLib.h (LoadLibrary / dlopen) — builds on MSVC and POSIX.
+        test_array += [['test_mta_engine_abi', 'MetatomicEngineAbiTest.cpp', '']]
     endif
     if get_option('with_xtb')
         test_array += [['test_xtb', 'XTBTest.cpp', 'sulfolene']]

--- a/client/meson.build
+++ b/client/meson.build
@@ -1206,7 +1206,12 @@ if get_option('with_tests')
     endif
     if get_option('with_metatomic')
         test_array += [['test_mta', 'MetatomicTest.cpp', 'lj38']]
-        test_array += [['test_mta_engine_abi', 'MetatomicEngineAbiTest.cpp', '']]
+        # MetatomicEngineAbiTest uses POSIX dlopen/dlsym; client/DynLib.h is the
+        # Windows-safe loader for production paths. Skip the ABI unit test on
+        # MSVC until the test is rewritten against DynLib + .dll naming.
+        if not is_windows
+            test_array += [['test_mta_engine_abi', 'MetatomicEngineAbiTest.cpp', '']]
+        endif
     endif
     if get_option('with_xtb')
         test_array += [['test_xtb', 'XTBTest.cpp', 'sulfolene']]

--- a/client/meson.build
+++ b/client/meson.build
@@ -186,36 +186,9 @@ features_list = [
     ['EMBED_PYTHON', 'Embedded Python'],
 ]
 
-# Join _args into a single string for checking
-_args_str = ' '.join(_args)
-
-features_string = ''
-foreach feature : features_list
-    feature_flag = feature[0]
-    feature_name = feature[1]
-    if '-D' + feature_flag in _args_str
-        features_string += '  ' + feature_name + ': enabled\n'
-    else
-        features_string += '  ' + feature_name + ': disabled\n'
-    endif
-endforeach
-
-# Configure the header file
-configure_file(
-    input: 'version.h.in',
-    output: 'version.h',
-    configuration: {
-        'VERSION': version,
-        'VERSION_MAJOR': version_major,
-        'VERSION_MINOR': version_minor,
-        'VERSION_PATCH': version_patch,
-        'BUILD_DATE': build_date,
-        'OS_INFO': host_system,
-        'ARCH': architecture,
-        'GIT_HASH': git_hash,
-        'FEATURES': features_string,
-    },
-)
+# features_string + version.h are assembled AFTER optional with_* blocks append
+# -DWITH_* to _args (metatomic, xtb, serve, artn, …). Scanning earlier under-reports
+# enabled features in eonclient --features even when those flags are linked in.
 
 # Dependencies
 if not is_windows
@@ -1059,6 +1032,35 @@ if is_windows
 else
     _deps += [readcon_dep]
 endif
+
+# version.h FEATURES must see every -DWITH_* appended by the blocks above.
+_args_str = ' '.join(_args)
+features_string = ''
+foreach feature : features_list
+    feature_flag = feature[0]
+    feature_name = feature[1]
+    if '-D' + feature_flag in _args_str
+        features_string += '  ' + feature_name + ': enabled\n'
+    else
+        features_string += '  ' + feature_name + ': disabled\n'
+    endif
+endforeach
+
+configure_file(
+    input: 'version.h.in',
+    output: 'version.h',
+    configuration: {
+        'VERSION': version,
+        'VERSION_MAJOR': version_major,
+        'VERSION_MINOR': version_minor,
+        'VERSION_PATCH': version_patch,
+        'BUILD_DATE': build_date,
+        'OS_INFO': host_system,
+        'ARCH': architecture,
+        'GIT_HASH': git_hash,
+        'FEATURES': features_string,
+    },
+)
 
 # --------------------- Library
 

--- a/client/unit_tests/MetatomicEngineAbiTest.cpp
+++ b/client/unit_tests/MetatomicEngineAbiTest.cpp
@@ -6,8 +6,8 @@
 #include <vector>
 
 // Structural + optional live check: libmetatomic_engine exports rgpot_mta_*
-// ABI. Uses DynLib (LoadLibrary on Windows, dlopen elsewhere) — not raw
-// dlfcn.h — so the test builds and runs on MSVC.
+// ABI. Uses DynLib (LoadLibrary on Windows, dlopen elsewhere) - not raw
+// dlfcn.h - so the test builds and runs on MSVC.
 TEST_CASE("metatomic engine C ABI symbols present when engine is loadable",
           "[metatomic][rgpot][engine]") {
   const char *env = std::getenv("RGPOT_METATOMIC_ENGINE");

--- a/client/unit_tests/MetatomicEngineAbiTest.cpp
+++ b/client/unit_tests/MetatomicEngineAbiTest.cpp
@@ -1,39 +1,65 @@
 #include "catch2/catch_amalgamated.hpp"
+#include "DynLib.h"
+
 #include <cstdlib>
-#include <dlfcn.h>
 #include <string>
+#include <vector>
 
 // Structural + optional live check: libmetatomic_engine exports rgpot_mta_*
-// ABI.
+// ABI. Uses DynLib (LoadLibrary on Windows, dlopen elsewhere) — not raw
+// dlfcn.h — so the test builds and runs on MSVC.
 TEST_CASE("metatomic engine C ABI symbols present when engine is loadable",
           "[metatomic][rgpot][engine]") {
   const char *env = std::getenv("RGPOT_METATOMIC_ENGINE");
-  std::string path = env && *env ? env : "libmetatomic_engine.so";
-  void *h = dlopen(path.c_str(), RTLD_NOW | RTLD_GLOBAL);
-  if (!h) {
-    // Also try build-tree relative path from test env
-    const char *pp = std::getenv("EON_POTENTIALS_PATH");
-    if (pp) {
-      std::string d(pp);
-      auto pos = d.find(':');
-      if (pos != std::string::npos)
-        d = d.substr(0, pos);
-      if (!d.empty() && d.back() != '/')
-        d += '/';
-      h = dlopen((d + "libmetatomic_engine.so").c_str(),
-                 RTLD_NOW | RTLD_GLOBAL);
-    }
+  std::vector<std::string> candidates;
+  if (env && *env) {
+    candidates.emplace_back(env);
+  }
+  // Platform default sonames / import names.
+  candidates.emplace_back("libmetatomic_engine.so");
+  candidates.emplace_back("libmetatomic_engine.dylib");
+  candidates.emplace_back("metatomic_engine.dll");
+  candidates.emplace_back("libmetatomic_engine.dll");
+
+  // Build-tree relative path from test env (colon/semicolon separated).
+  const char *pp = std::getenv("EON_POTENTIALS_PATH");
+  if (pp && *pp) {
+    std::string d(pp);
+#ifdef _WIN32
+    const char sep = ';';
+    const char slash = '\\';
+#else
+    const char sep = ':';
+    const char slash = '/';
+#endif
+    auto pos = d.find(sep);
+    if (pos != std::string::npos)
+      d = d.substr(0, pos);
+    if (!d.empty() && d.back() != '/' && d.back() != '\\')
+      d += slash;
+    candidates.push_back(d + "libmetatomic_engine.so");
+    candidates.push_back(d + "libmetatomic_engine.dylib");
+    candidates.push_back(d + "metatomic_engine.dll");
+    candidates.push_back(d + "libmetatomic_engine.dll");
+  }
+
+  eonc::dynlib::Handle h{};
+  for (const auto &path : candidates) {
+    h = eonc::dynlib::open(path.c_str());
+    if (h)
+      break;
   }
   if (!h) {
-    WARN("libmetatomic_engine.so not on path; skip live ABI check");
+    WARN("libmetatomic_engine not on path; skip live ABI check");
     return;
   }
-  REQUIRE(dlsym(h, "rgpot_mta_abi_version") != nullptr);
-  REQUIRE(dlsym(h, "rgpot_mta_create") != nullptr);
-  REQUIRE(dlsym(h, "rgpot_mta_destroy") != nullptr);
-  REQUIRE(dlsym(h, "rgpot_mta_force") != nullptr);
-  auto abi = reinterpret_cast<int (*)()>(dlsym(h, "rgpot_mta_abi_version"));
+
+  REQUIRE(eonc::dynlib::sym(h, "rgpot_mta_abi_version") != nullptr);
+  REQUIRE(eonc::dynlib::sym(h, "rgpot_mta_create") != nullptr);
+  REQUIRE(eonc::dynlib::sym(h, "rgpot_mta_destroy") != nullptr);
+  REQUIRE(eonc::dynlib::sym(h, "rgpot_mta_force") != nullptr);
+  auto abi = eonc::dynlib::loadSym<int (*)()>(h, "rgpot_mta_abi_version");
   REQUIRE(abi != nullptr);
   REQUIRE(abi() == 1);
-  dlclose(h);
+  eonc::dynlib::close(h);
 }


### PR DESCRIPTION
## Summary

- Rewrite `MetatomicEngineAbiTest` to use `DynLib` (LoadLibrary/dlopen) so MSVC builds and runs the ABI symbol check instead of POSIX-only `dlfcn.h`.
- Run Catch2 unit tests on the basic AKMC matrix (including Windows).
- Add `windows-latest` to `ci_metatomic.yml` (MSVC path scrub, static default-library, `pip_metatomic`) so feedstock-class Windows+metatomic+tests failures fail in GHA.
- Assemble `features_string` / `version.h` only after optional `-DWITH_*` blocks so `eonclient --features` matches the linked build.

## Context

conda-forge eon-feedstock 2.17.10 hit MSVC compile failure on the ABI unit test; upstream GHA never built metatomic unit tests on Windows, so it only failed packaging. DynLib fix is in this PR; the feedstock patch can drop after the next tarball cut that includes these commits.

## Test plan

- [ ] GHA `ci_metatomic` green on ubuntu, macos-14, **windows-latest**
- [ ] GHA `ci_build_akmc` green with Catch2 `meson test` on all three OSes
- [ ] Local/CI: build with `-Dwith_metatomic=True` reports Metatomic enabled via `eonclient --features`