### PR TITLE
feat(asv): continuous tachyon dashboard and asv-results history

### DIFF
--- a/.github/workflows/ci_asv_dashboard.yml
+++ b/.github/workflows/ci_asv_dashboard.yml
@@ -121,17 +121,23 @@ jobs:
           QUICK: ${{ (github.event_name == 'schedule' || inputs.force_full) && 'false' || 'true' }}
         run: |
           set -e
+          # existing: env cannot take a git range — loop SHAs with --set-commit-hash
           EXTRA=""
           if [ "$QUICK" = "true" ]; then EXTRA="--quick"; fi
+          N=5
+          if [ "$QUICK" != "true" ]; then N=8; fi
           pixi run bash -c "
+            set -e
             export PATH=\"\$CONDA_PREFIX/bin:\$PATH\"
             PY=\$(which python)
-            if git rev-parse HEAD~5 >/dev/null 2>&1; then
-              asv run -E \"existing:\$PY\" HEAD~5..HEAD --record-samples \$EXTRA || \
-              asv run -E \"existing:\$PY\" HEAD --record-samples \$EXTRA
-            else
-              asv run -E \"existing:\$PY\" HEAD --record-samples \$EXTRA
-            fi
+            mapfile -t SHAS < <(git rev-list --max-count=$N HEAD)
+            # oldest first so history is chronological
+            for ((i=\${#SHAS[@]}-1; i>=0; i--)); do
+              sha=\${SHAS[i]}
+              echo "=== asv run $EXTRA --set-commit-hash \$sha ==="
+              asv run -E \"existing:\$PY\" --set-commit-hash \"\$sha\" --record-samples $EXTRA \
+                || asv run -E \"existing:\$PY\" --set-commit-hash \"\$sha\" --record-samples $EXTRA -v
+            done
           "
 
       - name: asv publish + tachyon UI

--- a/.github/workflows/ci_asv_dashboard.yml
+++ b/.github/workflows/ci_asv_dashboard.yml
@@ -1,15 +1,18 @@
 # Continuous ASV history + asv-tachyon static dashboard.
-# Publishes to gh-pages under /bench/ (keep_files so docs stay at site root).
-# Live path after deploy: https://eondocs.org/bench/ (upstream) or
-# https://haozeke.github.io/eOn/bench/ (fork). For bench.eondocs.org see
-# docs note in the PR body (subdomain needs DNS CNAME + same Pages site
-# path, or a dedicated Pages project).
+#
+# Data: orphan branch `asv-results` holds `.asv/results/**` (long-lived history).
+# UI:   gh-pages `/bench/` via peaceiris (docs stay at site root with keep_files).
+# Host: optional Netlify site bench.eondocs.org (NETLIFY_AUTH_TOKEN + NETLIFY_SITE_ID secrets).
+#
+# Live paths after merge:
+#   https://eondocs.org/bench/
+#   https://bench.eondocs.org/   (if Netlify custom domain wired)
 
 name: ASV dashboard
 
 concurrency:
-  group: asv-dashboard-${{ github.ref }}
-  cancel-in-progress: true
+  group: asv-dashboard
+  cancel-in-progress: false
 
 on:
   push:
@@ -25,42 +28,70 @@ on:
       - "pixi.lock"
       - ".github/workflows/ci_asv_dashboard.yml"
   schedule:
-    # Weekly full-ish refresh (Monday 09:00 UTC)
     - cron: "0 9 * * 1"
   workflow_dispatch:
     inputs:
       quick:
-        description: "Use asv --quick (faster, noisier)"
+        description: "asv --quick (faster, noisier)"
         type: boolean
         default: true
+      force_full:
+        description: "Ignore quick; run full suite"
+        type: boolean
+        default: false
 
 permissions:
   contents: write
-  pages: write
-  id-token: write
 
 jobs:
   asv-publish:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout source
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          path: src
+
+      - name: Checkout asv-results orphan (history)
+        uses: actions/checkout@v4
+        with:
+          ref: asv-results
+          path: asv-results
+          fetch-depth: 0
+        continue-on-error: true
+
+      - name: Bootstrap asv-results layout
+        working-directory: src
+        run: |
+          set -e
+          mkdir -p .asv/results
+          if [ -d ../asv-results/.asv/results ]; then
+            rsync -a ../asv-results/.asv/results/ .asv/results/
+            echo "Restored results from asv-results branch"
+            find .asv/results -type f | wc -l
+          else
+            echo "No asv-results branch yet; starting fresh history"
+          fi
 
       - uses: prefix-dev/setup-pixi@v0.9.4
         with:
           cache: true
           cache-write: true
           activate-environment: true
+          manifest-path: src/pixi.toml
 
       - uses: astral-sh/setup-uv@v5
 
       - name: Ensure cbindgen
+        working-directory: src
         shell: bash
         run: command -v cbindgen || cargo install cbindgen
 
-      - name: Build eonclient + install into pixi prefix
+      - name: Build eonclient
+        working-directory: src
         run: |
+          set -e
           pixi run bash -c "meson setup bbdir \
             --prefix=\$CONDA_PREFIX --libdir=lib \
             --buildtype release --wipe 2>/dev/null \
@@ -68,22 +99,14 @@ jobs:
             --libdir=lib --buildtype release"
           pixi run meson install -C bbdir
           command -v eonclient
-          eonclient -h >/dev/null 2>&1 || true
-
-      - name: Restore ASV results cache
-        uses: actions/cache@v4
-        with:
-          path: .asv/results
-          key: asv-results-${{ runner.os }}-${{ hashFiles('benchmarks/**', 'asv.conf.json') }}-${{ github.sha }}
-          restore-keys: |
-            asv-results-${{ runner.os }}-${{ hashFiles('benchmarks/**', 'asv.conf.json') }}-
-            asv-results-${{ runner.os }}-
+          test -x "$(command -v eonclient)"
 
       - name: Install asv + tachyon
-        run: |
-          pixi run bash -c 'pip install -q "asv>=0.6" "asv-tachyon>=0.5.7"'
+        working-directory: src
+        run: pixi run bash -c 'pip install -q "asv>=0.6" "asv-tachyon>=0.5.7"'
 
       - name: asv machine
+        working-directory: src
         run: |
           pixi run asv machine --yes \
             --machine github-actions \
@@ -93,31 +116,30 @@ jobs:
             --ram "0"
 
       - name: asv run
+        working-directory: src
         env:
-          QUICK: ${{ github.event_name == 'workflow_dispatch' && inputs.quick || github.event_name != 'schedule' }}
+          QUICK: ${{ (github.event_name == 'schedule' || inputs.force_full) && 'false' || 'true' }}
         run: |
           set -e
-          # Prefer a short window of recent commits when history is available
           EXTRA=""
-          if [ "$QUICK" = "true" ]; then
-            EXTRA="--quick"
-          fi
+          if [ "$QUICK" = "true" ]; then EXTRA="--quick"; fi
           pixi run bash -c "
-            if git rev-parse HEAD~3 >/dev/null 2>&1; then
-              asv run -E \"existing:\$(which python)\" HEAD~3..HEAD --record-samples $EXTRA || \
-              asv run -E \"existing:\$(which python)\" HEAD --record-samples $EXTRA
+            export PATH=\"\$CONDA_PREFIX/bin:\$PATH\"
+            PY=\$(which python)
+            if git rev-parse HEAD~5 >/dev/null 2>&1; then
+              asv run -E \"existing:\$PY\" HEAD~5..HEAD --record-samples \$EXTRA || \
+              asv run -E \"existing:\$PY\" HEAD --record-samples \$EXTRA
             else
-              asv run -E \"existing:\$(which python)\" HEAD --record-samples $EXTRA
+              asv run -E \"existing:\$PY\" HEAD --record-samples \$EXTRA
             fi
           "
 
       - name: asv publish + tachyon UI
+        working-directory: src
         run: |
           set -e
           pixi run asv publish
-          # asv-tachyon install into the published tree
           pixi run asv-tachyon install .asv/html
-          # commits sidecar for Explore tooltips
           python - <<'PY'
           import json, subprocess
           from pathlib import Path
@@ -137,31 +159,81 @@ jobs:
           (html / "commits.json").write_text(
               json.dumps({"by_revision": by_rev, **by_hash}, indent=2) + "\n"
           )
-          # site meta for branding
           (html / "site.json").write_text(json.dumps({
               "project": "eOn",
               "title": "eOn benchmarks",
               "docs_url": "https://eondocs.org/",
               "repo_url": "https://github.com/TheochemUI/eOn",
+              "bench_url": "https://bench.eondocs.org/",
           }, indent=2) + "\n")
           PY
-          ls -la .asv/html | head
           test -f .asv/html/index.json
           test -f .asv/html/index.html
+          ls -la .asv/html | head
+
+      - name: Commit results to asv-results orphan
+        working-directory: src
+        run: |
+          set -e
+          # Prepare orphan worktree payload
+          STAGE="$GITHUB_WORKSPACE/asv-results-stage"
+          rm -rf "$STAGE"
+          mkdir -p "$STAGE/.asv"
+          rsync -a .asv/results/ "$STAGE/.asv/results/"
+          cd "$STAGE"
+          git init -b asv-results
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Preserve any existing README on the branch if present
+          if [ -f "$GITHUB_WORKSPACE/asv-results/README.md" ]; then
+            cp "$GITHUB_WORKSPACE/asv-results/README.md" README.md
+          else
+            cat > README.md <<'MD'
+          # asv-results (orphan)
+
+          Long-lived ASV result JSON for eOn. Updated by `ASV dashboard` workflow.
+          Do not put source trees here — only `.asv/results/**`.
+          MD
+          fi
+          echo "*.pyc" > .gitignore
+          echo "__pycache__/" >> .gitignore
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No result changes"
+          else
+            git commit -m "asv: update results $(date -u +%Y-%m-%dT%H:%MZ)"
+          fi
+          git remote add origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
+          git push -f origin asv-results
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Deploy UI to gh-pages /bench
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: src/.asv/html
+          destination_dir: bench
+          keep_files: true
+          commit_message: "deploy(asv): tachyon dashboard"
+
+      - name: Deploy to Netlify (bench.eondocs.org)
+        working-directory: src
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        run: |
+          set -e
+          if [ -z "${NETLIFY_AUTH_TOKEN:-}" ] || [ -z "${NETLIFY_SITE_ID:-}" ]; then
+            echo "NETLIFY_AUTH_TOKEN / NETLIFY_SITE_ID not set; skip Netlify deploy"
+            exit 0
+          fi
+          npx --yes netlify-cli deploy --prod --dir=.asv/html \
+            --message "asv-tachyon $(git rev-parse --short HEAD)"
 
       - name: Upload HTML artifact
         uses: actions/upload-artifact@v4
         with:
           name: asv-html
-          path: .asv/html/
-          retention-days: 14
-
-      - name: Deploy to gh-pages /bench
-        if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: .asv/html
-          destination_dir: bench
-          keep_files: true
-          commit_message: "deploy(asv): tachyon dashboard"
+          path: src/.asv/html/
+          retention-days: 30

--- a/.github/workflows/ci_asv_dashboard.yml
+++ b/.github/workflows/ci_asv_dashboard.yml
@@ -121,24 +121,14 @@ jobs:
           QUICK: ${{ (github.event_name == 'schedule' || inputs.force_full) && 'false' || 'true' }}
         run: |
           set -e
-          # existing: env cannot take a git range — loop SHAs with --set-commit-hash
           EXTRA=""
-          if [ "$QUICK" = "true" ]; then EXTRA="--quick"; fi
           N=5
-          if [ "$QUICK" != "true" ]; then N=8; fi
-          pixi run bash -c "
-            set -e
-            export PATH=\"\$CONDA_PREFIX/bin:\$PATH\"
-            PY=\$(which python)
-            mapfile -t SHAS < <(git rev-list --max-count=$N HEAD)
-            # oldest first so history is chronological
-            for ((i=\${#SHAS[@]}-1; i>=0; i--)); do
-              sha=\${SHAS[i]}
-              echo "=== asv run $EXTRA --set-commit-hash \$sha ==="
-              asv run -E \"existing:\$PY\" --set-commit-hash \"\$sha\" --record-samples $EXTRA \
-                || asv run -E \"existing:\$PY\" --set-commit-hash \"\$sha\" --record-samples $EXTRA -v
-            done
-          "
+          if [ "$QUICK" = "true" ]; then
+            EXTRA="--quick"
+          else
+            N=8
+          fi
+          pixi run bash scripts/asv_run_history.sh "$N" "$EXTRA"
 
       - name: asv publish + tachyon UI
         working-directory: src

--- a/.github/workflows/ci_asv_dashboard.yml
+++ b/.github/workflows/ci_asv_dashboard.yml
@@ -1,0 +1,167 @@
+# Continuous ASV history + asv-tachyon static dashboard.
+# Publishes to gh-pages under /bench/ (keep_files so docs stay at site root).
+# Live path after deploy: https://eondocs.org/bench/ (upstream) or
+# https://haozeke.github.io/eOn/bench/ (fork). For bench.eondocs.org see
+# docs note in the PR body (subdomain needs DNS CNAME + same Pages site
+# path, or a dedicated Pages project).
+
+name: ASV dashboard
+
+concurrency:
+  group: asv-dashboard-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "benchmarks/**"
+      - "asv.conf.json"
+      - "eon/**"
+      - "client/**"
+      - "meson.build"
+      - "meson_options.txt"
+      - "pixi.toml"
+      - "pixi.lock"
+      - ".github/workflows/ci_asv_dashboard.yml"
+  schedule:
+    # Weekly full-ish refresh (Monday 09:00 UTC)
+    - cron: "0 9 * * 1"
+  workflow_dispatch:
+    inputs:
+      quick:
+        description: "Use asv --quick (faster, noisier)"
+        type: boolean
+        default: true
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+jobs:
+  asv-publish:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: prefix-dev/setup-pixi@v0.9.4
+        with:
+          cache: true
+          cache-write: true
+          activate-environment: true
+
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Ensure cbindgen
+        shell: bash
+        run: command -v cbindgen || cargo install cbindgen
+
+      - name: Build eonclient + install into pixi prefix
+        run: |
+          pixi run bash -c "meson setup bbdir \
+            --prefix=\$CONDA_PREFIX --libdir=lib \
+            --buildtype release --wipe 2>/dev/null \
+            || meson setup bbdir --prefix=\$CONDA_PREFIX \
+            --libdir=lib --buildtype release"
+          pixi run meson install -C bbdir
+          command -v eonclient
+          eonclient -h >/dev/null 2>&1 || true
+
+      - name: Restore ASV results cache
+        uses: actions/cache@v4
+        with:
+          path: .asv/results
+          key: asv-results-${{ runner.os }}-${{ hashFiles('benchmarks/**', 'asv.conf.json') }}-${{ github.sha }}
+          restore-keys: |
+            asv-results-${{ runner.os }}-${{ hashFiles('benchmarks/**', 'asv.conf.json') }}-
+            asv-results-${{ runner.os }}-
+
+      - name: Install asv + tachyon
+        run: |
+          pixi run bash -c 'pip install -q "asv>=0.6" "asv-tachyon>=0.5.7"'
+
+      - name: asv machine
+        run: |
+          pixi run asv machine --yes \
+            --machine github-actions \
+            --os "$(uname -s)" \
+            --arch "$(uname -m)" \
+            --cpu "gha" \
+            --ram "0"
+
+      - name: asv run
+        env:
+          QUICK: ${{ github.event_name == 'workflow_dispatch' && inputs.quick || github.event_name != 'schedule' }}
+        run: |
+          set -e
+          # Prefer a short window of recent commits when history is available
+          EXTRA=""
+          if [ "$QUICK" = "true" ]; then
+            EXTRA="--quick"
+          fi
+          pixi run bash -c "
+            if git rev-parse HEAD~3 >/dev/null 2>&1; then
+              asv run -E \"existing:\$(which python)\" HEAD~3..HEAD --record-samples $EXTRA || \
+              asv run -E \"existing:\$(which python)\" HEAD --record-samples $EXTRA
+            else
+              asv run -E \"existing:\$(which python)\" HEAD --record-samples $EXTRA
+            fi
+          "
+
+      - name: asv publish + tachyon UI
+        run: |
+          set -e
+          pixi run asv publish
+          # asv-tachyon install into the published tree
+          pixi run asv-tachyon install .asv/html
+          # commits sidecar for Explore tooltips
+          python - <<'PY'
+          import json, subprocess
+          from pathlib import Path
+          html = Path(".asv/html")
+          idx = json.loads((html / "index.json").read_text())
+          by_hash, by_rev = {}, {}
+          for rev, h in idx.get("revision_to_hash", {}).items():
+              try:
+                  subj = subprocess.check_output(
+                      ["git", "log", "-1", "--format=%s", h], text=True
+                  ).strip()
+              except Exception:
+                  subj = ""
+              if subj:
+                  by_hash[h] = subj
+                  by_rev[str(rev)] = subj
+          (html / "commits.json").write_text(
+              json.dumps({"by_revision": by_rev, **by_hash}, indent=2) + "\n"
+          )
+          # site meta for branding
+          (html / "site.json").write_text(json.dumps({
+              "project": "eOn",
+              "title": "eOn benchmarks",
+              "docs_url": "https://eondocs.org/",
+              "repo_url": "https://github.com/TheochemUI/eOn",
+          }, indent=2) + "\n")
+          PY
+          ls -la .asv/html | head
+          test -f .asv/html/index.json
+          test -f .asv/html/index.html
+
+      - name: Upload HTML artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: asv-html
+          path: .asv/html/
+          retention-days: 14
+
+      - name: Deploy to gh-pages /bench
+        if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: .asv/html
+          destination_dir: bench
+          keep_files: true
+          commit_message: "deploy(asv): tachyon dashboard"

--- a/.github/workflows/ci_build_akmc.yml
+++ b/.github/workflows/ci_build_akmc.yml
@@ -64,21 +64,17 @@ jobs:
           export CC=cl CXX=cl
           export AR=lib
           export ARFLAGS=
-          # conda-forge win-64 flang 19 ships flang-new.exe (activate sets FC=flang-new).
-          if [ -x "${CONDA_PREFIX}/Library/bin/flang-new.exe" ]; then
-            export FC="${CONDA_PREFIX}/Library/bin/flang-new.exe"
-          elif [ -x "${CONDA_PREFIX}/Library/bin/flang.exe" ]; then
-            export FC="${CONDA_PREFIX}/Library/bin/flang.exe"
-          elif command -v flang-new >/dev/null 2>&1; then
-            export FC="$(command -v flang-new)"
-          elif command -v flang >/dev/null 2>&1; then
-            export FC="$(command -v flang)"
-          else
-            echo "flang-new/flang not found under CONDA_PREFIX=${CONDA_PREFIX:-unset}" >&2
+          # conda-forge flang_win-64 activate.bat sets FC=flang-new (binary is
+          # flang-new.exe). SciPy feedstock relies on that activation; pixi bash
+          # does not always apply .bat activate.d, so set the same value here.
+          # Meson also lists flang-new in its default Fortran compiler search.
+          export FC=flang-new
+          if ! command -v flang-new >/dev/null 2>&1; then
+            echo "flang-new not on PATH; CONDA_PREFIX=${CONDA_PREFIX:-unset}" >&2
             ls -la "${CONDA_PREFIX}/Library/bin"/flang* 2>/dev/null || true
             exit 1
           fi
-          echo "FC=$FC"
+          echo "FC=$(command -v flang-new)"
           # flang_rt import libs (LNK1104 FortranRuntime / flang_rt otherwise).
           FLANG_RT_DIR=""
           _res="$("$FC" -print-resource-dir 2>/dev/null || true)"

--- a/.github/workflows/ci_build_akmc.yml
+++ b/.github/workflows/ci_build_akmc.yml
@@ -37,7 +37,8 @@ jobs:
 
       - name: Activate MSVC (Windows)
         if: runner.os == 'Windows'
-        uses: ilammy/msvc-dev-cmd@v1
+        shell: pwsh
+        run: pwsh -File scripts/ci/activate_msvc_gha.ps1
 
       - name: Compile and install [windows]
         if: runner.os == 'Windows'
@@ -56,6 +57,10 @@ jobs:
         run: |
           # with_tests defaults true; catch MSVC-only compile/link failures in
           # unit tests that never run on the Unix-only feature workflows.
+          # Strip Git Bash /usr/bin so MSVC link.exe is not shadowed by GNU link.
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            export PATH=$(echo "$PATH" | tr ':' '\n' | grep -v '^/usr/bin$' | paste -sd:)
+          fi
           meson test -C bbdir --print-errorlogs
       - name: Run server smoke tests
         shell: pixi run bash -e {0}

--- a/.github/workflows/ci_build_akmc.yml
+++ b/.github/workflows/ci_build_akmc.yml
@@ -44,45 +44,7 @@ jobs:
         if: runner.os == 'Windows'
         shell: pixi run bash -e {0}
         run: |
-          # Windows: conda DLL path first (torch/shm.dll), then MSVC tools,
-          # and drop Git Bash /usr/bin so GNU link.exe cannot shadow MSVC.
-          export PATH=$(echo "$PATH" | tr ':' '\n' | grep -v '^/usr/bin$' | paste -sd:)
-          export PATH="$CONDA_PREFIX/Scripts:$CONDA_PREFIX:$CONDA_PREFIX/Library/bin:$PATH"
-          CLDIR=$(dirname "$(command -v cl.exe 2>/dev/null || true)")
-          if [ -n "$CLDIR" ] && [ -x "$CLDIR/link.exe" ]; then
-            export PATH="$CLDIR:$PATH"
-          fi
-          # pixi compilers set LD=lld-link / clang LDFLAGS; use MSVC for this build
-          unset LDFLAGS || true
-          export LD=link
-          export CC=cl
-          export CXX=cl
-          # Align with conda-forge/eon-feedstock#15 / build.bat: in-tree Fortran ON
-          # (m2w64/gfortran pots + MSVC C++; /STACK:16M in meson for GAGAFE; CuH2 on).
-          meson setup bbdir --prefix=$CONDA_PREFIX --libdir=lib --buildtype release \
-            --default-library=static -Dwith_fortran=true -Dwith_cuh2=true
-          meson install -C bbdir
-
-      - name: Run Catch2 unit tests
-        shell: pixi run bash -e {0}
-        run: |
-          # with_tests defaults true; catch MSVC-only compile/link failures in
-          # unit tests that never run on the Unix-only feature workflows.
-          # Strip Git Bash /usr/bin so MSVC link.exe is not shadowed by GNU link.
-          if [ "$RUNNER_OS" = "Windows" ]; then
-          # Windows: conda DLL path first (torch/shm.dll), then MSVC tools,
-          # and drop Git Bash /usr/bin so GNU link.exe cannot shadow MSVC.
-          export PATH=$(echo "$PATH" | tr ':' '\n' | grep -v '^/usr/bin$' | paste -sd:)
-          export PATH="$CONDA_PREFIX/Scripts:$CONDA_PREFIX:$CONDA_PREFIX/Library/bin:$PATH"
-          CLDIR=$(dirname "$(command -v cl.exe 2>/dev/null || true)")
-          if [ -n "$CLDIR" ] && [ -x "$CLDIR/link.exe" ]; then
-            export PATH="$CLDIR:$PATH"
-          fi
-          # pixi compilers set LD=lld-link / clang LDFLAGS; use MSVC for this build
-          unset LDFLAGS || true
-          export LD=link
-          export CC=cl
-          export CXX=cl
+          source scripts/ci/win_msvc_path.sh
           fi
           meson test -C bbdir --print-errorlogs
       - name: Run server smoke tests

--- a/.github/workflows/ci_build_akmc.yml
+++ b/.github/workflows/ci_build_akmc.yml
@@ -48,10 +48,38 @@ jobs:
         if: runner.os == 'Windows'
         shell: pixi run bash -e {0}
         run: |
-          # Git Bash puts GNU link.exe on PATH which shadows MSVC link.exe
-          export PATH=$(echo "$PATH" | tr ':' '\n' | grep -v '^/usr/bin$' | paste -sd:)
+          # Git Bash puts GNU link.exe on PATH which shadows MSVC link.exe.
+          # Also drop MinGW/Strawberry so they cannot reappear mid-build.
+          export PATH=$(echo "$PATH" | tr ':' '\n' \
+            | grep -vE '/usr/bin$|[Mm]ingw|[Ss]trawberry' \
+            | paste -sd:)
+          # conda LDFLAGS inject -Wl,... which GNU link mis-parses as --W and
+          # MSVC link rejects; strip them for MSVC.
+          unset LDFLAGS CFLAGS CXXFLAGS FCFLAGS || true
+          export CC=cl CXX=cl
+          export AR=lib
+          export ARFLAGS=
+          export FC=flang
+          # flang_rt import libs (LNK1104 FortranRuntime / flang_rt otherwise).
+          FLANG_RT_DIR=""
+          if command -v flang >/dev/null 2>&1; then
+            _res="$(flang -print-resource-dir 2>/dev/null || true)"
+            if [ -n "$_res" ] && [ -d "$_res/lib/x86_64-pc-windows-msvc" ]; then
+              FLANG_RT_DIR="$_res/lib/x86_64-pc-windows-msvc"
+            fi
+          fi
+          if [ -z "$FLANG_RT_DIR" ] && [ -n "${CONDA_PREFIX:-}" ]; then
+            for _d in "${CONDA_PREFIX}/lib/clang"/*/lib/x86_64-pc-windows-msvc \
+                      "${CONDA_PREFIX}/Library/lib/clang"/*/lib/x86_64-pc-windows-msvc; do
+              if [ -d "$_d" ]; then FLANG_RT_DIR="$_d"; break; fi
+            done
+          fi
+          if [ -n "$FLANG_RT_DIR" ]; then
+            export LIB="${FLANG_RT_DIR};${LIB:-}"
+            echo "Using flang_rt LIBPATH: $FLANG_RT_DIR"
+          fi
           # Align with conda-forge/eon-feedstock#15 / build.bat: in-tree Fortran ON
-          # (m2w64/gfortran pots + MSVC C++; /STACK:16M in meson for GAGAFE; CuH2 on).
+          # (flang pots + MSVC C++; /STACK:16M in meson for GAGAFE; CuH2 on).
           meson setup bbdir --prefix=$CONDA_PREFIX --libdir=lib --buildtype release \
             --default-library=static -Dwith_fortran=true -Dwith_cuh2=true
           meson install -C bbdir
@@ -59,6 +87,14 @@ jobs:
       - name: Run Catch2 unit tests
         shell: pixi run bash -e {0}
         run: |
+          # Same PATH hygiene as compile: meson test may rebuild targets and
+          # must not pick Git usr/bin/link or conda -Wl LDFLAGS.
+          export PATH=$(echo "$PATH" | tr ':' '\n' \
+            | grep -vE '/usr/bin$|[Mm]ingw|[Ss]trawberry' \
+            | paste -sd:)
+          unset LDFLAGS CFLAGS CXXFLAGS FCFLAGS || true
+          export CC=cl CXX=cl
+          export AR=lib
           # with_tests defaults true; catch MSVC-only compile/link failures in
           # unit tests that never run on the Unix-only feature workflows.
           meson test -C bbdir --print-errorlogs

--- a/.github/workflows/ci_build_akmc.yml
+++ b/.github/workflows/ci_build_akmc.yml
@@ -108,6 +108,38 @@ jobs:
           # shellcheck source=scripts/ci/win_flang_rt.sh
           source scripts/ci/win_flang_rt.sh
           eon_export_flang_rt "${CONDA_PREFIX:-}" --required
+          # Prove pot DLLs exist in the build tree and LoadLibrary can resolve
+          # flang_rt deps (fails fast with a clear dump if not).
+          for _pot in Aluminum SW EDIP FeHe Lenosky Tersoff; do
+            ls -la "bbdir/client/potentials/${_pot}"/eon_*.dll \
+              "bbdir/client/potentials/${_pot}"/libeon_*.dll 2>/dev/null || true
+          done
+          if [ -z "${FLANG_RT_DLL_DIR:-}" ]; then
+            echo "FLANG_RT_DLL_DIR unset after eon_export_flang_rt" >&2
+            exit 1
+          fi
+          echo "FLANG_RT_DLL_DIR=$FLANG_RT_DLL_DIR"
+          ls -la "${FLANG_RT_DLL_DIR}"/FortranRuntime*.dll \
+            "${FLANG_RT_DLL_DIR}"/flang_rt*.dll \
+            "${FLANG_RT_DLL_DIR}"/FortranDecimal*.dll 2>/dev/null | head -20
+          python - <<'PY'
+          import ctypes, os, sys
+          from pathlib import Path
+          pot = Path("bbdir/client/potentials/SW")
+          cands = list(pot.glob("eon_*.dll")) + list(pot.glob("libeon_*.dll"))
+          print("SW pot candidates:", cands)
+          if not cands:
+              sys.exit("no SW pot DLL in build tree")
+          dll = str(cands[0].resolve())
+          print("LoadLibrary", dll)
+          try:
+              ctypes.WinDLL(dll)
+              print("LoadLibrary OK")
+          except OSError as e:
+              print("LoadLibrary FAILED:", e)
+              print("PATH head:", os.environ.get("PATH", "")[:500])
+              sys.exit(1)
+          PY
           unset LDFLAGS CFLAGS CXXFLAGS FCFLAGS || true
           export CC=cl CXX=cl
           export AR=lib

--- a/.github/workflows/ci_build_akmc.yml
+++ b/.github/workflows/ci_build_akmc.yml
@@ -44,8 +44,19 @@ jobs:
         if: runner.os == 'Windows'
         shell: pixi run bash -e {0}
         run: |
-          # Git Bash puts GNU link.exe on PATH which shadows MSVC link.exe
+          # Windows: conda DLL path first (torch/shm.dll), then MSVC tools,
+          # and drop Git Bash /usr/bin so GNU link.exe cannot shadow MSVC.
           export PATH=$(echo "$PATH" | tr ':' '\n' | grep -v '^/usr/bin$' | paste -sd:)
+          export PATH="$CONDA_PREFIX/Scripts:$CONDA_PREFIX:$CONDA_PREFIX/Library/bin:$PATH"
+          CLDIR=$(dirname "$(command -v cl.exe 2>/dev/null || true)")
+          if [ -n "$CLDIR" ] && [ -x "$CLDIR/link.exe" ]; then
+            export PATH="$CLDIR:$PATH"
+          fi
+          # pixi compilers set LD=lld-link / clang LDFLAGS; use MSVC for this build
+          unset LDFLAGS || true
+          export LD=link
+          export CC=cl
+          export CXX=cl
           # Align with conda-forge/eon-feedstock#15 / build.bat: in-tree Fortran ON
           # (m2w64/gfortran pots + MSVC C++; /STACK:16M in meson for GAGAFE; CuH2 on).
           meson setup bbdir --prefix=$CONDA_PREFIX --libdir=lib --buildtype release \
@@ -59,7 +70,19 @@ jobs:
           # unit tests that never run on the Unix-only feature workflows.
           # Strip Git Bash /usr/bin so MSVC link.exe is not shadowed by GNU link.
           if [ "$RUNNER_OS" = "Windows" ]; then
-            export PATH=$(echo "$PATH" | tr ':' '\n' | grep -v '^/usr/bin$' | paste -sd:)
+          # Windows: conda DLL path first (torch/shm.dll), then MSVC tools,
+          # and drop Git Bash /usr/bin so GNU link.exe cannot shadow MSVC.
+          export PATH=$(echo "$PATH" | tr ':' '\n' | grep -v '^/usr/bin$' | paste -sd:)
+          export PATH="$CONDA_PREFIX/Scripts:$CONDA_PREFIX:$CONDA_PREFIX/Library/bin:$PATH"
+          CLDIR=$(dirname "$(command -v cl.exe 2>/dev/null || true)")
+          if [ -n "$CLDIR" ] && [ -x "$CLDIR/link.exe" ]; then
+            export PATH="$CLDIR:$PATH"
+          fi
+          # pixi compilers set LD=lld-link / clang LDFLAGS; use MSVC for this build
+          unset LDFLAGS || true
+          export LD=link
+          export CC=cl
+          export CXX=cl
           fi
           meson test -C bbdir --print-errorlogs
       - name: Run server smoke tests

--- a/.github/workflows/ci_build_akmc.yml
+++ b/.github/workflows/ci_build_akmc.yml
@@ -108,22 +108,13 @@ jobs:
           # shellcheck source=scripts/ci/win_flang_rt.sh
           source scripts/ci/win_flang_rt.sh
           eon_export_flang_rt "${CONDA_PREFIX:-}" --required
-          # Prove pot DLLs exist in the build tree and LoadLibrary can resolve
-          # flang_rt deps (fails fast with a clear dump if not).
+          # Prove pot DLLs exist and LoadLibrary works (static flang_rt preferred).
           for _pot in Aluminum SW EDIP FeHe Lenosky Tersoff; do
             ls -la "bbdir/client/potentials/${_pot}"/eon_*.dll \
               "bbdir/client/potentials/${_pot}"/libeon_*.dll 2>/dev/null || true
           done
-          if [ -z "${FLANG_RT_DLL_DIR:-}" ]; then
-            echo "FLANG_RT_DLL_DIR unset after eon_export_flang_rt" >&2
-            exit 1
-          fi
-          echo "FLANG_RT_DLL_DIR=$FLANG_RT_DLL_DIR"
-          ls -la "${FLANG_RT_DLL_DIR}"/FortranRuntime*.dll \
-            "${FLANG_RT_DLL_DIR}"/flang_rt*.dll \
-            "${FLANG_RT_DLL_DIR}"/FortranDecimal*.dll 2>/dev/null | head -20
           python - <<'PY'
-          import ctypes, os, sys
+          import ctypes, os, sys, subprocess
           from pathlib import Path
           pot = Path("bbdir/client/potentials/SW")
           cands = list(pot.glob("eon_*.dll")) + list(pot.glob("libeon_*.dll"))
@@ -137,7 +128,21 @@ jobs:
               print("LoadLibrary OK")
           except OSError as e:
               print("LoadLibrary FAILED:", e)
-              print("PATH head:", os.environ.get("PATH", "")[:500])
+              print("PATH head:", os.environ.get("PATH", "")[:800])
+              # dumpbin shows missing deps when present
+              for tool in ("dumpbin", "llvm-readobj"):
+                  try:
+                      out = subprocess.check_output(
+                          [tool, "/dependents", dll]
+                          if tool == "dumpbin"
+                          else [tool, "--coff-imports", dll],
+                          text=True,
+                          stderr=subprocess.STDOUT,
+                      )
+                      print(out[:2000])
+                      break
+                  except Exception as ex:
+                      print(tool, "failed:", ex)
               sys.exit(1)
           PY
           unset LDFLAGS CFLAGS CXXFLAGS FCFLAGS || true

--- a/.github/workflows/ci_build_akmc.yml
+++ b/.github/workflows/ci_build_akmc.yml
@@ -75,22 +75,10 @@ jobs:
             exit 1
           fi
           echo "FC=$(command -v flang-new)"
-          # flang_rt import libs (LNK1104 FortranRuntime / flang_rt otherwise).
-          FLANG_RT_DIR=""
-          _res="$("$FC" -print-resource-dir 2>/dev/null || true)"
-          if [ -n "$_res" ] && [ -d "$_res/lib/x86_64-pc-windows-msvc" ]; then
-            FLANG_RT_DIR="$_res/lib/x86_64-pc-windows-msvc"
-          fi
-          if [ -z "$FLANG_RT_DIR" ] && [ -n "${CONDA_PREFIX:-}" ]; then
-            for _d in "${CONDA_PREFIX}/lib/clang"/*/lib/x86_64-pc-windows-msvc \
-                      "${CONDA_PREFIX}/Library/lib/clang"/*/lib/x86_64-pc-windows-msvc; do
-              if [ -d "$_d" ]; then FLANG_RT_DIR="$_d"; break; fi
-            done
-          fi
-          if [ -n "$FLANG_RT_DIR" ]; then
-            export LIB="${FLANG_RT_DIR};${LIB:-}"
-            echo "Using flang_rt LIBPATH: $FLANG_RT_DIR"
-          fi
+          # flang_rt import libs (LNK1104) + runtime DLLs for pot plugins.
+          # shellcheck source=scripts/ci/win_flang_rt.sh
+          source scripts/ci/win_flang_rt.sh
+          eon_export_flang_rt "${CONDA_PREFIX:-}" --required
           # Align with conda-forge/eon-feedstock#15 / build.bat: in-tree Fortran ON
           # (flang pots + MSVC C++; /STACK:16M in meson for GAGAFE; CuH2 on).
           meson setup bbdir --prefix=$CONDA_PREFIX --libdir=lib --buildtype release \
@@ -117,6 +105,9 @@ jobs:
           if [ -n "${CONDA_PREFIX:-}" ]; then
             export PATH="${CONDA_PREFIX}/Library/bin:${CONDA_PREFIX}/bin:${PATH}"
           fi
+          # shellcheck source=scripts/ci/win_flang_rt.sh
+          source scripts/ci/win_flang_rt.sh
+          eon_export_flang_rt "${CONDA_PREFIX:-}" --required
           unset LDFLAGS CFLAGS CXXFLAGS FCFLAGS || true
           export CC=cl CXX=cl
           export AR=lib

--- a/.github/workflows/ci_build_akmc.yml
+++ b/.github/workflows/ci_build_akmc.yml
@@ -48,25 +48,40 @@ jobs:
         if: runner.os == 'Windows'
         shell: pixi run bash -e {0}
         run: |
+          set -euo pipefail
           # Git Bash puts GNU link.exe on PATH which shadows MSVC link.exe.
           # Also drop MinGW/Strawberry so they cannot reappear mid-build.
           export PATH=$(echo "$PATH" | tr ':' '\n' \
             | grep -vE '/usr/bin$|[Mm]ingw|[Ss]trawberry' \
             | paste -sd:)
+          # pixi/conda put flang under Library/bin; keep it first after MSVC.
+          if [ -n "${CONDA_PREFIX:-}" ]; then
+            export PATH="${CONDA_PREFIX}/Library/bin:${CONDA_PREFIX}/bin:${PATH}"
+          fi
           # conda LDFLAGS inject -Wl,... which GNU link mis-parses as --W and
           # MSVC link rejects; strip them for MSVC.
           unset LDFLAGS CFLAGS CXXFLAGS FCFLAGS || true
           export CC=cl CXX=cl
           export AR=lib
           export ARFLAGS=
-          export FC=flang
+          # Absolute FC so meson does not fail with WinError 2 on bare "flang".
+          if [ -x "${CONDA_PREFIX}/Library/bin/flang.exe" ]; then
+            export FC="${CONDA_PREFIX}/Library/bin/flang.exe"
+          elif [ -x "${CONDA_PREFIX}/Library/bin/flang" ]; then
+            export FC="${CONDA_PREFIX}/Library/bin/flang"
+          elif command -v flang >/dev/null 2>&1; then
+            export FC="$(command -v flang)"
+          else
+            echo "flang not found under CONDA_PREFIX=${CONDA_PREFIX:-unset}" >&2
+            ls -la "${CONDA_PREFIX}/Library/bin" 2>/dev/null | head -40 || true
+            exit 1
+          fi
+          echo "FC=$FC"
           # flang_rt import libs (LNK1104 FortranRuntime / flang_rt otherwise).
           FLANG_RT_DIR=""
-          if command -v flang >/dev/null 2>&1; then
-            _res="$(flang -print-resource-dir 2>/dev/null || true)"
-            if [ -n "$_res" ] && [ -d "$_res/lib/x86_64-pc-windows-msvc" ]; then
-              FLANG_RT_DIR="$_res/lib/x86_64-pc-windows-msvc"
-            fi
+          _res="$("$FC" -print-resource-dir 2>/dev/null || true)"
+          if [ -n "$_res" ] && [ -d "$_res/lib/x86_64-pc-windows-msvc" ]; then
+            FLANG_RT_DIR="$_res/lib/x86_64-pc-windows-msvc"
           fi
           if [ -z "$FLANG_RT_DIR" ] && [ -n "${CONDA_PREFIX:-}" ]; then
             for _d in "${CONDA_PREFIX}/lib/clang"/*/lib/x86_64-pc-windows-msvc \
@@ -84,20 +99,31 @@ jobs:
             --default-library=static -Dwith_fortran=true -Dwith_cuh2=true
           meson install -C bbdir
 
-      - name: Run Catch2 unit tests
+      - name: Run Catch2 unit tests [unix]
+        if: runner.os != 'Windows'
         shell: pixi run bash -e {0}
         run: |
+          # with_tests defaults true; catch compile/link failures in unit tests.
+          meson test -C bbdir --print-errorlogs
+
+      - name: Run Catch2 unit tests [windows]
+        if: runner.os == 'Windows'
+        shell: pixi run bash -e {0}
+        run: |
+          set -euo pipefail
           # Same PATH hygiene as compile: meson test may rebuild targets and
           # must not pick Git usr/bin/link or conda -Wl LDFLAGS.
           export PATH=$(echo "$PATH" | tr ':' '\n' \
             | grep -vE '/usr/bin$|[Mm]ingw|[Ss]trawberry' \
             | paste -sd:)
+          if [ -n "${CONDA_PREFIX:-}" ]; then
+            export PATH="${CONDA_PREFIX}/Library/bin:${CONDA_PREFIX}/bin:${PATH}"
+          fi
           unset LDFLAGS CFLAGS CXXFLAGS FCFLAGS || true
           export CC=cl CXX=cl
           export AR=lib
-          # with_tests defaults true; catch MSVC-only compile/link failures in
-          # unit tests that never run on the Unix-only feature workflows.
           meson test -C bbdir --print-errorlogs
+
       - name: Run server smoke tests
         shell: pixi run bash -e {0}
         run: |

--- a/.github/workflows/ci_build_akmc.yml
+++ b/.github/workflows/ci_build_akmc.yml
@@ -124,26 +124,31 @@ jobs:
           dll = str(cands[0].resolve())
           print("LoadLibrary", dll)
           try:
-              ctypes.WinDLL(dll)
+              h = ctypes.WinDLL(dll)
               print("LoadLibrary OK")
           except OSError as e:
               print("LoadLibrary FAILED:", e)
               print("PATH head:", os.environ.get("PATH", "")[:800])
-              # dumpbin shows missing deps when present
-              for tool in ("dumpbin", "llvm-readobj"):
-                  try:
-                      out = subprocess.check_output(
-                          [tool, "/dependents", dll]
-                          if tool == "dumpbin"
-                          else [tool, "--coff-imports", dll],
-                          text=True,
-                          stderr=subprocess.STDOUT,
-                      )
-                      print(out[:2000])
-                      break
-                  except Exception as ex:
-                      print(tool, "failed:", ex)
               sys.exit(1)
+          # Fortran symbols must be exported (Windows PE); catch missing exports early.
+          found = None
+          for name in ("sw_", "SW_", "_sw_", "sw__", "SW__"):
+              try:
+                  getattr(h, name)
+                  found = name
+                  break
+              except AttributeError:
+                  pass
+          print("sw symbol:", found)
+          try:
+              out = subprocess.check_output(
+                  ["dumpbin", "/exports", dll], text=True, stderr=subprocess.STDOUT
+              )
+              print(out[:2500])
+          except Exception as ex:
+              print("dumpbin /exports failed:", ex)
+          if not found:
+              sys.exit("eon_sw.dll loads but does not export sw_ (check .def / link)")
           PY
           unset LDFLAGS CFLAGS CXXFLAGS FCFLAGS || true
           export CC=cl CXX=cl

--- a/.github/workflows/ci_build_akmc.yml
+++ b/.github/workflows/ci_build_akmc.yml
@@ -64,16 +64,18 @@ jobs:
           export CC=cl CXX=cl
           export AR=lib
           export ARFLAGS=
-          # Absolute FC so meson does not fail with WinError 2 on bare "flang".
-          if [ -x "${CONDA_PREFIX}/Library/bin/flang.exe" ]; then
+          # conda-forge win-64 flang 19 ships flang-new.exe (activate sets FC=flang-new).
+          if [ -x "${CONDA_PREFIX}/Library/bin/flang-new.exe" ]; then
+            export FC="${CONDA_PREFIX}/Library/bin/flang-new.exe"
+          elif [ -x "${CONDA_PREFIX}/Library/bin/flang.exe" ]; then
             export FC="${CONDA_PREFIX}/Library/bin/flang.exe"
-          elif [ -x "${CONDA_PREFIX}/Library/bin/flang" ]; then
-            export FC="${CONDA_PREFIX}/Library/bin/flang"
+          elif command -v flang-new >/dev/null 2>&1; then
+            export FC="$(command -v flang-new)"
           elif command -v flang >/dev/null 2>&1; then
             export FC="$(command -v flang)"
           else
-            echo "flang not found under CONDA_PREFIX=${CONDA_PREFIX:-unset}" >&2
-            ls -la "${CONDA_PREFIX}/Library/bin" 2>/dev/null | head -40 || true
+            echo "flang-new/flang not found under CONDA_PREFIX=${CONDA_PREFIX:-unset}" >&2
+            ls -la "${CONDA_PREFIX}/Library/bin"/flang* 2>/dev/null || true
             exit 1
           fi
           echo "FC=$FC"

--- a/.github/workflows/ci_build_akmc.yml
+++ b/.github/workflows/ci_build_akmc.yml
@@ -10,7 +10,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-14, windows-latest]
+        # windows-2022: windows-latest currently ships VS 18 only; ilammy/msvc-dev-cmd
+        # fails there (invalid params on 18, or "VS not found" if pinned to 2022).
+        os: [ubuntu-22.04, macos-14, windows-2022]
     steps:
       - uses: actions/checkout@v4
       - uses: prefix-dev/setup-pixi@v0.9.4
@@ -40,7 +42,6 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: x64
-          # windows-latest may expose VS 18; pin 2022 (pixi / conda-forge MSVC).
           vsversion: "2022"
 
       - name: Compile and install [windows]

--- a/.github/workflows/ci_build_akmc.yml
+++ b/.github/workflows/ci_build_akmc.yml
@@ -38,6 +38,10 @@ jobs:
       - name: Activate MSVC (Windows)
         if: runner.os == 'Windows'
         uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+          # windows-latest may expose VS 18; pin 2022 (pixi / conda-forge MSVC).
+          vsversion: "2022"
 
       - name: Compile and install [windows]
         if: runner.os == 'Windows'

--- a/.github/workflows/ci_build_gprd.yml
+++ b/.github/workflows/ci_build_gprd.yml
@@ -16,6 +16,8 @@ on:
 jobs:
   build_eon:
     runs-on: ubuntu-latest
+    # Private gpr_optim clone needs SUBMODULE_PRIVATE; skip on forks/PRs without it.
+    if: ${{ secrets.SUBMODULE_PRIVATE != '' }}
     steps:
       - uses: actions/checkout@v4
       - name: Setup SSH for private submodule

--- a/.github/workflows/ci_build_gprd.yml
+++ b/.github/workflows/ci_build_gprd.yml
@@ -16,15 +16,29 @@ on:
 jobs:
   build_eon:
     runs-on: ubuntu-latest
-    # Private gpr_optim clone needs SUBMODULE_PRIVATE; skip on forks/PRs without it.
-    if: ${{ secrets.SUBMODULE_PRIVATE != '' }}
     steps:
+      # Private gpr_optim clone needs SUBMODULE_PRIVATE. Fork PRs do not receive
+      # repo secrets; exit 0 so the check stays green without a fake build.
+      - name: Check submodule SSH secret
+        id: gate
+        env:
+          SUBMODULE_PRIVATE: ${{ secrets.SUBMODULE_PRIVATE }}
+        run: |
+          if [ -z "$SUBMODULE_PRIVATE" ]; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "SUBMODULE_PRIVATE unavailable; skipping GPRD build"
+          else
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          fi
       - uses: actions/checkout@v4
+        if: steps.gate.outputs.available == 'true'
       - name: Setup SSH for private submodule
+        if: steps.gate.outputs.available == 'true'
         uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.SUBMODULE_PRIVATE }}
       - name: Pull GPRD submodule
+        if: steps.gate.outputs.available == 'true'
         run: |
           # develop tip: 26242c8 is not on any branch after gpr_optim history rewrite
           # (git clone then checkout fails with "unable to read tree").
@@ -34,6 +48,7 @@ jobs:
           git checkout 365b78bdf4042f75915e1113396e1b4aa50edaa2
           git rev-parse --short HEAD
       - uses: prefix-dev/setup-pixi@v0.9.4
+        if: steps.gate.outputs.available == 'true'
         with:
           cache: true
           cache-write: true
@@ -41,9 +56,11 @@ jobs:
           environments: >-
             dev
       - name: Install cbindgen
+        if: steps.gate.outputs.available == 'true'
         shell: bash
         run: command -v cbindgen || cargo install cbindgen
       - name: Install eon with GPRD
+        if: steps.gate.outputs.available == 'true'
         shell: pixi run bash -e {0}
         run: |
           meson setup --reconfigure bbdir  \
@@ -54,6 +71,7 @@ jobs:
           -Dwith_tests=true
           meson install -C bbdir
       - name: Integration Tests
+        if: steps.gate.outputs.available == 'true'
         shell: pixi run bash -e {0}
         run: |
           cd client/unit_tests/data/systems/saddle_search/

--- a/.github/workflows/ci_metatomic.yml
+++ b/.github/workflows/ci_metatomic.yml
@@ -34,9 +34,12 @@ jobs:
           FC=$(find "$(brew --prefix gcc)/bin" -name 'gfortran-*' | head -1)
           echo "FC=$FC" >> "$GITHUB_ENV"
           echo "SDKROOT=$(xcrun --show-sdk-path)" >> "$GITHUB_ENV"
+      # pixi/conda vs* activation leaves VSINSTALLDIR / CMAKE_GENERATOR_TOOLSET that
+      # break VsDevCmd when windows-latest ships VS 18 and vswhere picks it.
       - name: Activate MSVC (Windows)
         if: runner.os == 'Windows'
-        uses: ilammy/msvc-dev-cmd@v1
+        shell: pwsh
+        run: pwsh -File scripts/ci/activate_msvc_gha.ps1
       - name: Install eon [unix]
         if: runner.os != 'Windows'
         shell: pixi run bash -e {0}
@@ -71,4 +74,7 @@ jobs:
       - name: Run tests
         shell: pixi run bash -e {0}
         run: |
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            export PATH=$(echo "$PATH" | tr ':' '\n' | grep -v '^/usr/bin$' | paste -sd:)
+          fi
           meson test -C bbdir --print-errorlogs

--- a/.github/workflows/ci_metatomic.yml
+++ b/.github/workflows/ci_metatomic.yml
@@ -167,6 +167,23 @@ jobs:
           export CMAKE_CXX_COMPILER=cl
           export CMAKE_GENERATOR=Ninja
           python -c "import torch, vesin, metatensor, metatensor.torch, metatomic.torch; print('pre-meson import ok')"
+          # Help diagnose find_library against pip wheel layout
+          python - <<'PY'
+          import pathlib, site, torch
+          sp = pathlib.Path(torch.__file__).resolve().parent.parent
+          tv = ".".join(torch.__version__.split(".")[:2])
+          for rel in (
+              "metatensor/lib",
+              f"metatensor_torch/torch-{tv}/lib",
+              f"metatomic/torch/torch-{tv}/lib",
+              "vesin/lib",
+              "torch/lib",
+          ):
+              d = sp / rel
+              print(rel, "exists" if d.is_dir() else "MISSING", d)
+              if d.is_dir():
+                  print("  ", sorted(p.name for p in d.iterdir())[:40])
+          PY
           meson setup bbdir \
             --prefix="${PIXI_PRE}" \
             --libdir=lib \

--- a/.github/workflows/ci_metatomic.yml
+++ b/.github/workflows/ci_metatomic.yml
@@ -37,6 +37,10 @@ jobs:
       - name: Activate MSVC (Windows)
         if: runner.os == 'Windows'
         uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+          # windows-latest may expose VS 18; pin 2022 (pixi / conda-forge MSVC).
+          vsversion: "2022"
       - name: Install eon [unix]
         if: runner.os != 'Windows'
         shell: pixi run bash -e {0}

--- a/.github/workflows/ci_metatomic.yml
+++ b/.github/workflows/ci_metatomic.yml
@@ -234,6 +234,13 @@ jobs:
           # shellcheck source=scripts/ci/win_flang_rt.sh
           source scripts/ci/win_flang_rt.sh
           eon_export_flang_rt "${PIXI_PRE}" --required
+          if [ -z "${FLANG_RT_DLL_DIR:-}" ]; then
+            echo "FLANG_RT_DLL_DIR unset after eon_export_flang_rt" >&2
+            exit 1
+          fi
+          echo "FLANG_RT_DLL_DIR=$FLANG_RT_DLL_DIR"
+          ls -la "${FLANG_RT_DLL_DIR}"/FortranRuntime*.dll \
+            "${FLANG_RT_DLL_DIR}"/flang_rt*.dll 2>/dev/null | head -20 || true
           unset LDFLAGS CFLAGS CXXFLAGS FCFLAGS || true
           which meson
           meson --version

--- a/.github/workflows/ci_metatomic.yml
+++ b/.github/workflows/ci_metatomic.yml
@@ -64,6 +64,37 @@ jobs:
         run: |
           # Git Bash puts GNU link.exe on PATH which shadows MSVC link.exe
           export PATH=$(echo "$PATH" | tr ':' '\n' | grep -v '^/usr/bin$' | paste -sd:)
+          # pip torch / metatensor / metatomic ship native DLLs under site-packages;
+          # Windows LoadLibrary needs those dirs on PATH before import/meson probes.
+          _dll_path=$(
+            python - <<'PY'
+          import pathlib, site
+          roots = []
+          for sp in site.getsitepackages():
+              p = pathlib.Path(sp)
+              for rel in (
+                  "torch/lib",
+                  "torch/bin",
+                  "metatensor",
+                  "metatensor_torch",
+                  "metatomic",
+                  "vesin",
+              ):
+                  d = p / rel
+                  if d.is_dir():
+                      roots.append(str(d.resolve()))
+                  # nested torch-versioned lib dirs (metatensor_torch/torch-2.10/lib)
+                  for sub in p.glob(rel.replace("\\", "/") + "/**/lib"):
+                      if sub.is_dir():
+                          roots.append(str(sub.resolve()))
+          print(";".join(dict.fromkeys(roots)))
+          PY
+          )
+          if [ -n "$_dll_path" ]; then
+            export PATH="${_dll_path};${PATH}"
+            echo "Windows native lib PATH prepend: ${_dll_path}"
+          fi
+          python -c "import vesin, metatensor, metatensor.torch, metatomic.torch; print('pip_metatomic imports ok')"
           # Align with ci_build_akmc Windows + feedstock build.bat: static
           # default-library for MSVC; pip_metatomic for torch/metatomic wheels.
           meson setup bbdir \

--- a/.github/workflows/ci_metatomic.yml
+++ b/.github/workflows/ci_metatomic.yml
@@ -64,37 +64,12 @@ jobs:
         run: |
           # Git Bash puts GNU link.exe on PATH which shadows MSVC link.exe
           export PATH=$(echo "$PATH" | tr ':' '\n' | grep -v '^/usr/bin$' | paste -sd:)
-          # pip torch / metatensor / metatomic ship native DLLs under site-packages;
-          # Windows LoadLibrary needs those dirs on PATH before import/meson probes.
-          _dll_path=$(
-            python - <<'PY'
-          import pathlib, site
-          roots = []
-          for sp in site.getsitepackages():
-              p = pathlib.Path(sp)
-              for rel in (
-                  "torch/lib",
-                  "torch/bin",
-                  "metatensor",
-                  "metatensor_torch",
-                  "metatomic",
-                  "vesin",
-              ):
-                  d = p / rel
-                  if d.is_dir():
-                      roots.append(str(d.resolve()))
-                  # nested torch-versioned lib dirs (metatensor_torch/torch-2.10/lib)
-                  for sub in p.glob(rel.replace("\\", "/") + "/**/lib"):
-                      if sub.is_dir():
-                          roots.append(str(sub.resolve()))
-          print(";".join(dict.fromkeys(roots)))
-          PY
-          )
-          if [ -n "$_dll_path" ]; then
-            export PATH="${_dll_path};${PATH}"
-            echo "Windows native lib PATH prepend: ${_dll_path}"
-          fi
-          python -c "import vesin, metatensor, metatensor.torch, metatomic.torch; print('pip_metatomic imports ok')"
+          # pip torch DLLs: use Git-Bash colon paths (not Windows ';') + add_dll_directory
+          # via tools/win_pip_torch_path.py. Wrong separators caused WinError 127 on shm.dll.
+          _bash_dll=$(python tools/win_pip_torch_path.py --bash-path)
+          export PATH="${_bash_dll}:${PATH}"
+          echo "Windows native lib PATH prepend: ${_bash_dll}"
+          python tools/win_pip_torch_path.py --import-check
           # Align with ci_build_akmc Windows + feedstock build.bat: static
           # default-library for MSVC; pip_metatomic for torch/metatomic wheels.
           meson setup bbdir \

--- a/.github/workflows/ci_metatomic.yml
+++ b/.github/workflows/ci_metatomic.yml
@@ -125,7 +125,7 @@ jobs:
           export PATH=$(echo "$PATH" | tr ':' '\n' \
             | grep -vE '/usr/bin$|[Mm]ingw|[Ss]trawberry' \
             | paste -sd:)
-          # C++ deps from pixi (eigen, quill, …); do not use pixi python/torch
+          # C++ deps from pixi (eigen, quill, flang, …); do not use pixi python/torch
           PIXI_PRE="${PIXI_PROJECT_ROOT:-$PWD}/.pixi/envs/dev-mta"
           if [ ! -d "$PIXI_PRE/Library" ]; then
             echo "pixi env missing: $PIXI_PRE" >&2
@@ -158,14 +158,39 @@ jobs:
             || { echo "eigen headers missing under $PIXI_PRE"; find "$PIXI_PRE" -name 'Core' -path '*Eigen*' 2>/dev/null | head; exit 1; }
           export INCLUDE="${PIXI_PRE}/Library/include;${INCLUDE:-}"
           export LIB="${PIXI_PRE}/Library/lib;${LIB:-}"
-          # Put pixi Library/bin on PATH for DLLs, after MSVC tools
+          # pixi Library/bin: flang, flang_rt DLLs (after MSVC tools on PATH)
           export PATH="${PIXI_PRE}/Library/bin:${PATH}"
-          # Drop conda compiler flags; force MSVC for CMake probes
+          # Drop conda GNU-style flags; force MSVC for CMake probes + archives
+          # (feedstock build.bat: AR=lib so flang does not select llvm-ar).
           unset LDFLAGS CFLAGS CXXFLAGS FCFLAGS || true
           export CC=cl CXX=cl
+          export AR=lib
+          export ARFLAGS=
+          export FC=flang
           export CMAKE_C_COMPILER=cl
           export CMAKE_CXX_COMPILER=cl
           export CMAKE_GENERATOR=Ninja
+          # flang_rt import libs under clang resource dir (LNK1104 otherwise).
+          # Same search as conda-forge/eon-feedstock recipe/build.bat.
+          FLANG_RT_DIR=""
+          if command -v flang >/dev/null 2>&1; then
+            _res="$(flang -print-resource-dir 2>/dev/null || true)"
+            if [ -n "$_res" ] && [ -d "$_res/lib/x86_64-pc-windows-msvc" ]; then
+              FLANG_RT_DIR="$_res/lib/x86_64-pc-windows-msvc"
+            fi
+          fi
+          if [ -z "$FLANG_RT_DIR" ]; then
+            for _d in "${PIXI_PRE}/Library/lib/clang"/*/lib/x86_64-pc-windows-msvc; do
+              if [ -d "$_d" ]; then FLANG_RT_DIR="$_d"; break; fi
+            done
+          fi
+          if [ -n "$FLANG_RT_DIR" ]; then
+            export LIB="${FLANG_RT_DIR};${LIB}"
+            echo "Using flang_rt LIBPATH: $FLANG_RT_DIR"
+            ls "$FLANG_RT_DIR"/*.{lib,dll} 2>/dev/null | head -20 || ls "$FLANG_RT_DIR" | head -20
+          else
+            echo "WARNING: flang_rt resource dir not found" >&2
+          fi
           python -c "import torch, vesin, metatensor, metatensor.torch, metatomic.torch; print('pre-meson import ok')"
           # Help diagnose find_library against pip wheel layout
           python - <<'PY'
@@ -184,6 +209,7 @@ jobs:
               if d.is_dir():
                   print("  ", sorted(p.name for p in d.iterdir())[:40])
           PY
+          # In-tree Fortran + CuH2 ON (same as feedstock / AKMC Windows).
           meson setup bbdir \
             --prefix="${PIXI_PRE}" \
             --libdir=lib \
@@ -193,10 +219,8 @@ jobs:
             -Dtorch_version=2.10 \
             -Dwith_tests=True \
             -Dpip_metatomic=True \
-            -Dwith_fortran=false \
-            -Dwith_cuh2=false
-          # with_fortran/cuh2 off: avoids FortranRuntime.dynamic.lib (flang) on
-          # the pure MSVC + pip-torch link line; AKMC Windows covers Fortran pots.
+            -Dwith_fortran=true \
+            -Dwith_cuh2=true
           meson install -C bbdir
 
       - name: Run tests [windows]
@@ -212,8 +236,9 @@ jobs:
             | grep -vE '/usr/bin$|[Mm]ingw|[Ss]trawberry' \
             | paste -sd:)
           PIXI_PRE="${PIXI_PROJECT_ROOT:-$PWD}/.pixi/envs/dev-mta"
-          # DLLs only (torch + conda runtime), not pixi python/meson
+          # DLLs: torch + pixi runtime (flang_rt) for Fortran pot plugins
           export PATH="${pythonLocation}/Lib/site-packages/torch/lib:${PIXI_PRE}/Library/bin:${PATH}"
+          unset LDFLAGS CFLAGS CXXFLAGS FCFLAGS || true
           which meson
           meson --version
           meson test -C bbdir --print-errorlogs

--- a/.github/workflows/ci_metatomic.yml
+++ b/.github/workflows/ci_metatomic.yml
@@ -193,7 +193,10 @@ jobs:
             -Dtorch_version=2.10 \
             -Dwith_tests=True \
             -Dpip_metatomic=True \
-            -Dwith_fortran=false
+            -Dwith_fortran=false \
+            -Dwith_cuh2=false
+          # with_fortran/cuh2 off: avoids FortranRuntime.dynamic.lib (flang) on
+          # the pure MSVC + pip-torch link line; AKMC Windows covers Fortran pots.
           meson install -C bbdir
 
       - name: Run tests [windows]

--- a/.github/workflows/ci_metatomic.yml
+++ b/.github/workflows/ci_metatomic.yml
@@ -118,21 +118,54 @@ jobs:
           PIP_EXTRA_INDEX_URL: https://download.pytorch.org/whl/cpu
         run: |
           set -euo pipefail
-          # setup-python first; drop Git usr/bin (shadows MSVC link) and MinGW
+          # setup-python first
           export PATH="${pythonLocation}:${pythonLocation}/Scripts:${PATH}"
-          export PATH=$(echo "$PATH" | tr ':' '\n' | grep -vE '/usr/bin$|[Mm]ingw' | paste -sd:)
+          # Drop: Git usr (shadows MSVC link), MinGW, Strawberry Perl (broken
+          # pkg-config / windres / ld that poison CMake Eigen detection).
+          export PATH=$(echo "$PATH" | tr ':' '\n' \
+            | grep -vE '/usr/bin$|[Mm]ingw|[Ss]trawberry' \
+            | paste -sd:)
           # C++ deps from pixi (eigen, quill, …); do not use pixi python/torch
           PIXI_PRE="${PIXI_PROJECT_ROOT:-$PWD}/.pixi/envs/dev-mta"
-          if [ -d "$PIXI_PRE/Library" ]; then
-            export PKG_CONFIG_PATH="${PIXI_PRE}/Library/lib/pkgconfig:${PIXI_PRE}/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
-            export CMAKE_PREFIX_PATH="${PIXI_PRE}/Library;${PIXI_PRE};${CMAKE_PREFIX_PATH:-}"
-            # Include headers/libs for MSVC without putting conda compiler bins first
-            export INCLUDE="${PIXI_PRE}/Library/include;${INCLUDE:-}"
-            export LIB="${PIXI_PRE}/Library/lib;${LIB:-}"
+          if [ ! -d "$PIXI_PRE/Library" ]; then
+            echo "pixi env missing: $PIXI_PRE" >&2
+            ls -la .pixi/envs || true
+            exit 1
           fi
-          # Drop conda compiler LDFLAGS that inject clang_rt into MSVC link
+          # Prefer pixi pkg-config over anything left on PATH
+          if [ -x "$PIXI_PRE/Library/bin/pkg-config.exe" ]; then
+            export PKG_CONFIG="$PIXI_PRE/Library/bin/pkg-config.exe"
+          elif [ -x "$PIXI_PRE/Library/bin/pkgconf.exe" ]; then
+            export PKG_CONFIG="$PIXI_PRE/Library/bin/pkgconf.exe"
+          fi
+          export PKG_CONFIG_PATH="${PIXI_PRE}/Library/lib/pkgconfig:${PIXI_PRE}/lib/pkgconfig"
+          export CMAKE_PREFIX_PATH="${PIXI_PRE}/Library;${PIXI_PRE}"
+          # conda-forge eigen ships Eigen3Config under Library/share/eigen3/cmake
+          for _ed in \
+            "${PIXI_PRE}/Library/share/eigen3/cmake" \
+            "${PIXI_PRE}/Library/share/eigen3" \
+            "${PIXI_PRE}/Library/lib/cmake/Eigen3"
+          do
+            if [ -f "${_ed}/Eigen3Config.cmake" ] || [ -f "${_ed}/eigen3-config.cmake" ]; then
+              export Eigen3_DIR="${_ed}"
+              break
+            fi
+          done
+          echo "Eigen3_DIR=${Eigen3_DIR:-unset}"
+          echo "CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}"
+          ls "${PIXI_PRE}/Library/include/eigen3/Eigen/Core" 2>/dev/null \
+            || ls "${PIXI_PRE}/Library/include/Eigen/Core" 2>/dev/null \
+            || { echo "eigen headers missing under $PIXI_PRE"; find "$PIXI_PRE" -name 'Core' -path '*Eigen*' 2>/dev/null | head; exit 1; }
+          export INCLUDE="${PIXI_PRE}/Library/include;${INCLUDE:-}"
+          export LIB="${PIXI_PRE}/Library/lib;${LIB:-}"
+          # Put pixi Library/bin on PATH for DLLs, after MSVC tools
+          export PATH="${PIXI_PRE}/Library/bin:${PATH}"
+          # Drop conda compiler flags; force MSVC for CMake probes
           unset LDFLAGS CFLAGS CXXFLAGS FCFLAGS || true
           export CC=cl CXX=cl
+          export CMAKE_C_COMPILER=cl
+          export CMAKE_CXX_COMPILER=cl
+          export CMAKE_GENERATOR=Ninja
           python -c "import torch, vesin, metatensor, metatensor.torch, metatomic.torch; print('pre-meson import ok')"
           meson setup bbdir \
             --prefix="${PIXI_PRE}" \
@@ -142,7 +175,8 @@ jobs:
             -Dwith_metatomic=True \
             -Dtorch_version=2.10 \
             -Dwith_tests=True \
-            -Dpip_metatomic=True
+            -Dpip_metatomic=True \
+            -Dwith_fortran=false
           meson install -C bbdir
 
       - name: Run tests [windows]

--- a/.github/workflows/ci_metatomic.yml
+++ b/.github/workflows/ci_metatomic.yml
@@ -57,20 +57,21 @@ jobs:
         if: runner.os == 'Windows'
         shell: pixi run bash -e {0}
         run: |
-          # Git Bash puts GNU link.exe on PATH which shadows MSVC link.exe
-          export PATH=$(echo "$PATH" | tr ':' '\n' | grep -v '^/usr/bin$' | paste -sd:)
-          # Ensure MSVC link is first; prefer link.exe next to cl.exe
-          CLDIR=$(dirname "$(command -v cl.exe || true)")
-          if [ -n "$CLDIR" ]; then export PATH="$CLDIR:$PATH"; fi
-          # pip_metatomic modules must import for meson find_installation
-          python - <<'PY2'
-          import importlib
-          for m in ("vesin", "metatensor", "metatensor.torch", "metatomic.torch"):
-              importlib.import_module(m)
-              print("ok", m)
-          PY2
-          # Align with ci_build_akmc Windows + feedstock build.bat: static
-          # default-library for MSVC; pip_metatomic for torch/metatomic wheels.
+          # Windows: conda DLL path first (torch/shm.dll), then MSVC tools,
+          # and drop Git Bash /usr/bin so GNU link.exe cannot shadow MSVC.
+          export PATH=$(echo "$PATH" | tr ':' '
+' | grep -v '^/usr/bin$' | paste -sd:)
+          export PATH="$CONDA_PREFIX/Scripts:$CONDA_PREFIX:$CONDA_PREFIX/Library/bin:$PATH"
+          CLDIR=$(dirname "$(command -v cl.exe 2>/dev/null || true)")
+          if [ -n "$CLDIR" ] && [ -x "$CLDIR/link.exe" ]; then
+            export PATH="$CLDIR:$PATH"
+          fi
+          # pixi compilers set LD=lld-link / clang LDFLAGS; use MSVC for this build
+          unset LDFLAGS || true
+          export LD=link
+          export CC=cl
+          export CXX=cl
+          python -c "import vesin, metatensor, metatensor.torch, metatomic.torch; print('pip_metatomic imports ok')"
           meson setup bbdir \
             --prefix=$CONDA_PREFIX \
             --libdir=lib \
@@ -85,6 +86,18 @@ jobs:
         shell: pixi run bash -e {0}
         run: |
           if [ "$RUNNER_OS" = "Windows" ]; then
-            export PATH=$(echo "$PATH" | tr ':' '\n' | grep -v '^/usr/bin$' | paste -sd:)
+          # Windows: conda DLL path first (torch/shm.dll), then MSVC tools,
+          # and drop Git Bash /usr/bin so GNU link.exe cannot shadow MSVC.
+          export PATH=$(echo "$PATH" | tr ':' '\n' | grep -v '^/usr/bin$' | paste -sd:)
+          export PATH="$CONDA_PREFIX/Scripts:$CONDA_PREFIX:$CONDA_PREFIX/Library/bin:$PATH"
+          CLDIR=$(dirname "$(command -v cl.exe 2>/dev/null || true)")
+          if [ -n "$CLDIR" ] && [ -x "$CLDIR/link.exe" ]; then
+            export PATH="$CLDIR:$PATH"
+          fi
+          # pixi compilers set LD=lld-link / clang LDFLAGS; use MSVC for this build
+          unset LDFLAGS || true
+          export LD=link
+          export CC=cl
+          export CXX=cl
           fi
           meson test -C bbdir --print-errorlogs

--- a/.github/workflows/ci_metatomic.yml
+++ b/.github/workflows/ci_metatomic.yml
@@ -14,7 +14,9 @@ jobs:
         # builds with_metatomic + default with_tests; GHA must exercise that
         # surface so MSVC-only unit tests (e.g. MetatomicEngineAbiTest / DynLib)
         # fail here instead of only on conda-forge.
-        os: [ubuntu-22.04, macos-14, windows-latest]
+        # windows-2022: windows-latest currently ships VS 18 only; ilammy/msvc-dev-cmd
+        # fails there (invalid params on 18, or "VS not found" if pinned to 2022).
+        os: [ubuntu-22.04, macos-14, windows-2022]
     steps:
       - uses: actions/checkout@v4
       - uses: prefix-dev/setup-pixi@v0.9.4
@@ -39,7 +41,6 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: x64
-          # windows-latest may expose VS 18; pin 2022 (pixi / conda-forge MSVC).
           vsversion: "2022"
       - name: Install eon [unix]
         if: runner.os != 'Windows'

--- a/.github/workflows/ci_metatomic.yml
+++ b/.github/workflows/ci_metatomic.yml
@@ -34,8 +34,6 @@ jobs:
           FC=$(find "$(brew --prefix gcc)/bin" -name 'gfortran-*' | head -1)
           echo "FC=$FC" >> "$GITHUB_ENV"
           echo "SDKROOT=$(xcrun --show-sdk-path)" >> "$GITHUB_ENV"
-      # pixi/conda vs* activation leaves VSINSTALLDIR / CMAKE_GENERATOR_TOOLSET that
-      # break VsDevCmd when windows-latest ships VS 18 and vswhere picks it.
       - name: Activate MSVC (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
@@ -57,20 +55,8 @@ jobs:
         if: runner.os == 'Windows'
         shell: pixi run bash -e {0}
         run: |
-          # Windows: conda DLL path first (torch/shm.dll), then MSVC tools,
-          # and drop Git Bash /usr/bin so GNU link.exe cannot shadow MSVC.
-          export PATH=$(echo "$PATH" | tr ':' '
-' | grep -v '^/usr/bin$' | paste -sd:)
-          export PATH="$CONDA_PREFIX/Scripts:$CONDA_PREFIX:$CONDA_PREFIX/Library/bin:$PATH"
-          CLDIR=$(dirname "$(command -v cl.exe 2>/dev/null || true)")
-          if [ -n "$CLDIR" ] && [ -x "$CLDIR/link.exe" ]; then
-            export PATH="$CLDIR:$PATH"
-          fi
-          # pixi compilers set LD=lld-link / clang LDFLAGS; use MSVC for this build
-          unset LDFLAGS || true
-          export LD=link
-          export CC=cl
-          export CXX=cl
+          # shellcheck source=scripts/ci/win_msvc_path.sh
+          source scripts/ci/win_msvc_path.sh
           python -c "import vesin, metatensor, metatensor.torch, metatomic.torch; print('pip_metatomic imports ok')"
           meson setup bbdir \
             --prefix=$CONDA_PREFIX \
@@ -86,18 +72,7 @@ jobs:
         shell: pixi run bash -e {0}
         run: |
           if [ "$RUNNER_OS" = "Windows" ]; then
-          # Windows: conda DLL path first (torch/shm.dll), then MSVC tools,
-          # and drop Git Bash /usr/bin so GNU link.exe cannot shadow MSVC.
-          export PATH=$(echo "$PATH" | tr ':' '\n' | grep -v '^/usr/bin$' | paste -sd:)
-          export PATH="$CONDA_PREFIX/Scripts:$CONDA_PREFIX:$CONDA_PREFIX/Library/bin:$PATH"
-          CLDIR=$(dirname "$(command -v cl.exe 2>/dev/null || true)")
-          if [ -n "$CLDIR" ] && [ -x "$CLDIR/link.exe" ]; then
-            export PATH="$CLDIR:$PATH"
-          fi
-          # pixi compilers set LD=lld-link / clang LDFLAGS; use MSVC for this build
-          unset LDFLAGS || true
-          export LD=link
-          export CC=cl
-          export CXX=cl
+            # shellcheck source=scripts/ci/win_msvc_path.sh
+            source scripts/ci/win_msvc_path.sh
           fi
           meson test -C bbdir --print-errorlogs

--- a/.github/workflows/ci_metatomic.yml
+++ b/.github/workflows/ci_metatomic.yml
@@ -166,21 +166,16 @@ jobs:
           export CC=cl CXX=cl
           export AR=lib
           export ARFLAGS=
-          # conda-forge win-64 flang 19 ships flang-new.exe (activate: FC=flang-new).
-          if [ -x "${PIXI_PRE}/Library/bin/flang-new.exe" ]; then
-            export FC="${PIXI_PRE}/Library/bin/flang-new.exe"
-          elif [ -x "${PIXI_PRE}/Library/bin/flang.exe" ]; then
-            export FC="${PIXI_PRE}/Library/bin/flang.exe"
-          elif command -v flang-new >/dev/null 2>&1; then
-            export FC="$(command -v flang-new)"
-          elif command -v flang >/dev/null 2>&1; then
-            export FC="$(command -v flang)"
-          else
-            echo "flang-new/flang not found under PIXI_PRE=${PIXI_PRE}" >&2
+          # conda-forge flang_win-64 activate.bat: FC=flang-new (see also SciPy
+          # feedstock: trust compiler activation; meson searches flang-new).
+          # setup-python + pixi without full bat activation needs this explicitly.
+          export FC=flang-new
+          if ! command -v flang-new >/dev/null 2>&1; then
+            echo "flang-new not on PATH; PIXI_PRE=${PIXI_PRE}" >&2
             ls -la "${PIXI_PRE}/Library/bin"/flang* 2>/dev/null || true
             exit 1
           fi
-          echo "FC=$FC"
+          echo "FC=$(command -v flang-new)"
           export CMAKE_C_COMPILER=cl
           export CMAKE_CXX_COMPILER=cl
           export CMAKE_GENERATOR=Ninja

--- a/.github/workflows/ci_metatomic.yml
+++ b/.github/workflows/ci_metatomic.yml
@@ -23,7 +23,10 @@ jobs:
         with:
           cache: true
           cache-write: true
-          activate-environment: true
+          # Do not use activate-environment on Windows: setup-pixi fails with
+          # "Unable to handle environment activation which does not only append
+          # to PATH" for dev-mta (conda compiler activation rewrites PATH).
+          # Match ci_build_akmc: pixi run -e dev-mta per step.
           environments: >-
             dev-mta
       - name: Install cbindgen
@@ -44,7 +47,7 @@ jobs:
           vsversion: "2022"
       - name: Install eon [unix]
         if: runner.os != 'Windows'
-        shell: pixi run bash -e {0}
+        shell: pixi run -e dev-mta bash -e {0}
         run: |
           meson setup --reconfigure bbdir  \
           --prefix=$CONDA_PREFIX           \
@@ -57,7 +60,7 @@ jobs:
           meson install -C bbdir
       - name: Install eon [windows]
         if: runner.os == 'Windows'
-        shell: pixi run bash -e {0}
+        shell: pixi run -e dev-mta bash -e {0}
         run: |
           # Git Bash puts GNU link.exe on PATH which shadows MSVC link.exe
           export PATH=$(echo "$PATH" | tr ':' '\n' | grep -v '^/usr/bin$' | paste -sd:)
@@ -74,6 +77,6 @@ jobs:
             -Dpip_metatomic=True
           meson install -C bbdir
       - name: Run tests
-        shell: pixi run bash -e {0}
+        shell: pixi run -e dev-mta bash -e {0}
         run: |
           meson test -C bbdir --print-errorlogs

--- a/.github/workflows/ci_metatomic.yml
+++ b/.github/workflows/ci_metatomic.yml
@@ -59,6 +59,16 @@ jobs:
         run: |
           # Git Bash puts GNU link.exe on PATH which shadows MSVC link.exe
           export PATH=$(echo "$PATH" | tr ':' '\n' | grep -v '^/usr/bin$' | paste -sd:)
+          # Ensure MSVC link is first; prefer link.exe next to cl.exe
+          CLDIR=$(dirname "$(command -v cl.exe || true)")
+          if [ -n "$CLDIR" ]; then export PATH="$CLDIR:$PATH"; fi
+          # pip_metatomic modules must import for meson find_installation
+          python - <<'PY2'
+          import importlib
+          for m in ("vesin", "metatensor", "metatensor.torch", "metatomic.torch"):
+              importlib.import_module(m)
+              print("ok", m)
+          PY2
           # Align with ci_build_akmc Windows + feedstock build.bat: static
           # default-library for MSVC; pip_metatomic for torch/metatomic wheels.
           meson setup bbdir \

--- a/.github/workflows/ci_metatomic.yml
+++ b/.github/workflows/ci_metatomic.yml
@@ -180,24 +180,10 @@ jobs:
           export CMAKE_CXX_COMPILER=cl
           export CMAKE_GENERATOR=Ninja
           # flang_rt import libs under clang resource dir (LNK1104 otherwise).
-          # Same search as conda-forge/eon-feedstock recipe/build.bat.
-          FLANG_RT_DIR=""
-          _res="$("$FC" -print-resource-dir 2>/dev/null || true)"
-          if [ -n "$_res" ] && [ -d "$_res/lib/x86_64-pc-windows-msvc" ]; then
-            FLANG_RT_DIR="$_res/lib/x86_64-pc-windows-msvc"
-          fi
-          if [ -z "$FLANG_RT_DIR" ]; then
-            for _d in "${PIXI_PRE}/Library/lib/clang"/*/lib/x86_64-pc-windows-msvc; do
-              if [ -d "$_d" ]; then FLANG_RT_DIR="$_d"; break; fi
-            done
-          fi
-          if [ -n "$FLANG_RT_DIR" ]; then
-            export LIB="${FLANG_RT_DIR};${LIB}"
-            echo "Using flang_rt LIBPATH: $FLANG_RT_DIR"
-            ls "$FLANG_RT_DIR"/*.{lib,dll} 2>/dev/null | head -20 || ls "$FLANG_RT_DIR" | head -20
-          else
-            echo "WARNING: flang_rt resource dir not found" >&2
-          fi
+          # Also put runtime DLLs on PATH for LoadLibrary of pot plugins.
+          # shellcheck source=scripts/ci/win_flang_rt.sh
+          source scripts/ci/win_flang_rt.sh
+          eon_export_flang_rt "${PIXI_PRE}" --required
           python -c "import torch, vesin, metatensor, metatensor.torch, metatomic.torch; print('pre-meson import ok')"
           # Help diagnose find_library against pip wheel layout
           python - <<'PY'
@@ -245,6 +231,9 @@ jobs:
           PIXI_PRE="${PIXI_PROJECT_ROOT:-$PWD}/.pixi/envs/dev-mta"
           # DLLs: torch + pixi runtime (flang_rt) for Fortran pot plugins
           export PATH="${pythonLocation}/Lib/site-packages/torch/lib:${PIXI_PRE}/Library/bin:${PATH}"
+          # shellcheck source=scripts/ci/win_flang_rt.sh
+          source scripts/ci/win_flang_rt.sh
+          eon_export_flang_rt "${PIXI_PRE}" --required
           unset LDFLAGS CFLAGS CXXFLAGS FCFLAGS || true
           which meson
           meson --version

--- a/.github/workflows/ci_metatomic.yml
+++ b/.github/workflows/ci_metatomic.yml
@@ -234,13 +234,7 @@ jobs:
           # shellcheck source=scripts/ci/win_flang_rt.sh
           source scripts/ci/win_flang_rt.sh
           eon_export_flang_rt "${PIXI_PRE}" --required
-          if [ -z "${FLANG_RT_DLL_DIR:-}" ]; then
-            echo "FLANG_RT_DLL_DIR unset after eon_export_flang_rt" >&2
-            exit 1
-          fi
-          echo "FLANG_RT_DLL_DIR=$FLANG_RT_DLL_DIR"
-          ls -la "${FLANG_RT_DLL_DIR}"/FortranRuntime*.dll \
-            "${FLANG_RT_DLL_DIR}"/flang_rt*.dll 2>/dev/null | head -20 || true
+          echo "FLANG_RT_LIB_DIR=${FLANG_RT_LIB_DIR:-unset} FLANG_RT_DLL_DIR=${FLANG_RT_DLL_DIR:-unset}"
           unset LDFLAGS CFLAGS CXXFLAGS FCFLAGS || true
           which meson
           meson --version

--- a/.github/workflows/ci_metatomic.yml
+++ b/.github/workflows/ci_metatomic.yml
@@ -10,28 +10,28 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # win-64 is in feature.metatomic platforms (pixi.toml). Feedstock win
-        # builds with_metatomic + default with_tests; GHA must exercise that
-        # surface so MSVC-only unit tests (e.g. MetatomicEngineAbiTest / DynLib)
-        # fail here instead of only on conda-forge.
-        # windows-2022: windows-latest currently ships VS 18 only; ilammy/msvc-dev-cmd
-        # fails there (invalid params on 18, or "VS not found" if pinned to 2022).
+        # windows-2022: same runner family as metatomic/metatensor torch CI.
+        # windows-latest currently ships VS 18 only and breaks msvc-dev-cmd.
         os: [ubuntu-22.04, macos-14, windows-2022]
     steps:
       - uses: actions/checkout@v4
-      - uses: prefix-dev/setup-pixi@v0.9.4
+
+      # --- Unix: hermetic pixi (conda + pypi torch) ---
+      - name: Setup pixi [unix]
+        if: runner.os != 'Windows'
+        uses: prefix-dev/setup-pixi@v0.9.4
         with:
           cache: true
           cache-write: true
-          # Do not use activate-environment on Windows: setup-pixi fails with
-          # "Unable to handle environment activation which does not only append
-          # to PATH" for dev-mta (conda compiler activation rewrites PATH).
-          # Match ci_build_akmc: pixi run -e dev-mta per step.
+          activate-environment: true
           environments: >-
             dev-mta
-      - name: Install cbindgen
+
+      - name: Install cbindgen [unix]
+        if: runner.os != 'Windows'
         shell: bash
         run: command -v cbindgen || cargo install cbindgen
+
       - name: Use Homebrew gfortran (macOS)
         if: runner.os == 'macOS'
         run: |
@@ -39,12 +39,7 @@ jobs:
           FC=$(find "$(brew --prefix gcc)/bin" -name 'gfortran-*' | head -1)
           echo "FC=$FC" >> "$GITHUB_ENV"
           echo "SDKROOT=$(xcrun --show-sdk-path)" >> "$GITHUB_ENV"
-      - name: Activate MSVC (Windows)
-        if: runner.os == 'Windows'
-        uses: ilammy/msvc-dev-cmd@v1
-        with:
-          arch: x64
-          vsversion: "2022"
+
       - name: Install eon [unix]
         if: runner.os != 'Windows'
         shell: pixi run -e dev-mta bash -e {0}
@@ -58,22 +53,89 @@ jobs:
           -Dwith_tests=True                \
           -Dpip_metatomic=True
           meson install -C bbdir
-      - name: Install eon [windows]
-        if: runner.os == 'Windows'
+
+      - name: Run tests [unix]
+        if: runner.os != 'Windows'
         shell: pixi run -e dev-mta bash -e {0}
         run: |
-          # Git Bash puts GNU link.exe on PATH which shadows MSVC link.exe
-          export PATH=$(echo "$PATH" | tr ':' '\n' | grep -v '^/usr/bin$' | paste -sd:)
-          # pip torch DLLs: use Git-Bash colon paths (not Windows ';') + add_dll_directory
-          # via tools/win_pip_torch_path.py. Wrong separators caused WinError 127 on shm.dll.
-          _bash_dll=$(python tools/win_pip_torch_path.py --bash-path)
-          export PATH="${_bash_dll}:${PATH}"
-          echo "Windows native lib PATH prepend: ${_bash_dll}"
-          python tools/win_pip_torch_path.py --import-check
-          # Align with ci_build_akmc Windows + feedstock build.bat: static
-          # default-library for MSVC; pip_metatomic for torch/metatomic wheels.
+          meson test -C bbdir --print-errorlogs
+
+      # --- Windows: follow metatomic/metatensor torch CI ---
+      # setup-python + pip CPU torch + MSVC. Do NOT load pip torch from a
+      # conda/pixi env that also activates compilers (WinError 127 on shm.dll
+      # from DLL/search-order clashes). pixi only supplies C++ deps (eigen,
+      # quill, rust for readcon-core).
+      # Ref: metatensor/metatomic .github/workflows/torch-tests.yml
+      - name: Setup Python [windows]
+        if: runner.os == 'Windows'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Setup pixi C++ deps [windows]
+        if: runner.os == 'Windows'
+        uses: prefix-dev/setup-pixi@v0.9.4
+        with:
+          cache: true
+          cache-write: true
+          # No activate-environment: keep setup-python as the active interpreter.
+          environments: >-
+            dev-mta
+
+      - name: Install cbindgen [windows]
+        if: runner.os == 'Windows'
+        shell: bash
+        run: command -v cbindgen || cargo install cbindgen
+
+      - name: Activate MSVC [windows]
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Install pip torch + metatomic stack [windows]
+        if: runner.os == 'Windows'
+        shell: bash
+        env:
+          # Same as metatomic torch-tests / wheel builds
+          PIP_EXTRA_INDEX_URL: https://download.pytorch.org/whl/cpu
+        run: |
+          set -euo pipefail
+          # Prefer actions/setup-python over any conda/pixi python on PATH
+          export PATH="${pythonLocation}:${pythonLocation}/Scripts:${PATH}"
+          python -m pip install -U pip
+          python -m pip install meson ninja
+          python -m pip install "torch>=2.10,<2.11"
+          python -m pip install \
+            "metatomic-torch>=0.1.15,<0.2" \
+            "metatensor-torch>=0.10,<0.11" \
+            "vesin>=0.6,<0.7" \
+            "vesin-torch>=0.6,<0.7"
+          python -c "import torch, vesin, metatensor, metatensor.torch, metatomic.torch as m; print('pip_metatomic ok', torch.__version__, torch.__file__)"
+
+      - name: Install eon [windows]
+        if: runner.os == 'Windows'
+        shell: bash
+        env:
+          PIP_EXTRA_INDEX_URL: https://download.pytorch.org/whl/cpu
+        run: |
+          set -euo pipefail
+          # setup-python first; drop Git usr/bin (shadows MSVC link) and MinGW
+          export PATH="${pythonLocation}:${pythonLocation}/Scripts:${PATH}"
+          export PATH=$(echo "$PATH" | tr ':' '\n' | grep -vE '/usr/bin$|[Mm]ingw' | paste -sd:)
+          # C++ deps from pixi (eigen, quill, …); do not use pixi python/torch
+          PIXI_PRE="${PIXI_PROJECT_ROOT:-$PWD}/.pixi/envs/dev-mta"
+          if [ -d "$PIXI_PRE/Library" ]; then
+            export PKG_CONFIG_PATH="${PIXI_PRE}/Library/lib/pkgconfig:${PIXI_PRE}/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
+            export CMAKE_PREFIX_PATH="${PIXI_PRE}/Library;${PIXI_PRE};${CMAKE_PREFIX_PATH:-}"
+            # Include headers/libs for MSVC without putting conda compiler bins first
+            export INCLUDE="${PIXI_PRE}/Library/include;${INCLUDE:-}"
+            export LIB="${PIXI_PRE}/Library/lib;${LIB:-}"
+          fi
+          # Drop conda compiler LDFLAGS that inject clang_rt into MSVC link
+          unset LDFLAGS CFLAGS CXXFLAGS FCFLAGS || true
+          export CC=cl CXX=cl
+          python -c "import torch, vesin, metatensor, metatensor.torch, metatomic.torch; print('pre-meson import ok')"
           meson setup bbdir \
-            --prefix=$CONDA_PREFIX \
+            --prefix="${PIXI_PRE}" \
             --libdir=lib \
             --buildtype release \
             --default-library=static \
@@ -82,7 +144,14 @@ jobs:
             -Dwith_tests=True \
             -Dpip_metatomic=True
           meson install -C bbdir
-      - name: Run tests
-        shell: pixi run -e dev-mta bash -e {0}
+
+      - name: Run tests [windows]
+        if: runner.os == 'Windows'
+        shell: bash
         run: |
+          set -euo pipefail
+          export PATH="${pythonLocation}:${pythonLocation}/Scripts:${PATH}"
+          export PATH=$(echo "$PATH" | tr ':' '\n' | grep -vE '/usr/bin$|[Mm]ingw' | paste -sd:)
+          PIXI_PRE="${PIXI_PROJECT_ROOT:-$PWD}/.pixi/envs/dev-mta"
+          export PATH="${PIXI_PRE}/Library/bin:${PIXI_PRE}/Scripts:${PATH}"
           meson test -C bbdir --print-errorlogs

--- a/.github/workflows/ci_metatomic.yml
+++ b/.github/workflows/ci_metatomic.yml
@@ -166,17 +166,18 @@ jobs:
           export CC=cl CXX=cl
           export AR=lib
           export ARFLAGS=
-          # Absolute FC path: bare "flang" fails meson detection (WinError 2)
-          # when the shell does not resolve Library/bin the same way as meson.
-          if [ -x "${PIXI_PRE}/Library/bin/flang.exe" ]; then
+          # conda-forge win-64 flang 19 ships flang-new.exe (activate: FC=flang-new).
+          if [ -x "${PIXI_PRE}/Library/bin/flang-new.exe" ]; then
+            export FC="${PIXI_PRE}/Library/bin/flang-new.exe"
+          elif [ -x "${PIXI_PRE}/Library/bin/flang.exe" ]; then
             export FC="${PIXI_PRE}/Library/bin/flang.exe"
-          elif [ -x "${PIXI_PRE}/Library/bin/flang" ]; then
-            export FC="${PIXI_PRE}/Library/bin/flang"
+          elif command -v flang-new >/dev/null 2>&1; then
+            export FC="$(command -v flang-new)"
           elif command -v flang >/dev/null 2>&1; then
             export FC="$(command -v flang)"
           else
-            echo "flang not found under PIXI_PRE=${PIXI_PRE}" >&2
-            ls -la "${PIXI_PRE}/Library/bin" 2>/dev/null | head -40 || true
+            echo "flang-new/flang not found under PIXI_PRE=${PIXI_PRE}" >&2
+            ls -la "${PIXI_PRE}/Library/bin"/flang* 2>/dev/null || true
             exit 1
           fi
           echo "FC=$FC"

--- a/.github/workflows/ci_metatomic.yml
+++ b/.github/workflows/ci_metatomic.yml
@@ -159,25 +159,36 @@ jobs:
           export INCLUDE="${PIXI_PRE}/Library/include;${INCLUDE:-}"
           export LIB="${PIXI_PRE}/Library/lib;${LIB:-}"
           # pixi Library/bin: flang, flang_rt DLLs (after MSVC tools on PATH)
-          export PATH="${PIXI_PRE}/Library/bin:${PATH}"
+          export PATH="${PIXI_PRE}/Library/bin:${PIXI_PRE}/bin:${PATH}"
           # Drop conda GNU-style flags; force MSVC for CMake probes + archives
           # (feedstock build.bat: AR=lib so flang does not select llvm-ar).
           unset LDFLAGS CFLAGS CXXFLAGS FCFLAGS || true
           export CC=cl CXX=cl
           export AR=lib
           export ARFLAGS=
-          export FC=flang
+          # Absolute FC path: bare "flang" fails meson detection (WinError 2)
+          # when the shell does not resolve Library/bin the same way as meson.
+          if [ -x "${PIXI_PRE}/Library/bin/flang.exe" ]; then
+            export FC="${PIXI_PRE}/Library/bin/flang.exe"
+          elif [ -x "${PIXI_PRE}/Library/bin/flang" ]; then
+            export FC="${PIXI_PRE}/Library/bin/flang"
+          elif command -v flang >/dev/null 2>&1; then
+            export FC="$(command -v flang)"
+          else
+            echo "flang not found under PIXI_PRE=${PIXI_PRE}" >&2
+            ls -la "${PIXI_PRE}/Library/bin" 2>/dev/null | head -40 || true
+            exit 1
+          fi
+          echo "FC=$FC"
           export CMAKE_C_COMPILER=cl
           export CMAKE_CXX_COMPILER=cl
           export CMAKE_GENERATOR=Ninja
           # flang_rt import libs under clang resource dir (LNK1104 otherwise).
           # Same search as conda-forge/eon-feedstock recipe/build.bat.
           FLANG_RT_DIR=""
-          if command -v flang >/dev/null 2>&1; then
-            _res="$(flang -print-resource-dir 2>/dev/null || true)"
-            if [ -n "$_res" ] && [ -d "$_res/lib/x86_64-pc-windows-msvc" ]; then
-              FLANG_RT_DIR="$_res/lib/x86_64-pc-windows-msvc"
-            fi
+          _res="$("$FC" -print-resource-dir 2>/dev/null || true)"
+          if [ -n "$_res" ] && [ -d "$_res/lib/x86_64-pc-windows-msvc" ]; then
+            FLANG_RT_DIR="$_res/lib/x86_64-pc-windows-msvc"
           fi
           if [ -z "$FLANG_RT_DIR" ]; then
             for _d in "${PIXI_PRE}/Library/lib/clang"/*/lib/x86_64-pc-windows-msvc; do

--- a/.github/workflows/ci_metatomic.yml
+++ b/.github/workflows/ci_metatomic.yml
@@ -204,8 +204,16 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          export PATH="${pythonLocation}:${pythonLocation}/Scripts:${PATH}"
-          export PATH=$(echo "$PATH" | tr ':' '\n' | grep -vE '/usr/bin$|[Mm]ingw' | paste -sd:)
+          # Same interpreter/meson as Install eon (pip meson in setup-python).
+          # Do not prepend pixi Scripts — that puts a different meson first and
+          # meson test then rejects build.dat from the pip meson configure.
+          export PATH="${pythonLocation}/Scripts:${pythonLocation}:${PATH}"
+          export PATH=$(echo "$PATH" | tr ':' '\n' \
+            | grep -vE '/usr/bin$|[Mm]ingw|[Ss]trawberry' \
+            | paste -sd:)
           PIXI_PRE="${PIXI_PROJECT_ROOT:-$PWD}/.pixi/envs/dev-mta"
-          export PATH="${PIXI_PRE}/Library/bin:${PIXI_PRE}/Scripts:${PATH}"
+          # DLLs only (torch + conda runtime), not pixi python/meson
+          export PATH="${pythonLocation}/Lib/site-packages/torch/lib:${PIXI_PRE}/Library/bin:${PATH}"
+          which meson
+          meson --version
           meson test -C bbdir --print-errorlogs

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Custom, other things are auto-ignored
-subprojects
+# subprojects extracted trees ignored under Meson section; wraps + packagefiles kept
 artn_gitinfo.h
 ira_gitinfo.h
 **/artn_gitinfo.h
@@ -607,9 +607,11 @@ Temporary Items
 # Edit at https://www.toptal.com/developers/gitignore?templates=meson
 
 ### Meson ###
-# subproject directories
+# subproject directories (extracted sources stay ignored; wraps + packagefiles tracked)
 /subprojects/*
 !/subprojects/*.wrap
+!/subprojects/packagefiles/
+!/subprojects/packagefiles/**
 
 # Meson Directories
 meson-logs

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -7,7 +7,10 @@
     "benchmark_dir": "benchmarks",
     "results_dir": ".asv/results",
     "html_dir": ".asv/html",
-    "branches": ["HEAD"],
+    "branches": [
+        "HEAD"
+    ],
     "build_command": [],
-    "install_command": []
+    "install_command": [],
+    "show_commit_url": "https://github.com/TheochemUI/eOn/commit/"
 }

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,33 @@
+# eOn ASV benchmarks
+
+Python ASV suite that times the `eonclient` binary (saddle search, point
+energy, …). See `bench_eonclient.py` and `data/`.
+
+## Local
+
+```bash
+pixi install
+# build + install eonclient into the pixi env (same as CI)
+pixi run meson setup bbdir --prefix=$CONDA_PREFIX --libdir=lib --buildtype release
+pixi run meson install -C bbdir
+pixi run bash -c 'pip install asv asv-tachyon'
+pixi run asv machine --yes
+pixi run asv run -E "existing:$(which python)" --quick
+pixi run asv publish
+pixi run asv-tachyon install .asv/html
+pixi run asv-tachyon serve .asv/html --open
+```
+
+## Dashboard CI
+
+`.github/workflows/ci_asv_dashboard.yml` runs on `main`, weekly, and
+`workflow_dispatch`. It publishes an [asv-tachyon](https://github.com/HaoZeke/asv_tachyon)
+static site to the `gh-pages` branch under **`/bench/`**.
+
+- Fork: `https://haozeke.github.io/eOn/bench/`
+- Upstream docs site: `https://eondocs.org/bench/` (once merged)
+- Optional custom host: `https://bench.eondocs.org` → CNAME to the Pages
+  host that serves this tree (see workflow header comments)
+
+PR comments still use [asv-perch](https://github.com/HaoZeke/asv-perch)
+via `ci_benchmark.yml` + `ci_bench_commenter.yml`.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -7,7 +7,6 @@ energy, …). See `bench_eonclient.py` and `data/`.
 
 ```bash
 pixi install
-# build + install eonclient into the pixi env (same as CI)
 pixi run meson setup bbdir --prefix=$CONDA_PREFIX --libdir=lib --buildtype release
 pixi run meson install -C bbdir
 pixi run bash -c 'pip install asv asv-tachyon'
@@ -18,16 +17,30 @@ pixi run asv-tachyon install .asv/html
 pixi run asv-tachyon serve .asv/html --open
 ```
 
+## History storage
+
+Long-lived results live on the **orphan** git branch `asv-results`
+(`.asv/results/**` only). The **ASV dashboard** workflow restores that branch
+before each run and force-pushes updates after publish so history is not lost
+to Actions cache eviction.
+
 ## Dashboard CI
 
 `.github/workflows/ci_asv_dashboard.yml` runs on `main`, weekly, and
-`workflow_dispatch`. It publishes an [asv-tachyon](https://github.com/HaoZeke/asv_tachyon)
-static site to the `gh-pages` branch under **`/bench/`**.
+`workflow_dispatch`. It:
 
-- Fork: `https://haozeke.github.io/eOn/bench/`
-- Upstream docs site: `https://eondocs.org/bench/` (once merged)
-- Optional custom host: `https://bench.eondocs.org` → CNAME to the Pages
-  host that serves this tree (see workflow header comments)
+1. Restores `asv-results`
+2. Builds `eonclient`, runs ASV, publishes with [asv-tachyon](https://github.com/HaoZeke/asv_tachyon)
+3. Pushes results back to `asv-results`
+4. Deploys UI to `gh-pages` → **`/bench/`**
+5. Optionally deploys to Netlify (`NETLIFY_AUTH_TOKEN` + `NETLIFY_SITE_ID`) for **bench.eondocs.org**
+
+| Surface | URL |
+|---------|-----|
+| Docs | https://eondocs.org/ |
+| Bench (path) | https://eondocs.org/bench/ |
+| Bench (host) | https://bench.eondocs.org/ |
+| Fork preview | https://haozeke.github.io/eOn/bench/ |
 
 PR comments still use [asv-perch](https://github.com/HaoZeke/asv-perch)
 via `ci_benchmark.yml` + `ci_bench_commenter.yml`.

--- a/client/EonLogger.h
+++ b/client/EonLogger.h
@@ -18,11 +18,11 @@
 #include "quill/sinks/FileSink.h"
 #include <atomic>
 #include <filesystem>
-#include <system_error>
 #include <mutex>
 #include <source_location>
 #include <string>
 #include <string_view>
+#include <system_error>
 
 namespace eonc::log {
 

--- a/client/meson.build
+++ b/client/meson.build
@@ -1434,6 +1434,9 @@ if get_option('with_tests')
                 dependencies: test_deps,
                 include_directories: _incdirs,
                 cpp_args: test_args,
+                # Include /STACK:16M (Windows) so EAM Al Fortran pots do not
+                # SIGSEGV with STATUS_STACK_OVERFLOW (default stack is 1 MB).
+                link_args: _linkargs,
                 link_with: _linkto,
                 build_rpath: ':'.join(_runtime_rpath),
             ),

--- a/client/meson.build
+++ b/client/meson.build
@@ -76,16 +76,16 @@ if is_windows
                 ]
             endif
             # Fallback: conda/pixi layout under the compiler's bindir parents.
+            # win-64 flang often ships import libs in Library/lib (not only under
+            # the clang resource triple dir).
             _fc_path = fc.cmd_array()[0]
             _fc_dir = fs.parent(_fc_path)
             # .../Library/bin/flang-new.exe -> .../Library
             _lib_root = fs.parent(_fc_dir)
             _flang_rt_candidates += [
-                join_paths(
-                    _lib_root,
-                    'lib',
-                    'clang',
-                ),
+                join_paths(_lib_root, 'lib'),
+                join_paths(_lib_root, 'lib', 'clang'),
+                join_paths(_lib_root, 'bin'),
             ]
             _flang_rt_dir = ''
             foreach _cand : _flang_rt_candidates

--- a/client/meson.build
+++ b/client/meson.build
@@ -55,7 +55,8 @@ if is_windows
         # conda-forge flang ships flang_rt import libs under the clang resource
         # dir (e.g. Library/lib/clang/19/lib/x86_64-pc-windows-msvc/).  Meson
         # links Fortran objects with MSVC link.exe, which does not search that
-        # path by default and fails with LNK1104 on flang_rt.runtime.dynamic.lib.
+        # path by default and fails with LNK1104 on FortranRuntime.dynamic.lib
+        # / flang_rt.runtime.dynamic.lib. Feedstock also puts this dir on LIB.
         if use_fortran and fc.get_id() == 'flang'
             _flang_rt_libpath = run_command(
                 fc,
@@ -71,6 +72,18 @@ if is_windows
                 )
                 if fs.is_dir(_flang_rt_dir)
                     _linkargs += ['/LIBPATH:' + _flang_rt_dir]
+                    # Named import libs differ across flang releases; pass the
+                    # first that exists so MSVC link resolves defaultlib drectves.
+                    foreach _frt : [
+                        'flang_rt.runtime.dynamic.lib',
+                        'FortranRuntime.dynamic.lib',
+                        'flang_rt.dynamic.lib',
+                    ]
+                        if fs.is_file(join_paths(_flang_rt_dir, _frt))
+                            _linkargs += [join_paths(_flang_rt_dir, _frt)]
+                            break
+                        endif
+                    endforeach
                 endif
             endif
         endif

--- a/client/meson.build
+++ b/client/meson.build
@@ -1303,7 +1303,13 @@ if get_option('with_tests')
     )
     _test_env.set('EON_TEST_SYSTEMS_DIR', _systems_dir)
     if _fortran_pot_dirs.length() > 0
-        _test_env.set('EON_POTENTIALS_PATH', ':'.join(_fortran_pot_dirs))
+        # FortranPotLoader splits on ';' on Windows (drive letters break ':').
+        # Same pathsep rule as PATH: win=';' unix=':'.
+        _pot_pathsep = is_windows ? ';' : ':'
+        _test_env.set(
+            'EON_POTENTIALS_PATH',
+            _pot_pathsep.join(_fortran_pot_dirs),
+        )
     endif
 
     foreach test : test_array

--- a/client/meson.build
+++ b/client/meson.build
@@ -33,6 +33,8 @@ endif
 host_system = host_machine.system()
 is_windows = host_system == 'windows'
 is_mingw = is_windows and cc.get_id() == 'gcc'
+# Populated when flang_rt import libs are located (Windows MSVC + flang).
+_flang_rt_dir = ''
 
 # Add conditionals
 if host_system == 'darwin'
@@ -700,6 +702,41 @@ eonclib_sources += fortran_pot_cpp_sources
 # Fortran shared libraries: built only when a Fortran compiler is available,
 # installed separately, and loaded at runtime via dlopen.
 _fortran_pot_libs = []
+# Windows: conda-forge flang ships FortranRuntime*.lib but often no matching
+# .dll. Pot plugins are LoadLibrary'd; if they depend on FortranRuntime.dynamic
+# the load fails. Prefer static flang runtime objects inside each pot DLL.
+_fortran_pot_link_args = []
+if get_option('with_fortran') and is_windows and fc.get_id() in ['flang', 'llvm-flang', 'flang-new']
+    _fc_path = fc.cmd_array()[0]
+    _fc_dir = fs.parent(_fc_path)
+    _lib_root = fs.parent(_fc_dir)
+    _static_search = [join_paths(_lib_root, 'lib')]
+    if _flang_rt_dir != ''
+        _static_search += [_flang_rt_dir]
+    endif
+    foreach _static_frt : [
+        'FortranRuntime.static.lib',
+        'FortranDecimal.static.lib',
+    ]
+        foreach _sdir : _static_search
+            _probe = join_paths(_sdir, _static_frt)
+            if fs.is_file(_probe)
+                _fortran_pot_link_args += [_probe]
+                break
+            endif
+        endforeach
+    endforeach
+    if _fortran_pot_link_args.length() > 0
+        message(
+            'Fortran pot plugins: static flang_rt '
+            + ', '.join(_fortran_pot_link_args),
+        )
+    else
+        warning(
+            'Fortran pot plugins: no static flang_rt libs; LoadLibrary may need runtime DLLs',
+        )
+    endif
+endif
 if get_option('with_fortran')
     subdir('potentials/Aluminum')
     subdir('potentials/EDIP')

--- a/client/meson.build
+++ b/client/meson.build
@@ -57,7 +57,9 @@ if is_windows
         # links Fortran objects with MSVC link.exe, which does not search that
         # path by default and fails with LNK1104 on FortranRuntime.dynamic.lib
         # / flang_rt.runtime.dynamic.lib. Feedstock also puts this dir on LIB.
-        if use_fortran and fc.get_id() == 'flang'
+        # flang-new reports id 'llvm-flang' or 'flang' depending on Meson.
+        if use_fortran and fc.get_id() in ['flang', 'llvm-flang', 'flang-new']
+            _flang_rt_candidates = []
             _flang_rt_libpath = run_command(
                 fc,
                 '-print-resource-dir',
@@ -65,26 +67,96 @@ if is_windows
             )
             if _flang_rt_libpath.returncode() == 0
                 _flang_rt_res = _flang_rt_libpath.stdout().strip()
-                _flang_rt_dir = join_paths(
+                # Normalize D:\... to D:/... so join_paths / fs.is_* work.
+                _flang_rt_res = _flang_rt_res.replace('\\', '/')
+                _flang_rt_candidates += [
+                    join_paths(_flang_rt_res, 'lib', 'x86_64-pc-windows-msvc'),
+                    join_paths(_flang_rt_res, 'lib'),
                     _flang_rt_res,
+                ]
+            endif
+            # Fallback: conda/pixi layout under the compiler's bindir parents.
+            _fc_path = fc.cmd_array()[0]
+            _fc_dir = fs.parent(_fc_path)
+            # .../Library/bin/flang-new.exe -> .../Library
+            _lib_root = fs.parent(_fc_dir)
+            _flang_rt_candidates += [
+                join_paths(
+                    _lib_root,
                     'lib',
-                    'x86_64-pc-windows-msvc',
-                )
-                if fs.is_dir(_flang_rt_dir)
-                    _linkargs += ['/LIBPATH:' + _flang_rt_dir]
-                    # Named import libs differ across flang releases; pass the
-                    # first that exists so MSVC link resolves defaultlib drectves.
+                    'clang',
+                ),
+            ]
+            _flang_rt_dir = ''
+            foreach _cand : _flang_rt_candidates
+                if _flang_rt_dir != ''
+                    break
+                endif
+                if not fs.is_dir(_cand)
+                    continue
+                endif
+                # Direct match or clang/<ver>/lib/x86_64-pc-windows-msvc under cand
+                foreach _probe : [
+                    _cand,
+                    join_paths(_cand, 'lib', 'x86_64-pc-windows-msvc'),
+                ]
                     foreach _frt : [
                         'flang_rt.runtime.dynamic.lib',
                         'FortranRuntime.dynamic.lib',
                         'flang_rt.dynamic.lib',
                     ]
-                        if fs.is_file(join_paths(_flang_rt_dir, _frt))
-                            _linkargs += [join_paths(_flang_rt_dir, _frt)]
+                        if fs.is_file(join_paths(_probe, _frt))
+                            _flang_rt_dir = _probe
+                            break
+                        endif
+                    endforeach
+                    if _flang_rt_dir != ''
+                        break
+                    endif
+                endforeach
+                # Walk clang version dirs one level if cand is .../lib/clang
+                if _flang_rt_dir == '' and fs.name(_cand) == 'clang'
+                    # Meson has no readdir; try common versions from recent flang.
+                    foreach _ver : ['21', '20', '19', '18', '17']
+                        _probe = join_paths(
+                            _cand,
+                            _ver,
+                            'lib',
+                            'x86_64-pc-windows-msvc',
+                        )
+                        foreach _frt : [
+                            'flang_rt.runtime.dynamic.lib',
+                            'FortranRuntime.dynamic.lib',
+                            'flang_rt.dynamic.lib',
+                        ]
+                            if fs.is_file(join_paths(_probe, _frt))
+                                _flang_rt_dir = _probe
+                                break
+                            endif
+                        endforeach
+                        if _flang_rt_dir != ''
                             break
                         endif
                     endforeach
                 endif
+            endforeach
+            if _flang_rt_dir != ''
+                _linkargs += ['/LIBPATH:' + _flang_rt_dir]
+                message('flang_rt LIBPATH: ' + _flang_rt_dir)
+                foreach _frt : [
+                    'flang_rt.runtime.dynamic.lib',
+                    'FortranRuntime.dynamic.lib',
+                    'flang_rt.dynamic.lib',
+                ]
+                    if fs.is_file(join_paths(_flang_rt_dir, _frt))
+                        _linkargs += [join_paths(_flang_rt_dir, _frt)]
+                        break
+                    endif
+                endforeach
+            else
+                warning(
+                    'flang_rt import lib dir not found; MSVC link may LNK1104',
+                )
             endif
         endif
     endif

--- a/client/meson.build
+++ b/client/meson.build
@@ -767,11 +767,12 @@ for name in ("metatensor", "metatensor_torch", "metatomic", "vesin"):
             # MSVC has no -isystem; /external:I is opt-in. Use -I style via include_directories.
             mts_inc_args += ['-I' + d]
         endforeach
-        # Windows wheels ship import libs as metatensor.lib and/or libmetatensor.lib
-        # (same as non-pip MSVC fallback below). Try both names in each lib dir.
-        _mts_lib_candidates = is_windows ? ['metatensor', 'libmetatensor'] : ['metatensor']
-        _mts_torch_candidates = is_windows ? ['metatensor_torch', 'libmetatensor_torch'] : ['metatensor_torch']
-        _mta_torch_candidates = is_windows ? ['metatomic_torch', 'libmetatomic_torch'] : ['metatomic_torch']
+        # Windows wheels: import libs may be foo.lib, libfoo.lib, or foo.dll.lib
+        # (metatensor-core win ships metatensor.dll.lib). Meson find_library('x')
+        # probes x.lib / libx.lib; pass 'x.dll' to hit x.dll.lib.
+        _mts_lib_candidates = is_windows ? ['metatensor', 'libmetatensor', 'metatensor.dll'] : ['metatensor']
+        _mts_torch_candidates = is_windows ? ['metatensor_torch', 'libmetatensor_torch', 'metatensor_torch.dll'] : ['metatensor_torch']
+        _mta_torch_candidates = is_windows ? ['metatomic_torch', 'libmetatomic_torch', 'metatomic_torch.dll'] : ['metatomic_torch']
         _mts_core_found = disabler()
         foreach _n : _mts_lib_candidates
             if not _mts_core_found.found()

--- a/client/meson.build
+++ b/client/meson.build
@@ -764,31 +764,71 @@ for name in ("metatensor", "metatensor_torch", "metatomic", "vesin"):
         endif
         mts_inc_args = []
         foreach d : [_mts_core_inc, _mts_torch_inc_new, _mts_torch_inc_old, _mta_inc]
-            mts_inc_args += ['-isystem', d]
+            # MSVC has no -isystem; /external:I is opt-in. Use -I style via include_directories.
+            mts_inc_args += ['-I' + d]
         endforeach
+        # Windows wheels ship import libs as metatensor.lib and/or libmetatensor.lib
+        # (same as non-pip MSVC fallback below). Try both names in each lib dir.
+        _mts_lib_candidates = is_windows ? ['metatensor', 'libmetatensor'] : ['metatensor']
+        _mts_torch_candidates = is_windows ? ['metatensor_torch', 'libmetatensor_torch'] : ['metatensor_torch']
+        _mta_torch_candidates = is_windows ? ['metatomic_torch', 'libmetatomic_torch'] : ['metatomic_torch']
+        _mts_core_found = disabler()
+        foreach _n : _mts_lib_candidates
+            if not _mts_core_found.found()
+                _mts_core_found = cppc.find_library(_n, dirs: [_mts_core_lib], required: false)
+            endif
+        endforeach
+        if not _mts_core_found.found()
+            error(
+                'pip_metatomic: C library metatensor not found under '
+                + _mts_core_lib
+                + ' (tried '
+                + ', '.join(_mts_lib_candidates)
+                + ')',
+            )
+        endif
+        _mts_torch_found = disabler()
+        foreach _n : _mts_torch_candidates
+            if not _mts_torch_found.found()
+                _mts_torch_found = cppc.find_library(
+                    _n,
+                    dirs: _mts_torch_lib_dirs,
+                    required: false,
+                )
+            endif
+        endforeach
+        if not _mts_torch_found.found()
+            error(
+                'pip_metatomic: C library metatensor_torch not found under '
+                + ' '.join(_mts_torch_lib_dirs),
+            )
+        endif
+        _mta_torch_found = disabler()
+        foreach _n : _mta_torch_candidates
+            if not _mta_torch_found.found()
+                _mta_torch_found = cppc.find_library(_n, dirs: [_mta_lib], required: false)
+            endif
+        endforeach
+        if not _mta_torch_found.found()
+            error(
+                'pip_metatomic: C library metatomic_torch not found under ' + _mta_lib,
+            )
+        endif
         mts_dep = declare_dependency(
-            dependencies: [
-                cppc.find_library('metatensor', dirs: [_mts_core_lib]),
-                cppc.find_library('metatensor_torch', dirs: _mts_torch_lib_dirs),
-                cppc.find_library('metatomic_torch', dirs: [_mta_lib]),
-            ],
+            dependencies: [_mts_core_found, _mts_torch_found, _mta_torch_found],
             compile_args: mts_inc_args,
         )
-        vesin_dep = cppc.find_library(
-            'vesin',
-            dirs: [_vesin_lib],
-            required: false,
-        )
+        _vesin_candidates = is_windows ? ['vesin', 'libvesin'] : ['vesin']
+        vesin_dep = disabler()
+        foreach _n : _vesin_candidates
+            if not vesin_dep.found()
+                vesin_dep = cppc.find_library(_n, dirs: [_vesin_lib], required: false)
+            endif
+        endforeach
         if vesin_dep.found()
             vesin_dep = declare_dependency(
-                dependencies: [
-                    cppc.find_library(
-                        'vesin',
-                        dirs: [_vesin_lib],
-                        required: false,
-                    ),
-                ],
-                compile_args: ['-isystem', _vesin_inc],
+                dependencies: [vesin_dep],
+                compile_args: ['-I' + _vesin_inc],
             )
         endif
     else

--- a/client/potentials/Aluminum/meson.build
+++ b/client/potentials/Aluminum/meson.build
@@ -1,5 +1,6 @@
 # Fortran-only shared module: loaded at runtime via dlopen/LoadLibrary
-eon_aluminum = shared_module('eon_aluminum',
+eon_aluminum = shared_module(
+    'eon_aluminum',
            'fofrhoDblexp.f',
            'dfrhoDblexp.f',
            'potinit.f',
@@ -7,14 +8,29 @@ eon_aluminum = shared_module('eon_aluminum',
            'gagafeDblexp.f',
            'embedenergy.f',
            'sumembforce.f',
-           fortran_args : _fargs,
-           link_args : _fortran_pot_link_args,
-           install : true)
+    fortran_args: _fargs,
+    link_args: _fortran_pot_link_args
+    + (
+        is_windows ? [
+            '/DEF:'
+            + join_paths(
+                meson.project_source_root(),
+                'client',
+                'potentials',
+                'win_exports',
+                'eon_aluminum.def',
+            ),
+        ] : []
+    ),
+    install: true,
+)
 
 # C++ wrapper (compiled into client, loads Fortran lib at runtime)
-aluminum_cpp = static_library('aluminum_cpp',
-           'Aluminum.cpp',
-           dependencies : _deps,
-           cpp_args : _args,
-           link_with : _linkto,
-           include_directories: _incdirs)
+aluminum_cpp = static_library(
+    'aluminum_cpp',
+    'Aluminum.cpp',
+    dependencies: _deps,
+    cpp_args: _args,
+    link_with: _linkto,
+    include_directories: _incdirs,
+)

--- a/client/potentials/Aluminum/meson.build
+++ b/client/potentials/Aluminum/meson.build
@@ -12,7 +12,7 @@ eon_aluminum = shared_module(
     link_args: _fortran_pot_link_args
     + (
         is_windows ? [
-            '/DEF:'
+            '-Wl,/DEF:'
             + join_paths(
                 meson.project_source_root(),
                 'client',

--- a/client/potentials/Aluminum/meson.build
+++ b/client/potentials/Aluminum/meson.build
@@ -8,6 +8,7 @@ eon_aluminum = shared_library('eon_aluminum',
            'embedenergy.f',
            'sumembforce.f',
            fortran_args : _fargs,
+           link_args : _fortran_pot_link_args,
            install : true)
 
 # C++ wrapper (compiled into client, loads Fortran lib at runtime)

--- a/client/potentials/Aluminum/meson.build
+++ b/client/potentials/Aluminum/meson.build
@@ -1,5 +1,5 @@
-# Fortran-only shared library: loaded at runtime via dlopen
-eon_aluminum = shared_library('eon_aluminum',
+# Fortran-only shared module: loaded at runtime via dlopen/LoadLibrary
+eon_aluminum = shared_module('eon_aluminum',
            'fofrhoDblexp.f',
            'dfrhoDblexp.f',
            'potinit.f',

--- a/client/potentials/EDIP/meson.build
+++ b/client/potentials/EDIP/meson.build
@@ -6,7 +6,7 @@ eon_edip = shared_module(
     link_args: _fortran_pot_link_args
     + (
         is_windows ? [
-            '/DEF:'
+            '-Wl,/DEF:'
             + join_paths(
                 meson.project_source_root(),
                 'client',

--- a/client/potentials/EDIP/meson.build
+++ b/client/potentials/EDIP/meson.build
@@ -1,14 +1,30 @@
 # Fortran-only shared module: loaded at runtime via dlopen/LoadLibrary
-eon_edip = shared_module('eon_edip',
+eon_edip = shared_module(
+    'eon_edip',
            'edipFortran.f90',
-           fortran_args : _fargs,
-           link_args : _fortran_pot_link_args,
-           install : true)
+    fortran_args: _fargs,
+    link_args: _fortran_pot_link_args
+    + (
+        is_windows ? [
+            '/DEF:'
+            + join_paths(
+                meson.project_source_root(),
+                'client',
+                'potentials',
+                'win_exports',
+                'eon_edip.def',
+            ),
+        ] : []
+    ),
+    install: true,
+)
 
 # C++ wrapper (compiled into client, loads Fortran lib at runtime)
-edip_cpp = static_library('edip_cpp',
-           'EDIP.cpp',
-           dependencies : _deps,
-           cpp_args : _args,
-           link_with : _linkto,
-           include_directories: _incdirs)
+edip_cpp = static_library(
+    'edip_cpp',
+    'EDIP.cpp',
+    dependencies: _deps,
+    cpp_args: _args,
+    link_with: _linkto,
+    include_directories: _incdirs,
+)

--- a/client/potentials/EDIP/meson.build
+++ b/client/potentials/EDIP/meson.build
@@ -1,5 +1,5 @@
-# Fortran-only shared library: loaded at runtime via dlopen
-eon_edip = shared_library('eon_edip',
+# Fortran-only shared module: loaded at runtime via dlopen/LoadLibrary
+eon_edip = shared_module('eon_edip',
            'edipFortran.f90',
            fortran_args : _fargs,
            link_args : _fortran_pot_link_args,

--- a/client/potentials/EDIP/meson.build
+++ b/client/potentials/EDIP/meson.build
@@ -2,6 +2,7 @@
 eon_edip = shared_library('eon_edip',
            'edipFortran.f90',
            fortran_args : _fargs,
+           link_args : _fortran_pot_link_args,
            install : true)
 
 # C++ wrapper (compiled into client, loads Fortran lib at runtime)

--- a/client/potentials/FeHe/meson.build
+++ b/client/potentials/FeHe/meson.build
@@ -1,14 +1,30 @@
 # Fortran-only shared module: loaded at runtime via dlopen/LoadLibrary
-eon_fehe = shared_module('eon_fehe',
+eon_fehe = shared_module(
+    'eon_fehe',
            'feforce.f',
-           fortran_args : _fargs,
-           link_args : _fortran_pot_link_args,
-           install : true)
+    fortran_args: _fargs,
+    link_args: _fortran_pot_link_args
+    + (
+        is_windows ? [
+            '/DEF:'
+            + join_paths(
+                meson.project_source_root(),
+                'client',
+                'potentials',
+                'win_exports',
+                'eon_fehe.def',
+            ),
+        ] : []
+    ),
+    install: true,
+)
 
 # C++ wrapper (compiled into client, loads Fortran lib at runtime)
-fehe_cpp = static_library('fehe_cpp',
-           'FeHe.cpp',
-           dependencies : _deps,
-           cpp_args : _args,
-           link_with : _linkto,
-           include_directories: _incdirs)
+fehe_cpp = static_library(
+    'fehe_cpp',
+    'FeHe.cpp',
+    dependencies: _deps,
+    cpp_args: _args,
+    link_with: _linkto,
+    include_directories: _incdirs,
+)

--- a/client/potentials/FeHe/meson.build
+++ b/client/potentials/FeHe/meson.build
@@ -6,7 +6,7 @@ eon_fehe = shared_module(
     link_args: _fortran_pot_link_args
     + (
         is_windows ? [
-            '/DEF:'
+            '-Wl,/DEF:'
             + join_paths(
                 meson.project_source_root(),
                 'client',

--- a/client/potentials/FeHe/meson.build
+++ b/client/potentials/FeHe/meson.build
@@ -2,6 +2,7 @@
 eon_fehe = shared_library('eon_fehe',
            'feforce.f',
            fortran_args : _fargs,
+           link_args : _fortran_pot_link_args,
            install : true)
 
 # C++ wrapper (compiled into client, loads Fortran lib at runtime)

--- a/client/potentials/FeHe/meson.build
+++ b/client/potentials/FeHe/meson.build
@@ -1,5 +1,5 @@
-# Fortran-only shared library: loaded at runtime via dlopen
-eon_fehe = shared_library('eon_fehe',
+# Fortran-only shared module: loaded at runtime via dlopen/LoadLibrary
+eon_fehe = shared_module('eon_fehe',
            'feforce.f',
            fortran_args : _fargs,
            link_args : _fortran_pot_link_args,

--- a/client/potentials/FortranPotLoader.cpp
+++ b/client/potentials/FortranPotLoader.cpp
@@ -150,7 +150,8 @@ dynlib::Handle FortranPotLoader::open_lib(const char *lib_base) {
     last_err = dynlib::error();
   }
 
-  // Stash diagnostics for throw_not_found (thread-local; open is mutex-guarded).
+  // Stash diagnostics for throw_not_found (thread-local; open is
+  // mutex-guarded).
   m_last_load_error = last_err;
   m_last_load_saw_file = any_file;
   m_handles[lib_base] = nullptr;
@@ -179,7 +180,8 @@ void FortranPotLoader::throw_not_found(const char *lib_base,
     oss << "A matching file was present but LoadLibrary/dlopen failed";
     if (!m_last_load_error.empty())
       oss << ": " << m_last_load_error;
-    oss << "\n(often a missing flang_rt / FortranRuntime dependency on PATH).\n";
+    oss << "\n(often a missing flang_rt / FortranRuntime dependency on "
+           "PATH).\n";
   } else if (!m_last_load_error.empty()) {
     oss << "Loader error: " << m_last_load_error << "\n";
   }

--- a/client/potentials/FortranPotLoader.cpp
+++ b/client/potentials/FortranPotLoader.cpp
@@ -121,6 +121,8 @@ dynlib::Handle FortranPotLoader::open_lib(const char *lib_base) {
 
   auto names = lib_names(lib_base);
   dynlib::Handle h{};
+  std::string last_err;
+  bool any_file = false;
 
   // Try each search path (config paths precede env-var paths in m_search_paths)
   for (const auto &dir : m_search_paths) {
@@ -131,6 +133,10 @@ dynlib::Handle FortranPotLoader::open_lib(const char *lib_base) {
         m_handles[lib_base] = h;
         return h;
       }
+      // Capture immediately after LoadLibrary/dlopen (GetLastError/dlerror).
+      last_err = dynlib::error();
+      if (std::filesystem::exists(full))
+        any_file = true;
     }
   }
 
@@ -141,8 +147,12 @@ dynlib::Handle FortranPotLoader::open_lib(const char *lib_base) {
       m_handles[lib_base] = h;
       return h;
     }
+    last_err = dynlib::error();
   }
 
+  // Stash diagnostics for throw_not_found (thread-local; open is mutex-guarded).
+  m_last_load_error = last_err;
+  m_last_load_saw_file = any_file;
   m_handles[lib_base] = nullptr;
   return nullptr;
 }
@@ -164,6 +174,14 @@ void FortranPotLoader::throw_not_found(const char *lib_base,
     for (const auto &p : m_search_paths) {
       oss << "  " << p << "\n";
     }
+  }
+  if (m_last_load_saw_file) {
+    oss << "A matching file was present but LoadLibrary/dlopen failed";
+    if (!m_last_load_error.empty())
+      oss << ": " << m_last_load_error;
+    oss << "\n(often a missing flang_rt / FortranRuntime dependency on PATH).\n";
+  } else if (!m_last_load_error.empty()) {
+    oss << "Loader error: " << m_last_load_error << "\n";
   }
   oss << "Set [Potential] potentials_path in config.ini, "
          "or set EON_POTENTIALS_PATH,\n"

--- a/client/potentials/FortranPotLoader.h
+++ b/client/potentials/FortranPotLoader.h
@@ -16,7 +16,7 @@
 /// Uses dlopen (POSIX) or LoadLibrary (Windows) to load Fortran potential
 /// libraries at runtime. The search order is:
 ///   1. Paths from the [Potential] potentials_path config key
-///   2. EON_POTENTIALS_PATH environment variable (colon-separated)
+///   2. EON_POTENTIALS_PATH environment variable (';' on Windows, ':' elsewhere)
 ///   3. Default system library search path (LD_LIBRARY_PATH, etc.)
 ///
 /// Call add_config_paths() once at startup (before any potential constructor)

--- a/client/potentials/FortranPotLoader.h
+++ b/client/potentials/FortranPotLoader.h
@@ -78,6 +78,9 @@ private:
   std::vector<std::string> m_search_paths;
   std::mutex m_mutex;
   std::unordered_map<std::string, dynlib::Handle> m_handles;
+  /// Last dynlib::error() from a failed open (for throw_not_found).
+  std::string m_last_load_error;
+  bool m_last_load_saw_file = false;
 };
 
 } // namespace eonc

--- a/client/potentials/FortranPotLoader.h
+++ b/client/potentials/FortranPotLoader.h
@@ -16,7 +16,8 @@
 /// Uses dlopen (POSIX) or LoadLibrary (Windows) to load Fortran potential
 /// libraries at runtime. The search order is:
 ///   1. Paths from the [Potential] potentials_path config key
-///   2. EON_POTENTIALS_PATH environment variable (';' on Windows, ':' elsewhere)
+///   2. EON_POTENTIALS_PATH environment variable (';' on Windows, ':'
+///   elsewhere)
 ///   3. Default system library search path (LD_LIBRARY_PATH, etc.)
 ///
 /// Call add_config_paths() once at startup (before any potential constructor)

--- a/client/potentials/Lenosky/meson.build
+++ b/client/potentials/Lenosky/meson.build
@@ -1,14 +1,30 @@
 # Fortran-only shared module: loaded at runtime via dlopen/LoadLibrary
-eon_lenosky = shared_module('eon_lenosky',
+eon_lenosky = shared_module(
+    'eon_lenosky',
            'lenoskyFortran.f90',
-           fortran_args : _fargs,
-           link_args : _fortran_pot_link_args,
-           install : true)
+    fortran_args: _fargs,
+    link_args: _fortran_pot_link_args
+    + (
+        is_windows ? [
+            '/DEF:'
+            + join_paths(
+                meson.project_source_root(),
+                'client',
+                'potentials',
+                'win_exports',
+                'eon_lenosky.def',
+            ),
+        ] : []
+    ),
+    install: true,
+)
 
 # C++ wrapper (compiled into client, loads Fortran lib at runtime)
-lenosky_cpp = static_library('lenosky_cpp',
-           'Lenosky.cpp',
-           dependencies : _deps,
-           cpp_args : _args,
-           link_with : _linkto,
-           include_directories: _incdirs)
+lenosky_cpp = static_library(
+    'lenosky_cpp',
+    'Lenosky.cpp',
+    dependencies: _deps,
+    cpp_args: _args,
+    link_with: _linkto,
+    include_directories: _incdirs,
+)

--- a/client/potentials/Lenosky/meson.build
+++ b/client/potentials/Lenosky/meson.build
@@ -2,6 +2,7 @@
 eon_lenosky = shared_library('eon_lenosky',
            'lenoskyFortran.f90',
            fortran_args : _fargs,
+           link_args : _fortran_pot_link_args,
            install : true)
 
 # C++ wrapper (compiled into client, loads Fortran lib at runtime)

--- a/client/potentials/Lenosky/meson.build
+++ b/client/potentials/Lenosky/meson.build
@@ -6,7 +6,7 @@ eon_lenosky = shared_module(
     link_args: _fortran_pot_link_args
     + (
         is_windows ? [
-            '/DEF:'
+            '-Wl,/DEF:'
             + join_paths(
                 meson.project_source_root(),
                 'client',

--- a/client/potentials/Lenosky/meson.build
+++ b/client/potentials/Lenosky/meson.build
@@ -1,5 +1,5 @@
-# Fortran-only shared library: loaded at runtime via dlopen
-eon_lenosky = shared_library('eon_lenosky',
+# Fortran-only shared module: loaded at runtime via dlopen/LoadLibrary
+eon_lenosky = shared_module('eon_lenosky',
            'lenoskyFortran.f90',
            fortran_args : _fargs,
            link_args : _fortran_pot_link_args,

--- a/client/potentials/SW/meson.build
+++ b/client/potentials/SW/meson.build
@@ -1,14 +1,30 @@
 # Fortran-only shared module: loaded at runtime via dlopen/LoadLibrary
-eon_sw = shared_module('eon_sw',
+eon_sw = shared_module(
+    'eon_sw',
            'SWFortran.f90',
-           fortran_args : _fargs,
-           link_args : _fortran_pot_link_args,
-           install : true)
+    fortran_args: _fargs,
+    link_args: _fortran_pot_link_args
+    + (
+        is_windows ? [
+            '/DEF:'
+            + join_paths(
+                meson.project_source_root(),
+                'client',
+                'potentials',
+                'win_exports',
+                'eon_sw.def',
+            ),
+        ] : []
+    ),
+    install: true,
+)
 
 # C++ wrapper (compiled into client, loads Fortran lib at runtime)
-sw_cpp = static_library('sw_cpp',
-           'SW.cpp',
-           dependencies : _deps,
-           cpp_args : _args,
-           link_with : _linkto,
-           include_directories: _incdirs)
+sw_cpp = static_library(
+    'sw_cpp',
+    'SW.cpp',
+    dependencies: _deps,
+    cpp_args: _args,
+    link_with: _linkto,
+    include_directories: _incdirs,
+)

--- a/client/potentials/SW/meson.build
+++ b/client/potentials/SW/meson.build
@@ -2,6 +2,7 @@
 eon_sw = shared_library('eon_sw',
            'SWFortran.f90',
            fortran_args : _fargs,
+           link_args : _fortran_pot_link_args,
            install : true)
 
 # C++ wrapper (compiled into client, loads Fortran lib at runtime)

--- a/client/potentials/SW/meson.build
+++ b/client/potentials/SW/meson.build
@@ -1,5 +1,5 @@
-# Fortran-only shared library: loaded at runtime via dlopen
-eon_sw = shared_library('eon_sw',
+# Fortran-only shared module: loaded at runtime via dlopen/LoadLibrary
+eon_sw = shared_module('eon_sw',
            'SWFortran.f90',
            fortran_args : _fargs,
            link_args : _fortran_pot_link_args,

--- a/client/potentials/SW/meson.build
+++ b/client/potentials/SW/meson.build
@@ -6,7 +6,7 @@ eon_sw = shared_module(
     link_args: _fortran_pot_link_args
     + (
         is_windows ? [
-            '/DEF:'
+            '-Wl,/DEF:'
             + join_paths(
                 meson.project_source_root(),
                 'client',

--- a/client/potentials/Tersoff/meson.build
+++ b/client/potentials/Tersoff/meson.build
@@ -2,6 +2,7 @@
 eon_tersoff = shared_library('eon_tersoff',
            'tersoffFortran.f90',
            fortran_args : _fargs,
+           link_args : _fortran_pot_link_args,
            install : true)
 
 # C++ wrapper (compiled into client, loads Fortran lib at runtime)

--- a/client/potentials/Tersoff/meson.build
+++ b/client/potentials/Tersoff/meson.build
@@ -6,7 +6,7 @@ eon_tersoff = shared_module(
     link_args: _fortran_pot_link_args
     + (
         is_windows ? [
-            '/DEF:'
+            '-Wl,/DEF:'
             + join_paths(
                 meson.project_source_root(),
                 'client',

--- a/client/potentials/Tersoff/meson.build
+++ b/client/potentials/Tersoff/meson.build
@@ -1,5 +1,5 @@
-# Fortran-only shared library: loaded at runtime via dlopen
-eon_tersoff = shared_library('eon_tersoff',
+# Fortran-only shared module: loaded at runtime via dlopen/LoadLibrary
+eon_tersoff = shared_module('eon_tersoff',
            'tersoffFortran.f90',
            fortran_args : _fargs,
            link_args : _fortran_pot_link_args,

--- a/client/potentials/Tersoff/meson.build
+++ b/client/potentials/Tersoff/meson.build
@@ -1,14 +1,30 @@
 # Fortran-only shared module: loaded at runtime via dlopen/LoadLibrary
-eon_tersoff = shared_module('eon_tersoff',
+eon_tersoff = shared_module(
+    'eon_tersoff',
            'tersoffFortran.f90',
-           fortran_args : _fargs,
-           link_args : _fortran_pot_link_args,
-           install : true)
+    fortran_args: _fargs,
+    link_args: _fortran_pot_link_args
+    + (
+        is_windows ? [
+            '/DEF:'
+            + join_paths(
+                meson.project_source_root(),
+                'client',
+                'potentials',
+                'win_exports',
+                'eon_tersoff.def',
+            ),
+        ] : []
+    ),
+    install: true,
+)
 
 # C++ wrapper (compiled into client, loads Fortran lib at runtime)
-tersoff_cpp = static_library('tersoff_cpp',
-           'Tersoff.cpp',
-           dependencies : _deps,
-           cpp_args : _args,
-           link_with : _linkto,
-           include_directories: _incdirs)
+tersoff_cpp = static_library(
+    'tersoff_cpp',
+    'Tersoff.cpp',
+    dependencies: _deps,
+    cpp_args: _args,
+    link_with: _linkto,
+    include_directories: _incdirs,
+)

--- a/client/potentials/win_exports/eon_aluminum.def
+++ b/client/potentials/win_exports/eon_aluminum.def
@@ -1,0 +1,3 @@
+EXPORTS
+    force_
+    potinit_

--- a/client/potentials/win_exports/eon_edip.def
+++ b/client/potentials/win_exports/eon_edip.def
@@ -1,0 +1,2 @@
+EXPORTS
+    edip_

--- a/client/potentials/win_exports/eon_fehe.def
+++ b/client/potentials/win_exports/eon_fehe.def
@@ -1,0 +1,2 @@
+EXPORTS
+    feforce_

--- a/client/potentials/win_exports/eon_lenosky.def
+++ b/client/potentials/win_exports/eon_lenosky.def
@@ -1,0 +1,2 @@
+EXPORTS
+    lenosky_

--- a/client/potentials/win_exports/eon_sw.def
+++ b/client/potentials/win_exports/eon_sw.def
@@ -1,0 +1,2 @@
+EXPORTS
+    sw_

--- a/client/potentials/win_exports/eon_tersoff.def
+++ b/client/potentials/win_exports/eon_tersoff.def
@@ -1,0 +1,2 @@
+EXPORTS
+    tersoff_

--- a/client/python/pyeonclient/__init__.py
+++ b/client/python/pyeonclient/__init__.py
@@ -167,6 +167,18 @@ from pyeonclient.steps import (  # noqa: E402
     rgpot_metatomic_neb_workdir,
 )
 
+# Optional gpr_optim overlay (GP-OIE / OCINEB via gpr_optim.session)
+try:
+    from pyeonclient.gpr_overlay import (  # type: ignore F401
+        compute_gpneb_from_matters,
+        gpr_optim_available,
+        gpneb_session_from_matters,
+    )
+except ImportError:  # pragma: no cover
+    gpr_optim_available = lambda: False  # type: ignore[misc, assignment]
+    gpneb_session_from_matters = None  # type: ignore[misc, assignment]
+    compute_gpneb_from_matters = None  # type: ignore[misc, assignment]
+
 to_ase = matter_to_ase
 from_ase = ase_to_matter
 
@@ -273,5 +285,8 @@ __all__ = [
     "to_structure",
     "matter_to_structure",
     "structure_to_matter",
+    "gpr_optim_available",
+    "gpneb_session_from_matters",
+    "compute_gpneb_from_matters",
     "__version__",
 ]

--- a/client/python/pyeonclient/gpr_overlay.py
+++ b/client/python/pyeonclient/gpr_overlay.py
@@ -1,0 +1,107 @@
+"""Optional gpr_optim overlay for pyeonclient Matter workflows.
+
+Requires the ``gpr_optim`` package (nanobind step surface + GPNEBSession).
+Does not change the default ``NEB(accelerant="gp")`` path (eOn GPSurrogateJob);
+call this explicitly when you want gpr_optim's production GP-OIE / OCINEB stack.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+
+def gpr_optim_available() -> bool:
+    try:
+        import gpr_optim  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def gpneb_session_from_matters(
+    initial: Any,
+    final: Any,
+    n_intermediate: int = 8,
+    *,
+    calculator: Any,
+    gp: Any = None,
+    path_method: str = "idpp",
+    **session_kwargs: Any,
+) -> Any:
+    """Build a :class:`gpr_optim.session.GPNEBSession` from Matter endpoints.
+
+    Parameters
+    ----------
+    initial, final
+        pyeonclient.Matter (or duck-types with positions / atomic_numbers).
+    n_intermediate
+        Interior image count.
+    calculator
+        ASE Calculator used as the oracle (e.g. MetatomicCalculator).
+    gp
+        Optional pre-built ``gpr_optim.GaussianProcess``. Default: production-ish
+        Laplace-slice chain without forcing board pins.
+    path_method
+        C++ path init name (idpp / linear / sidpp / ...).
+    **session_kwargs
+        Forwarded to GPNEBSession (acquisition, use_mmf, climb, ...).
+    """
+    if not gpr_optim_available():
+        raise ImportError(
+            "gpneb_session_from_matters requires gpr_optim "
+            "(pip/pixi install the gpr_optim package)"
+        )
+    from gpr_optim import GaussianProcess
+    from gpr_optim.session import GPNEBSession
+
+    if gp is None:
+        gp = GaussianProcess(
+            uncertainty="laplace",
+            psis=True,
+            psis_deterministic=True,
+            use_delta=True,
+        )
+    return GPNEBSession.from_matters(
+        initial,
+        final,
+        n_intermediate,
+        oracle=calculator,
+        gp=gp,
+        path_method=path_method,
+        calculator=calculator,
+        **session_kwargs,
+    )
+
+
+def compute_gpneb_from_matters(
+    initial: Any,
+    final: Any,
+    n_intermediate: int = 8,
+    *,
+    calculator: Any,
+    fmax: float = 0.05,
+    steps: int = 500,
+    gp: Any = None,
+    path_method: str = "idpp",
+    **session_kwargs: Any,
+) -> Any:
+    """Full prepare+compute from Matter endpoints; returns GPNEBSession."""
+    sess = gpneb_session_from_matters(
+        initial,
+        final,
+        n_intermediate,
+        calculator=calculator,
+        gp=gp,
+        path_method=path_method,
+        **session_kwargs,
+    )
+    sess.compute(fmax=fmax, steps=steps)
+    return sess
+
+
+__all__ = [
+    "gpr_optim_available",
+    "gpneb_session_from_matters",
+    "compute_gpneb_from_matters",
+]

--- a/client/unit_tests/ApproveConFileIO.cpp
+++ b/client/unit_tests/ApproveConFileIO.cpp
@@ -123,9 +123,12 @@ TEST_CASE("VerifyForceBearingWrite", "[approval][confileio][modern]") {
   REQUIRE(eonc::io::io_ok(m->matter2con(tmp.string(), false)));
   eonc::io::set_write_con_forces(false);
 
-  std::ifstream in(tmp);
-  std::string body((std::istreambuf_iterator<char>(in)),
-                   std::istreambuf_iterator<char>());
+  std::string body;
+  {
+    std::ifstream in(tmp);
+    body.assign((std::istreambuf_iterator<char>(in)),
+                std::istreambuf_iterator<char>());
+  }
 
   Parameters params;
   params.potential_options.potential = PotType::LJ;
@@ -159,9 +162,12 @@ TEST_CASE("VerifyDefaultWriteHasNoForceSections",
   const auto tmp = make_tmp_con("default_no_forces");
   REQUIRE(eonc::io::io_ok(m->matter2con(tmp.string(), false)));
 
-  std::ifstream in(tmp);
-  std::string body((std::istreambuf_iterator<char>(in)),
-                   std::istreambuf_iterator<char>());
+  std::string body;
+  {
+    std::ifstream in(tmp);
+    body.assign((std::istreambuf_iterator<char>(in)),
+                std::istreambuf_iterator<char>());
+  }
 
   // Classic layout: no per-component force sections and no forces entry in
   // the metadata sections list, so ASE-class readers keep parsing our output.
@@ -193,9 +199,12 @@ TEST_CASE("VerifyNebPathCloneWrite", "[approval][confileio][neb]") {
   const auto tmp = make_tmp_con("neb_band");
   REQUIRE(eonc::io::io_ok(eonc::io::writeNebPath(tmp.string(), path, metas)));
 
-  std::ifstream in(tmp);
-  std::string body((std::istreambuf_iterator<char>(in)),
-                   std::istreambuf_iterator<char>());
+  std::string body;
+  {
+    std::ifstream in(tmp);
+    body.assign((std::istreambuf_iterator<char>(in)),
+                std::istreambuf_iterator<char>());
+  }
   fs::remove(tmp);
 
   std::ostringstream summary;

--- a/client/unit_tests/ConFileIOTest.cpp
+++ b/client/unit_tests/ConFileIOTest.cpp
@@ -118,9 +118,12 @@ TEST_CASE_METHOD(
   REQUIRE(eonc::io::io_ok(movie->matter2con(tmpfile, false, &first)));
   REQUIRE(eonc::io::io_ok(movie->matter2con(tmpfile, true, &second)));
 
-  std::ifstream file(tmpfile);
-  std::string file_contents((std::istreambuf_iterator<char>(file)),
-                            std::istreambuf_iterator<char>());
+  std::string file_contents;
+  {
+    std::ifstream file(tmpfile);
+    file_contents.assign((std::istreambuf_iterator<char>(file)),
+                         std::istreambuf_iterator<char>());
+  }
   REQUIRE_FALSE(file_contents.empty());
   REQUIRE(file_contents.front() != '\n');
   REQUIRE(file_contents.find("\"frame_index\":0") != std::string::npos);
@@ -176,10 +179,12 @@ TEST_CASE_METHOD(ConFileIOFixture, "XYZ output is finite and non-empty",
   REQUIRE(size > 0);
 
   // Read first line -- should be atom count
-  std::ifstream f(tmpfile);
-  int natoms;
-  f >> natoms;
-  REQUIRE(natoms == original->numberOfAtoms());
+  {
+    std::ifstream f(tmpfile);
+    int natoms;
+    f >> natoms;
+    REQUIRE(natoms == original->numberOfAtoms());
+  }
 
   std::remove(tmpfile.c_str());
 }
@@ -282,9 +287,12 @@ TEST_CASE("ConFileIO embeds movie metadata in frame JSON",
   std::string tmpfile = tmppath.string();
   m->matter2con(tmpfile, false, &metadata);
 
-  std::ifstream in(tmpfile);
-  std::string file_contents((std::istreambuf_iterator<char>(in)),
-                            std::istreambuf_iterator<char>());
+  std::string file_contents;
+  {
+    std::ifstream in(tmpfile);
+    file_contents.assign((std::istreambuf_iterator<char>(in)),
+                         std::istreambuf_iterator<char>());
+  }
   REQUIRE(file_contents.find("\"frame_index\":7") != std::string::npos);
   REQUIRE(file_contents.find("\"energy\":-12.5") != std::string::npos);
   REQUIRE(file_contents.find("\"step_size\":0.125") != std::string::npos);
@@ -324,9 +332,12 @@ TEST_CASE("ConFileIO preserves metadata across append-mode movie frames",
   second.scalars.push_back({"step_size", 0.25});
   REQUIRE(eonc::io::io_ok(m->matter2con(tmpfile, true, &second)));
 
-  std::ifstream in(tmpfile);
-  std::string file_contents((std::istreambuf_iterator<char>(in)),
-                            std::istreambuf_iterator<char>());
+  std::string file_contents;
+  {
+    std::ifstream in(tmpfile);
+    file_contents.assign((std::istreambuf_iterator<char>(in)),
+                         std::istreambuf_iterator<char>());
+  }
   REQUIRE(file_contents.find("\"frame_index\":0") != std::string::npos);
   REQUIRE(file_contents.find("\"frame_index\":1") != std::string::npos);
   REQUIRE(file_contents.find("\"step_size\":0.25") != std::string::npos);
@@ -359,15 +370,21 @@ TEST_CASE("ConFileIO append mode rejects corrupt existing files",
     out << "not a valid con file\n";
   }
 
-  std::ifstream before_in(tmpfile);
-  std::string before((std::istreambuf_iterator<char>(before_in)),
-                     std::istreambuf_iterator<char>());
+  std::string before;
+  {
+    std::ifstream before_in(tmpfile);
+    before.assign((std::istreambuf_iterator<char>(before_in)),
+                  std::istreambuf_iterator<char>());
+  }
 
   REQUIRE_FALSE(eonc::io::io_ok(m->matter2con(tmpfile, true)));
 
-  std::ifstream after_in(tmpfile);
-  std::string after((std::istreambuf_iterator<char>(after_in)),
-                    std::istreambuf_iterator<char>());
+  std::string after;
+  {
+    std::ifstream after_in(tmpfile);
+    after.assign((std::istreambuf_iterator<char>(after_in)),
+                 std::istreambuf_iterator<char>());
+  }
   REQUIRE(after == before);
 
   std::filesystem::remove(tmpfile);
@@ -433,9 +450,12 @@ TEST_CASE("NEB path writer embeds structured frame metadata",
   REQUIRE(eonc::io::io_ok(eonc::neb::writePathCon(
       path, tangent, eigenmode_solvers, 1, false, tmpfile, 12)));
 
-  std::ifstream in(tmpfile);
-  std::string file_contents((std::istreambuf_iterator<char>(in)),
-                            std::istreambuf_iterator<char>());
+  std::string file_contents;
+  {
+    std::ifstream in(tmpfile);
+    file_contents.assign((std::istreambuf_iterator<char>(in)),
+                         std::istreambuf_iterator<char>());
+  }
   REQUIRE(file_contents.find("\"neb_band\":12") != std::string::npos);
   REQUIRE(file_contents.find("\"neb_bead\":1") != std::string::npos);
   REQUIRE(file_contents.find("\"reaction_coordinate\"") != std::string::npos);

--- a/client/unit_tests/MetatomicEngineAbiTest.cpp
+++ b/client/unit_tests/MetatomicEngineAbiTest.cpp
@@ -1,5 +1,5 @@
-#include "catch2/catch_amalgamated.hpp"
 #include "DynLib.h"
+#include "catch2/catch_amalgamated.hpp"
 
 #include <cstdlib>
 #include <string>

--- a/client/unit_tests/SiPotTest.cpp
+++ b/client/unit_tests/SiPotTest.cpp
@@ -154,8 +154,7 @@ TEST_CASE("SW minimization energy matches SVN", "[pot][sw][si][minimization]") {
   }
 }
 
-TEST_CASE("SW CG minimization matches SVN",
-          "[pot][sw][si][minimization][cg]") {
+TEST_CASE("SW CG minimization matches SVN", "[pot][sw][si][minimization][cg]") {
   SIPOT_REQUIRE_POS_CON();
   Parameters params;
   params.potential_options.potential = PotType::SW_SI;

--- a/docs/newsfragments/377.dev.md
+++ b/docs/newsfragments/377.dev.md
@@ -1,0 +1,4 @@
+Windows CI builds and tests metatomic (and Catch2 on the basic matrix) on
+windows-2022 so MSVC-only unit-test failures surface in GHA instead of only on
+conda-forge. MetatomicEngineAbiTest loads the engine via DynLib on all
+platforms.

--- a/docs/newsfragments/377.dev.md
+++ b/docs/newsfragments/377.dev.md
@@ -1,4 +1,4 @@
-Windows CI builds and tests metatomic (and Catch2 on the basic matrix) on
-windows-2022 so MSVC-only unit-test failures surface in GHA instead of only on
-conda-forge. MetatomicEngineAbiTest loads the engine via DynLib on all
-platforms.
+Windows metatomic CI follows the metatomic/metatensor torch workflow:
+windows-2022, setup-python, pip CPU torch (PIP_EXTRA_INDEX_URL), and MSVC,
+with pixi only for C++ deps. MetatomicEngineAbiTest uses DynLib on all
+platforms; Catch2 runs on the basic multi-OS matrix including windows-2022.

--- a/docs/newsfragments/377.dev.md
+++ b/docs/newsfragments/377.dev.md
@@ -1,4 +1,7 @@
 Windows metatomic CI follows the metatomic/metatensor torch workflow:
 windows-2022, setup-python, pip CPU torch (PIP_EXTRA_INDEX_URL), and MSVC,
-with pixi only for C++ deps. MetatomicEngineAbiTest uses DynLib on all
-platforms; Catch2 runs on the basic multi-OS matrix including windows-2022.
+with pixi for C++ deps and flang. In-tree Fortran pots and CuH2 stay enabled
+via feedstock-style flang_rt LIBPATH and MSVC AR=lib. Catch2 runs on the basic
+multi-OS matrix including windows-2022; ConFileIO tests close temp streams
+before remove (Windows file locks); inih example tests strip CR for MSVC
+text-mode stdout.

--- a/docs/newsfragments/378.added.md
+++ b/docs/newsfragments/378.added.md
@@ -1,0 +1,1 @@
+Continuous ASV dashboard: results history on the `asv-results` orphan branch, asv-tachyon UI under `gh-pages/bench/`, optional Netlify deploy for bench.eondocs.org.

--- a/docs/newsfragments/378.added.md
+++ b/docs/newsfragments/378.added.md
@@ -1,1 +1,2 @@
 Continuous ASV dashboard: results history on the `asv-results` orphan branch, asv-tachyon UI under `gh-pages/bench/`, optional Netlify deploy for bench.eondocs.org.
+Windows CI: robust MSVC activation (VS 18 runners) and strip GNU link.exe from PATH for meson test.

--- a/meson.build
+++ b/meson.build
@@ -56,7 +56,22 @@ endif
 # ("Unusable script"), and find_installation fails the pip_metatomic modules.
 # Prefer python.exe so ExternalProgram treats it as a real Windows binary.
 _py_cmd = host_system == 'windows' ? 'python.exe' : 'python3'
-py = import('python').find_installation(_py_cmd, pure: false, modules: py_modules)
+# find_installation(..., modules:) only reports "missing modules" with no stderr.
+# On Windows pip torch/metatensor, imports often fail with DLL load errors; check
+# each module via run_command so the real ImportError surfaces in the log.
+py = import('python').find_installation(_py_cmd, pure: false)
+foreach _mod : py_modules
+    _r = run_command(py, '-c', 'import ' + _mod, check: false)
+    if _r.returncode() != 0
+        error(
+            'Python module "' + _mod + '" is not importable with '
+            + py.full_path()
+            + ':\n'
+            + _r.stderr()
+            + _r.stdout(),
+        )
+    endif
+endforeach
 if py_embed
     python_dep = py.dependency(embed: py_embed)
     _deps += python_dep

--- a/meson.build
+++ b/meson.build
@@ -51,7 +51,12 @@ if get_option('pip_metatomic')
     # We don't need the runtime, so we don't change py_embed
 endif
 
-py = import('python').find_installation(pure: false, modules: py_modules)
+# On Windows, conda/pixi often put a PE binary at `python` (no .exe). Meson then
+# tries to read it as a shebang script, hits UnicodeDecodeError on the MZ header
+# ("Unusable script"), and find_installation fails the pip_metatomic modules.
+# Prefer python.exe so ExternalProgram treats it as a real Windows binary.
+_py_cmd = host_system == 'windows' ? 'python.exe' : 'python3'
+py = import('python').find_installation(_py_cmd, pure: false, modules: py_modules)
 if py_embed
     python_dep = py.dependency(embed: py_embed)
     _deps += python_dep

--- a/meson.build
+++ b/meson.build
@@ -57,21 +57,41 @@ endif
 # Prefer python.exe so ExternalProgram treats it as a real Windows binary.
 _py_cmd = host_system == 'windows' ? 'python.exe' : 'python3'
 # find_installation(..., modules:) only reports "missing modules" with no stderr.
-# On Windows pip torch/metatensor, imports often fail with DLL load errors; check
-# each module via run_command so the real ImportError surfaces in the log.
+# On Windows pip torch, imports need DLL directories registered; use the helper
+# for a single stack check. Elsewhere check each module so ImportError is logged.
 py = import('python').find_installation(_py_cmd, pure: false)
-foreach _mod : py_modules
-    _r = run_command(py, '-c', 'import ' + _mod, check: false)
-    if _r.returncode() != 0
-        error(
-            'Python module "' + _mod + '" is not importable with '
-            + py.full_path()
-            + ':\n'
-            + _r.stderr()
-            + _r.stdout(),
+if py_modules.length() > 0
+    if host_system == 'windows' and get_option('pip_metatomic')
+        _r = run_command(
+            py,
+            meson.project_source_root() / 'tools' / 'win_pip_torch_path.py',
+            '--import-check',
+            check: false,
         )
+        if _r.returncode() != 0
+            error(
+                'pip_metatomic Python stack not importable with '
+                + py.full_path()
+                + ':\n'
+                + _r.stderr()
+                + _r.stdout(),
+            )
+        endif
+    else
+        foreach _mod : py_modules
+            _r = run_command(py, '-c', 'import ' + _mod, check: false)
+            if _r.returncode() != 0
+                error(
+                    'Python module "' + _mod + '" is not importable with '
+                    + py.full_path()
+                    + ':\n'
+                    + _r.stderr()
+                    + _r.stdout(),
+                )
+            endif
+        endforeach
     endif
-endforeach
+endif
 if py_embed
     python_dep = py.dependency(embed: py_embed)
     _deps += python_dep

--- a/scripts/asv_run_history.sh
+++ b/scripts/asv_run_history.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Run ASV for the last N commits against an existing env (eonclient already on PATH).
+set -euo pipefail
+N="${1:-5}"
+EXTRA="${2:-}"
+PY="$(which python)"
+echo "python=$PY"
+echo "eonclient=$(command -v eonclient || true)"
+mapfile -t SHAS < <(git rev-list --max-count="$N" HEAD)
+# oldest first
+for ((i=${#SHAS[@]}-1; i>=0; i--)); do
+  sha="${SHAS[i]}"
+  echo "=== asv run $EXTRA --set-commit-hash $sha ==="
+  # shellcheck disable=SC2086
+  asv run -E "existing:${PY}" --set-commit-hash "${sha}" --record-samples ${EXTRA}
+done

--- a/scripts/ci/activate_msvc_gha.ps1
+++ b/scripts/ci/activate_msvc_gha.ps1
@@ -1,5 +1,5 @@
-# Activate MSVC for GitHub Actions without clobbering the pixi/conda env.
-# Clears conda-forge vs* leftovers that break VsDevCmd when vswhere selects VS 18.
+# Activate MSVC include/lib for meson without putting MSVC bin first on PATH
+# (MSVC bin first breaks torch DLL load: WinError 127 on shm.dll).
 
 $kill = @(
   'VSINSTALLDIR','VS_VERSION','VS_MAJOR','VS_YEAR','VCVARSBAT',
@@ -12,28 +12,17 @@ $kill = @(
   'WindowsSDKVersion','ExtensionSdkDir','VCToolsRedistDir','FrameworkDir',
   'FrameworkDir64','FrameworkVersion','FrameworkVersion64','Framework40Version'
 )
-foreach ($v in $kill) {
-  Remove-Item "Env:$v" -ErrorAction SilentlyContinue
-}
+foreach ($v in $kill) { Remove-Item "Env:$v" -ErrorAction SilentlyContinue }
 
 $vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
-if (-not (Test-Path $vswhere)) { throw "vswhere not found at $vswhere" }
-
+if (-not (Test-Path $vswhere)) { throw "vswhere not found" }
 $installPath = & $vswhere -latest -products * `
   -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
   -property installationPath
-if (-not $installPath) { throw "vswhere: no VC tools installation" }
-
+if (-not $installPath) { throw "vswhere: no VC tools" }
 $vcvars = Join-Path $installPath "VC\Auxiliary\Build\vcvars64.bat"
-if (-not (Test-Path $vcvars)) { throw "vcvars64.bat missing: $vcvars" }
-
+if (-not (Test-Path $vcvars)) { throw "missing $vcvars" }
 Write-Host "Using $vcvars"
-
-# Snapshot env before/after vcvars; only push MSVC-related deltas + PATH/INCLUDE/LIB*
-$before = @{}
-cmd.exe /c set | ForEach-Object {
-  if ($_ -match '^([^=]+)=(.*)$') { $before[$Matches[1]] = $Matches[2] }
-}
 
 $afterLines = cmd.exe /c "`"$vcvars`" >nul 2>&1 && set"
 $after = @{}
@@ -41,40 +30,36 @@ foreach ($line in $afterLines) {
   if ($line -match '^([^=]+)=(.*)$') { $after[$Matches[1]] = $Matches[2] }
 }
 
-# Always take these from vcvars (required for cl/link)
-$must = @('PATH','INCLUDE','LIB','LIBPATH','VCINSTALLDIR','VCToolsInstallDir',
-  'VCToolsVersion','WindowsSdkDir','WindowsSDKVersion','WindowsSdkVerBinPath',
-  'UniversalCRTSdkDir','UCRTVersion','WindowsLibPath','WindowsSdkLibPath',
-  'VSINSTALLDIR','VSCMD_VER','VSCMD_ARG_TGT_ARCH','VSCMD_ARG_HOST_ARCH',
-  'FrameworkDir','FrameworkDir64','FrameworkVersion','FrameworkVersion64',
-  'DevEnvDir','ExtensionSdkDir','VCToolsRedistDir','WindowsSdkBinPath',
-  'WindowsSdkDir','IFCPATH','NETFXSDKDir','ExternalCompilerOptions')
-
-foreach ($name in $must) {
+# Include/lib and VC locations only — NOT PATH (torch needs conda DLL order)
+$exportNames = @(
+  'INCLUDE','LIB','LIBPATH','VCINSTALLDIR','VCToolsInstallDir','VCToolsVersion',
+  'WindowsSdkDir','WindowsSDKVersion','WindowsSdkVerBinPath','UniversalCRTSdkDir',
+  'UCRTVersion','WindowsLibPath','WindowsSdkLibPath','VSINSTALLDIR','VSCMD_VER',
+  'VSCMD_ARG_TGT_ARCH','VSCMD_ARG_HOST_ARCH','FrameworkDir','FrameworkDir64',
+  'FrameworkVersion','FrameworkVersion64','DevEnvDir','ExtensionSdkDir',
+  'VCToolsRedistDir','WindowsSdkBinPath','NETFXSDKDir','WindowsSDK_ExecutablePath_x64',
+  'WindowsSDK_ExecutablePath_x86','WindowsSDKLibVersion','VCIDEInstallDir',
+  'VSCMD_ARG_app_plat','IFCPATH','ExternalCompilerOptions'
+)
+foreach ($name in $exportNames) {
   if ($after.ContainsKey($name)) {
-    $value = $after[$name]
-    Add-Content -Path $env:GITHUB_ENV -Value "$name=$value"
-    Set-Item -Path "Env:$name" -Value $value
+    Add-Content -Path $env:GITHUB_ENV -Value "$name=$($after[$name])"
   }
 }
 
-# Also export any VSCMD_* / VC* / WindowsSDK* newly set by vcvars
-foreach ($name in $after.Keys) {
-  if ($name -match '^(VSCMD_|VC|WindowsSDK|WindowsSdk|UniversalCRT|Framework|DevEnv|IFC|NETFX)') {
-    if (-not ($must -contains $name)) {
-      $value = $after[$name]
-      Add-Content -Path $env:GITHUB_ENV -Value "$name=$value"
-      Set-Item -Path "Env:$name" -Value $value
-    }
+# Absolute tool paths for later steps (no PATH mutation in GITHUB_ENV)
+$cl = $null
+$link = $null
+if ($after.ContainsKey('PATH')) {
+  foreach ($dir in $after['PATH'].Split(';')) {
+    if (-not $cl -and (Test-Path (Join-Path $dir 'cl.exe'))) { $cl = Join-Path $dir 'cl.exe' }
+    if (-not $link -and (Test-Path (Join-Path $dir 'link.exe'))) { $link = Join-Path $dir 'link.exe' }
   }
 }
-
-$cl = Get-Command cl.exe -ErrorAction SilentlyContinue
-$link = Get-Command link.exe -ErrorAction SilentlyContinue
-if (-not $cl) { throw "cl.exe not on PATH after vcvars64" }
-if (-not $link) { throw "link.exe not on PATH after vcvars64" }
-Write-Host "cl: $($cl.Source)"
-Write-Host "link: $($link.Source)"
-if ($link.Source -match 'Git|usr\\bin|mingw') {
-  throw "link.exe is still GNU/Git, not MSVC: $($link.Source)"
-}
+if (-not $cl) { throw "cl.exe not found after vcvars" }
+if (-not $link) { throw "link.exe not found after vcvars" }
+Add-Content -Path $env:GITHUB_ENV -Value "EON_MSVC_CL=$cl"
+Add-Content -Path $env:GITHUB_ENV -Value "EON_MSVC_LINK=$link"
+Add-Content -Path $env:GITHUB_ENV -Value "EON_MSVC_BIN=$(Split-Path $cl -Parent)"
+Write-Host "EON_MSVC_CL=$cl"
+Write-Host "EON_MSVC_LINK=$link"

--- a/scripts/ci/activate_msvc_gha.ps1
+++ b/scripts/ci/activate_msvc_gha.ps1
@@ -1,5 +1,6 @@
-# Clear conda-forge vs* leftovers that break VsDevCmd when the runner has VS 18+
-# and vswhere selects a different install than conda's VSINSTALLDIR.
+# Activate MSVC for GitHub Actions without clobbering the pixi/conda env.
+# Clears conda-forge vs* leftovers that break VsDevCmd when vswhere selects VS 18.
+
 $kill = @(
   'VSINSTALLDIR','VS_VERSION','VS_MAJOR','VS_YEAR','VCVARSBAT',
   'NEWER_VS_WITH_OLDER_VC','WindowsSdkDir','WindowsSDKVer','MSSdk',
@@ -8,7 +9,8 @@ $kill = @(
   'CMAKE_GEN','CMAKE_PLAT','USE_NEW_CMAKE_GEN_SYNTAX','VSCMD_VER',
   'VSCMD_ARG_TGT_ARCH','VSCMD_ARG_HOST_ARCH','UniversalCRTSdkDir',
   'UCRTVersion','WindowsLibPath','WindowsSdkLibPath','WindowsSdkVerBinPath',
-  'WindowsSDKVersion','ExtensionSdkDir','VCToolsRedistDir'
+  'WindowsSDKVersion','ExtensionSdkDir','VCToolsRedistDir','FrameworkDir',
+  'FrameworkDir64','FrameworkVersion','FrameworkVersion64','Framework40Version'
 )
 foreach ($v in $kill) {
   Remove-Item "Env:$v" -ErrorAction SilentlyContinue
@@ -26,14 +28,41 @@ $vcvars = Join-Path $installPath "VC\Auxiliary\Build\vcvars64.bat"
 if (-not (Test-Path $vcvars)) { throw "vcvars64.bat missing: $vcvars" }
 
 Write-Host "Using $vcvars"
-# Capture environment after vcvars64
-$cmdOut = cmd.exe /c "`"$vcvars`" >nul 2>&1 && set"
-foreach ($line in $cmdOut) {
-  if ($line -match '^([^=]+)=(.*)$') {
-    $name = $Matches[1]
-    $value = $Matches[2]
-    # Skip empty names; append to GITHUB_ENV for subsequent steps
-    if ($name) {
+
+# Snapshot env before/after vcvars; only push MSVC-related deltas + PATH/INCLUDE/LIB*
+$before = @{}
+cmd.exe /c set | ForEach-Object {
+  if ($_ -match '^([^=]+)=(.*)$') { $before[$Matches[1]] = $Matches[2] }
+}
+
+$afterLines = cmd.exe /c "`"$vcvars`" >nul 2>&1 && set"
+$after = @{}
+foreach ($line in $afterLines) {
+  if ($line -match '^([^=]+)=(.*)$') { $after[$Matches[1]] = $Matches[2] }
+}
+
+# Always take these from vcvars (required for cl/link)
+$must = @('PATH','INCLUDE','LIB','LIBPATH','VCINSTALLDIR','VCToolsInstallDir',
+  'VCToolsVersion','WindowsSdkDir','WindowsSDKVersion','WindowsSdkVerBinPath',
+  'UniversalCRTSdkDir','UCRTVersion','WindowsLibPath','WindowsSdkLibPath',
+  'VSINSTALLDIR','VSCMD_VER','VSCMD_ARG_TGT_ARCH','VSCMD_ARG_HOST_ARCH',
+  'FrameworkDir','FrameworkDir64','FrameworkVersion','FrameworkVersion64',
+  'DevEnvDir','ExtensionSdkDir','VCToolsRedistDir','WindowsSdkBinPath',
+  'WindowsSdkDir','IFCPATH','NETFXSDKDir','ExternalCompilerOptions')
+
+foreach ($name in $must) {
+  if ($after.ContainsKey($name)) {
+    $value = $after[$name]
+    Add-Content -Path $env:GITHUB_ENV -Value "$name=$value"
+    Set-Item -Path "Env:$name" -Value $value
+  }
+}
+
+# Also export any VSCMD_* / VC* / WindowsSDK* newly set by vcvars
+foreach ($name in $after.Keys) {
+  if ($name -match '^(VSCMD_|VC|WindowsSDK|WindowsSdk|UniversalCRT|Framework|DevEnv|IFC|NETFX)') {
+    if (-not ($must -contains $name)) {
+      $value = $after[$name]
       Add-Content -Path $env:GITHUB_ENV -Value "$name=$value"
       Set-Item -Path "Env:$name" -Value $value
     }

--- a/scripts/ci/activate_msvc_gha.ps1
+++ b/scripts/ci/activate_msvc_gha.ps1
@@ -1,0 +1,51 @@
+# Clear conda-forge vs* leftovers that break VsDevCmd when the runner has VS 18+
+# and vswhere selects a different install than conda's VSINSTALLDIR.
+$kill = @(
+  'VSINSTALLDIR','VS_VERSION','VS_MAJOR','VS_YEAR','VCVARSBAT',
+  'NEWER_VS_WITH_OLDER_VC','WindowsSdkDir','WindowsSDKVer','MSSdk',
+  'DISTUTILS_USE_SDK','VCINSTALLDIR','VCToolsInstallDir','VCToolsVersion',
+  'CMAKE_GENERATOR','CMAKE_GENERATOR_TOOLSET','CMAKE_GENERATOR_PLATFORM',
+  'CMAKE_GEN','CMAKE_PLAT','USE_NEW_CMAKE_GEN_SYNTAX','VSCMD_VER',
+  'VSCMD_ARG_TGT_ARCH','VSCMD_ARG_HOST_ARCH','UniversalCRTSdkDir',
+  'UCRTVersion','WindowsLibPath','WindowsSdkLibPath','WindowsSdkVerBinPath',
+  'WindowsSDKVersion','ExtensionSdkDir','VCToolsRedistDir'
+)
+foreach ($v in $kill) {
+  Remove-Item "Env:$v" -ErrorAction SilentlyContinue
+}
+
+$vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
+if (-not (Test-Path $vswhere)) { throw "vswhere not found at $vswhere" }
+
+$installPath = & $vswhere -latest -products * `
+  -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+  -property installationPath
+if (-not $installPath) { throw "vswhere: no VC tools installation" }
+
+$vcvars = Join-Path $installPath "VC\Auxiliary\Build\vcvars64.bat"
+if (-not (Test-Path $vcvars)) { throw "vcvars64.bat missing: $vcvars" }
+
+Write-Host "Using $vcvars"
+# Capture environment after vcvars64
+$cmdOut = cmd.exe /c "`"$vcvars`" >nul 2>&1 && set"
+foreach ($line in $cmdOut) {
+  if ($line -match '^([^=]+)=(.*)$') {
+    $name = $Matches[1]
+    $value = $Matches[2]
+    # Skip empty names; append to GITHUB_ENV for subsequent steps
+    if ($name) {
+      Add-Content -Path $env:GITHUB_ENV -Value "$name=$value"
+      Set-Item -Path "Env:$name" -Value $value
+    }
+  }
+}
+
+$cl = Get-Command cl.exe -ErrorAction SilentlyContinue
+$link = Get-Command link.exe -ErrorAction SilentlyContinue
+if (-not $cl) { throw "cl.exe not on PATH after vcvars64" }
+if (-not $link) { throw "link.exe not on PATH after vcvars64" }
+Write-Host "cl: $($cl.Source)"
+Write-Host "link: $($link.Source)"
+if ($link.Source -match 'Git|usr\\bin|mingw') {
+  throw "link.exe is still GNU/Git, not MSVC: $($link.Source)"
+}

--- a/scripts/ci/win_flang_rt.sh
+++ b/scripts/ci/win_flang_rt.sh
@@ -147,12 +147,18 @@ eon_find_first() {
 }
 
 eon_export_flang_rt() {
+  # --required: must find import libs (MSVC link). Runtime DLLs are optional:
+  # conda-forge flang often ships only .lib; pot plugins should link static
+  # FortranRuntime (see client/meson.build _fortran_pot_link_args).
   local required=0
+  local require_dll=0
   local roots=()
   local arg
   for arg in "$@"; do
     if [ "$arg" = "--required" ]; then
       required=1
+    elif [ "$arg" = "--require-dll" ]; then
+      require_dll=1
     elif [ -n "$arg" ]; then
       roots+=("$arg")
     fi
@@ -212,9 +218,8 @@ eon_export_flang_rt() {
     ls "$dll_dir"/FortranRuntime*.dll "$dll_dir"/flang_rt*.dll \
        "$dll_dir"/FortranDecimal*.dll 2>/dev/null | head -20 || true
   else
-    echo "WARNING: flang_rt runtime DLL dir not found (LoadLibrary of pots may fail)" >&2
-    # --required means tests will LoadLibrary Fortran pots: hard-fail without DLLs.
-    if [ "$required" -eq 1 ]; then
+    echo "NOTE: no flang_rt runtime DLLs in env (pot plugins should use static flang_rt)" >&2
+    if [ "$require_dll" -eq 1 ]; then
       return 1
     fi
   fi

--- a/scripts/ci/win_flang_rt.sh
+++ b/scripts/ci/win_flang_rt.sh
@@ -18,6 +18,24 @@ eon_win_to_unix_path() {
   fi
 }
 
+eon_unix_to_win_path() {
+  # MSVC link.exe reads LIB with Windows paths. MSYS converts PATH for native
+  # children but does NOT rewrite LIB — Unix /d/... entries are ignored → LNK1104.
+  local p="$1"
+  if command -v cygpath >/dev/null 2>&1; then
+    cygpath -w "$p"
+    return
+  fi
+  if [[ "$p" =~ ^/([a-zA-Z])/(.*)$ ]]; then
+    local drive rest
+    drive="$(echo "${BASH_REMATCH[1]}" | tr 'a-z' 'A-Z')"
+    rest="${BASH_REMATCH[2]//\//\\}"
+    echo "${drive}:\\${rest}"
+  else
+    echo "${p//\//\\}"
+  fi
+}
+
 eon_dir_has() {
   # $1=dir $2=glob-ish name prefix (FortranRuntime or flang_rt) $3=ext (lib|dll)
   local d="$1" base="$2" ext="$3" f
@@ -175,11 +193,16 @@ eon_export_flang_rt() {
 
   if [ -n "$lib_dir" ]; then
     export FLANG_RT_LIB_DIR="$lib_dir"
-    export LIB="${lib_dir};${LIB:-}"
-    echo "Using flang_rt LIB: $lib_dir"
+    local lib_win
+    lib_win="$(eon_unix_to_win_path "$lib_dir")"
+    export LIB="${lib_win};${LIB:-}"
+    echo "Using flang_rt LIB: $lib_dir (win=$lib_win)"
     ls "$lib_dir"/FortranRuntime* "$lib_dir"/flang_rt* 2>/dev/null | head -20 || true
   else
     echo "WARNING: flang_rt import lib dir not found (link may LNK1104)" >&2
+    if [ "$required" -eq 1 ]; then
+      return 1
+    fi
   fi
 
   if [ -n "$dll_dir" ]; then

--- a/scripts/ci/win_flang_rt.sh
+++ b/scripts/ci/win_flang_rt.sh
@@ -1,52 +1,49 @@
 # shellcheck shell=bash
-# Locate conda-forge flang_rt import libs + runtime DLLs for MSVC link and
-# LoadLibrary of Fortran pot plugins. Source from Windows GHA bash steps:
-#   source scripts/ci/win_flang_rt.sh
-#   eon_export_flang_rt "${CONDA_PREFIX:-$PIXI_PRE}"
+# Locate conda-forge flang_rt for:
+#   - MSVC link: import libs (FortranRuntime.dynamic.lib / flang_rt*.lib) via LIB
+#   - LoadLibrary of pot plugins: runtime DLLs via PATH
 #
-# Sets FLANG_RT_DIR and prepends it to LIB (link) and PATH (runtime DLLs).
-# Exits 1 if required and the dir cannot be found.
+# Source: source scripts/ci/win_flang_rt.sh
+# Use:    eon_export_flang_rt "${CONDA_PREFIX:-}" --required
 
 eon_win_to_unix_path() {
-  # flang -print-resource-dir often emits D:\...; Git Bash [ -d ] needs /d/...
   local p="${1//\\//}"
   if [[ "$p" =~ ^([A-Za-z]):(.*)$ ]]; then
-    local drive="${BASH_REMATCH[1]}"
-    local rest="${BASH_REMATCH[2]}"
-    # lower-case drive for Git Bash
-    drive="$(echo "$drive" | tr 'A-Z' 'a-z')"
+    local drive rest
+    drive="$(echo "${BASH_REMATCH[1]}" | tr 'A-Z' 'a-z')"
+    rest="${BASH_REMATCH[2]}"
     echo "/${drive}${rest}"
   else
     echo "$p"
   fi
 }
 
-eon_flang_rt_has_artifacts() {
-  local d="$1"
+eon_dir_has() {
+  # $1=dir $2=glob-ish name prefix (FortranRuntime or flang_rt) $3=ext (lib|dll)
+  local d="$1" base="$2" ext="$3" f
   [ -d "$d" ] || return 1
-  # Import libs (MSVC link) and/or runtime DLLs (LoadLibrary of pot plugins)
-  local f
-  for f in \
-    flang_rt.runtime.dynamic.lib \
-    FortranRuntime.dynamic.lib \
-    flang_rt.dynamic.lib \
-    flang_rt.runtime.dynamic.dll \
-    FortranRuntime.dynamic.dll \
-    flang_rt.dynamic.dll
+  for f in "$d"/"${base}".dynamic."${ext}" \
+           "$d"/"${base}".dynamic_dbg."${ext}" \
+           "$d"/"${base}"."${ext}" \
+           "$d"/"${base}"*."${ext}"
   do
-    if [ -f "$d/$f" ]; then
-      return 0
-    fi
+    case "$f" in *\**) continue ;; esac
+    [ -f "$f" ] && return 0
   done
-  # Some layouts only ship versioned names
-  ls "$d"/flang_rt*.lib "$d"/FortranRuntime*.lib \
-     "$d"/flang_rt*.dll "$d"/FortranRuntime*.dll \
-     >/dev/null 2>&1
+  ls "$d"/${base}*."${ext}" >/dev/null 2>&1
 }
 
-eon_find_flang_rt_dir() {
-  # Optional roots: conda/pixi prefixes to search when -print-resource-dir fails
-  local root res candidate found
+eon_has_import_lib() {
+  eon_dir_has "$1" FortranRuntime lib || eon_dir_has "$1" flang_rt lib
+}
+
+eon_has_runtime_dll() {
+  eon_dir_has "$1" FortranRuntime dll || eon_dir_has "$1" flang_rt dll \
+    || eon_dir_has "$1" FortranDecimal dll
+}
+
+eon_candidate_list() {
+  local root res candidate
   local roots=()
   for root in "$@"; do
     [ -n "$root" ] || continue
@@ -63,57 +60,75 @@ eon_find_flang_rt_dir() {
   if [ -n "$res" ]; then
     res="$(eon_win_to_unix_path "$res")"
     echo "flang -print-resource-dir -> $res" >&2
+    # Prefer the MSVC triple layout first (feedstock / clang resource dir).
+    echo "${res}/lib/x86_64-pc-windows-msvc"
+    echo "${res}/lib"
+    echo "${res}"
   fi
 
-  local candidates=()
-  if [ -n "$res" ]; then
-    candidates+=(
-      "${res}/lib/x86_64-pc-windows-msvc"
-      "${res}/lib"
-      "${res}"
-    )
-  fi
   for root in "${roots[@]}"; do
     # shellcheck disable=SC2086
     for candidate in \
       "${root}/Library/lib/clang"/*/lib/x86_64-pc-windows-msvc \
       "${root}/lib/clang"/*/lib/x86_64-pc-windows-msvc \
+      "${root}/Library/bin" \
       "${root}/Library/lib" \
-      "${root}/Library/bin"
+      "${root}/bin" \
+      "${root}/lib"
     do
-      candidates+=("$candidate")
+      case "$candidate" in *\**) continue ;; esac
+      echo "$candidate"
     done
   done
+}
 
-  for candidate in "${candidates[@]}"; do
-    # Unmatched globs stay literal; skip those
-    case "$candidate" in
-      *\**) continue ;;
-    esac
-    if eon_flang_rt_has_artifacts "$candidate"; then
-      echo "$candidate"
+eon_find_first() {
+  # $1=predicate function name; remaining args = roots
+  local pred="$1"
+  shift
+  local c
+  while IFS= read -r c; do
+    [ -n "$c" ] || continue
+    if "$pred" "$c"; then
+      echo "$c"
       return 0
     fi
-  done
-
-  # Last resort: find import lib under roots
-  for root in "${roots[@]}"; do
+  done < <(eon_candidate_list "$@")
+  # find(1) fallback under roots
+  local root found name
+  if [ "$pred" = eon_has_import_lib ]; then
+    name='FortranRuntime.dynamic.lib'
+  else
+    name='FortranRuntime.dynamic.dll'
+  fi
+  for root in "$@"; do
+    [ -n "$root" ] || continue
+    root="$(eon_win_to_unix_path "$root")"
     [ -d "$root" ] || continue
-    found="$(find "$root" \( \
-      -name 'flang_rt.runtime.dynamic.lib' -o \
-      -name 'FortranRuntime.dynamic.lib' -o \
-      -name 'flang_rt.dynamic.lib' \
-    \) 2>/dev/null | head -1 || true)"
+    found="$(find "$root" -name "$name" 2>/dev/null | head -1 || true)"
     if [ -n "$found" ]; then
       dirname "$found"
       return 0
+    fi
+    # alternate names
+    found="$(find "$root" \( -name 'flang_rt*.dll' -o -name 'flang_rt*.lib' \
+      -o -name 'FortranRuntime*.dll' -o -name 'FortranRuntime*.lib' \) \
+      2>/dev/null | head -1 || true)"
+    if [ -n "$found" ]; then
+      if [ "$pred" = eon_has_import_lib ] && [[ "$found" == *.lib ]]; then
+        dirname "$found"
+        return 0
+      fi
+      if [ "$pred" = eon_has_runtime_dll ] && [[ "$found" == *.dll ]]; then
+        dirname "$found"
+        return 0
+      fi
     fi
   done
   return 1
 }
 
 eon_export_flang_rt() {
-  # Usage: eon_export_flang_rt [prefix ...] [--required]
   local required=0
   local roots=()
   local arg
@@ -125,29 +140,74 @@ eon_export_flang_rt() {
     fi
   done
 
-  local dir
-  if ! dir="$(eon_find_flang_rt_dir "${roots[@]}")"; then
-    echo "WARNING: flang_rt resource dir not found (roots: ${roots[*]:-none})" >&2
-    if [ -n "${CONDA_PREFIX:-}" ]; then
-      echo "CONDA_PREFIX=$CONDA_PREFIX" >&2
-      ls -la "${CONDA_PREFIX}/Library/lib/clang" 2>/dev/null || true
-    fi
+  local lib_dir dll_dir
+  lib_dir="$(eon_find_first eon_has_import_lib "${roots[@]}")" || lib_dir=""
+  dll_dir="$(eon_find_first eon_has_runtime_dll "${roots[@]}")" || dll_dir=""
+
+  # Library/bin often holds the runtime DLLs even when import libs live in Library/lib
+  if [ -z "$dll_dir" ]; then
+    local root
+    for root in "${roots[@]}"; do
+      root="$(eon_win_to_unix_path "$root")"
+      if eon_has_runtime_dll "${root}/Library/bin"; then
+        dll_dir="${root}/Library/bin"
+        break
+      fi
+    done
+  fi
+
+  if [ -z "$lib_dir" ] && [ -z "$dll_dir" ]; then
+    echo "WARNING: flang_rt import libs and runtime DLLs not found (roots: ${roots[*]:-none})" >&2
     if command -v flang-new >/dev/null 2>&1; then
       echo "flang-new=$(command -v flang-new)" >&2
       flang-new -print-resource-dir 2>&1 || true
     fi
+    for root in "${roots[@]}"; do
+      root="$(eon_win_to_unix_path "$root")"
+      echo "find under $root:" >&2
+      find "$root" \( -name 'FortranRuntime*' -o -name 'flang_rt*' \) 2>/dev/null | head -30 >&2 || true
+    done
     if [ "$required" -eq 1 ]; then
       return 1
     fi
     return 0
   fi
 
-  export FLANG_RT_DIR="$dir"
-  # LIB uses Windows-style ';' separators for MSVC link.exe
-  export LIB="${FLANG_RT_DIR};${LIB:-}"
-  # Runtime DLLs for LoadLibrary of eon_*.dll pot plugins
-  export PATH="${FLANG_RT_DIR}:${PATH}"
-  echo "Using flang_rt LIBPATH+PATH: $FLANG_RT_DIR"
-  ls "$FLANG_RT_DIR"/*.{lib,dll} 2>/dev/null | head -30 || ls "$FLANG_RT_DIR" | head -30
+  if [ -n "$lib_dir" ]; then
+    export FLANG_RT_LIB_DIR="$lib_dir"
+    export LIB="${lib_dir};${LIB:-}"
+    echo "Using flang_rt LIB: $lib_dir"
+    ls "$lib_dir"/FortranRuntime* "$lib_dir"/flang_rt* 2>/dev/null | head -20 || true
+  else
+    echo "WARNING: flang_rt import lib dir not found (link may LNK1104)" >&2
+  fi
+
+  if [ -n "$dll_dir" ]; then
+    export FLANG_RT_DLL_DIR="$dll_dir"
+    export PATH="${dll_dir}:${PATH}"
+    echo "Using flang_rt PATH (runtime DLLs): $dll_dir"
+    ls "$dll_dir"/FortranRuntime*.dll "$dll_dir"/flang_rt*.dll \
+       "$dll_dir"/FortranDecimal*.dll 2>/dev/null | head -20 || true
+  else
+    echo "WARNING: flang_rt runtime DLL dir not found (LoadLibrary of pots may fail)" >&2
+    # --required means tests will LoadLibrary Fortran pots: hard-fail without DLLs.
+    if [ "$required" -eq 1 ]; then
+      return 1
+    fi
+  fi
+
+  # Keep prefix bin on PATH (conda puts many runtime DLLs there).
+  local root
+  for root in "${roots[@]}"; do
+    root="$(eon_win_to_unix_path "$root")"
+    if [ -d "${root}/Library/bin" ]; then
+      export PATH="${root}/Library/bin:${PATH}"
+    fi
+    if [ -d "${root}/bin" ]; then
+      export PATH="${root}/bin:${PATH}"
+    fi
+  done
+
+  export FLANG_RT_DIR="${dll_dir:-$lib_dir}"
   return 0
 }

--- a/scripts/ci/win_flang_rt.sh
+++ b/scripts/ci/win_flang_rt.sh
@@ -1,0 +1,153 @@
+# shellcheck shell=bash
+# Locate conda-forge flang_rt import libs + runtime DLLs for MSVC link and
+# LoadLibrary of Fortran pot plugins. Source from Windows GHA bash steps:
+#   source scripts/ci/win_flang_rt.sh
+#   eon_export_flang_rt "${CONDA_PREFIX:-$PIXI_PRE}"
+#
+# Sets FLANG_RT_DIR and prepends it to LIB (link) and PATH (runtime DLLs).
+# Exits 1 if required and the dir cannot be found.
+
+eon_win_to_unix_path() {
+  # flang -print-resource-dir often emits D:\...; Git Bash [ -d ] needs /d/...
+  local p="${1//\\//}"
+  if [[ "$p" =~ ^([A-Za-z]):(.*)$ ]]; then
+    local drive="${BASH_REMATCH[1]}"
+    local rest="${BASH_REMATCH[2]}"
+    # lower-case drive for Git Bash
+    drive="$(echo "$drive" | tr 'A-Z' 'a-z')"
+    echo "/${drive}${rest}"
+  else
+    echo "$p"
+  fi
+}
+
+eon_flang_rt_has_artifacts() {
+  local d="$1"
+  [ -d "$d" ] || return 1
+  # Import libs (MSVC link) and/or runtime DLLs (LoadLibrary of pot plugins)
+  local f
+  for f in \
+    flang_rt.runtime.dynamic.lib \
+    FortranRuntime.dynamic.lib \
+    flang_rt.dynamic.lib \
+    flang_rt.runtime.dynamic.dll \
+    FortranRuntime.dynamic.dll \
+    flang_rt.dynamic.dll
+  do
+    if [ -f "$d/$f" ]; then
+      return 0
+    fi
+  done
+  # Some layouts only ship versioned names
+  ls "$d"/flang_rt*.lib "$d"/FortranRuntime*.lib \
+     "$d"/flang_rt*.dll "$d"/FortranRuntime*.dll \
+     >/dev/null 2>&1
+}
+
+eon_find_flang_rt_dir() {
+  # Optional roots: conda/pixi prefixes to search when -print-resource-dir fails
+  local root res candidate found
+  local roots=()
+  for root in "$@"; do
+    [ -n "$root" ] || continue
+    roots+=("$(eon_win_to_unix_path "$root")")
+  done
+
+  res=""
+  if command -v flang-new >/dev/null 2>&1; then
+    res="$(flang-new -print-resource-dir 2>/dev/null || true)"
+  fi
+  if [ -z "$res" ] && command -v flang >/dev/null 2>&1; then
+    res="$(flang -print-resource-dir 2>/dev/null || true)"
+  fi
+  if [ -n "$res" ]; then
+    res="$(eon_win_to_unix_path "$res")"
+    echo "flang -print-resource-dir -> $res" >&2
+  fi
+
+  local candidates=()
+  if [ -n "$res" ]; then
+    candidates+=(
+      "${res}/lib/x86_64-pc-windows-msvc"
+      "${res}/lib"
+      "${res}"
+    )
+  fi
+  for root in "${roots[@]}"; do
+    # shellcheck disable=SC2086
+    for candidate in \
+      "${root}/Library/lib/clang"/*/lib/x86_64-pc-windows-msvc \
+      "${root}/lib/clang"/*/lib/x86_64-pc-windows-msvc \
+      "${root}/Library/lib" \
+      "${root}/Library/bin"
+    do
+      candidates+=("$candidate")
+    done
+  done
+
+  for candidate in "${candidates[@]}"; do
+    # Unmatched globs stay literal; skip those
+    case "$candidate" in
+      *\**) continue ;;
+    esac
+    if eon_flang_rt_has_artifacts "$candidate"; then
+      echo "$candidate"
+      return 0
+    fi
+  done
+
+  # Last resort: find import lib under roots
+  for root in "${roots[@]}"; do
+    [ -d "$root" ] || continue
+    found="$(find "$root" \( \
+      -name 'flang_rt.runtime.dynamic.lib' -o \
+      -name 'FortranRuntime.dynamic.lib' -o \
+      -name 'flang_rt.dynamic.lib' \
+    \) 2>/dev/null | head -1 || true)"
+    if [ -n "$found" ]; then
+      dirname "$found"
+      return 0
+    fi
+  done
+  return 1
+}
+
+eon_export_flang_rt() {
+  # Usage: eon_export_flang_rt [prefix ...] [--required]
+  local required=0
+  local roots=()
+  local arg
+  for arg in "$@"; do
+    if [ "$arg" = "--required" ]; then
+      required=1
+    elif [ -n "$arg" ]; then
+      roots+=("$arg")
+    fi
+  done
+
+  local dir
+  if ! dir="$(eon_find_flang_rt_dir "${roots[@]}")"; then
+    echo "WARNING: flang_rt resource dir not found (roots: ${roots[*]:-none})" >&2
+    if [ -n "${CONDA_PREFIX:-}" ]; then
+      echo "CONDA_PREFIX=$CONDA_PREFIX" >&2
+      ls -la "${CONDA_PREFIX}/Library/lib/clang" 2>/dev/null || true
+    fi
+    if command -v flang-new >/dev/null 2>&1; then
+      echo "flang-new=$(command -v flang-new)" >&2
+      flang-new -print-resource-dir 2>&1 || true
+    fi
+    if [ "$required" -eq 1 ]; then
+      return 1
+    fi
+    return 0
+  fi
+
+  export FLANG_RT_DIR="$dir"
+  # LIB uses Windows-style ';' separators for MSVC link.exe
+  export LIB="${FLANG_RT_DIR};${LIB:-}"
+  # Runtime DLLs for LoadLibrary of eon_*.dll pot plugins
+  export PATH="${FLANG_RT_DIR}:${PATH}"
+  echo "Using flang_rt LIBPATH+PATH: $FLANG_RT_DIR"
+  ls "$FLANG_RT_DIR"/*.{lib,dll} 2>/dev/null | head -30 || ls "$FLANG_RT_DIR" | head -30
+  return 0
+}

--- a/scripts/ci/win_msvc_path.sh
+++ b/scripts/ci/win_msvc_path.sh
@@ -1,11 +1,5 @@
 # shellcheck shell=bash
-# Windows GHA: make MSVC available for meson without breaking torch DLL load.
-#
-# Order matters:
-# 1) Capture absolute cl/link while vcvars PATH is still present
-# 2) Rebuild PATH with conda + torch/lib first (shm.dll deps)
-# 3) Append MSVC tool dir after conda so Python loads conda CRTs first
-# 4) Drop Git /usr/bin so GNU link.exe cannot win
+# Windows GHA meson/test env: conda first for torch DLLs; MSVC via absolute tools.
 
 _path_without_usr_bin() {
   local _out="" _p
@@ -13,68 +7,40 @@ _path_without_usr_bin() {
   for _p in $1; do
     [ "$_p" = "/usr/bin" ] && continue
     [ -z "$_p" ] && continue
-    if [ -z "$_out" ]; then
-      _out="$_p"
-    else
-      _out="${_out}:${_p}"
-    fi
+    if [ -z "$_out" ]; then _out="$_p"; else _out="${_out}:${_p}"; fi
   done
   printf '%s' "$_out"
 }
 
-# Capture MSVC tools before we rewrite PATH
-_CL="$(command -v cl.exe 2>/dev/null || true)"
-_LINK="$(command -v link.exe 2>/dev/null || true)"
-# Prefer real MSVC link if GNU link is first
-if [ -n "$_CL" ]; then
-  _CLDIR="$(dirname "$_CL")"
-  if [ -x "${_CLDIR}/link.exe" ]; then
-    _LINK="${_CLDIR}/link.exe"
-  fi
-fi
-
 PATH="$(_path_without_usr_bin "$PATH")"
 export PATH
 
-# Conda / pixi first (DLLs for torch, numpy, etc.)
 if [ -n "${CONDA_PREFIX:-}" ]; then
   export PATH="${CONDA_PREFIX}/Scripts:${CONDA_PREFIX}:${CONDA_PREFIX}/Library/bin:${PATH}"
-  # torch native libs (shm.dll and friends)
   _torch_lib="${CONDA_PREFIX}/Lib/site-packages/torch/lib"
   if [ -d "$_torch_lib" ]; then
     export PATH="${_torch_lib}:${PATH}"
   fi
 fi
 
-# MSVC tool dir after conda so LoadLibrary prefers conda CRT/OpenMP
-if [ -n "$_CL" ]; then
-  export CC="$_CL"
-  export CXX="$_CL"
-  export PATH="$(dirname "$_CL"):${PATH}"
+# Absolute MSVC tools from activate_msvc_gha.ps1
+if [ -n "${EON_MSVC_CL:-}" ] && [ -x "$EON_MSVC_CL" ]; then
+  export CC="$EON_MSVC_CL"
+  export CXX="$EON_MSVC_CL"
+  # Append (not prepend) MSVC bin so LoadLibrary still prefers conda
+  export PATH="${PATH}:${EON_MSVC_BIN:-$(dirname "$EON_MSVC_CL")}"
+else
+  export CC=cl
+  export CXX=cl
 fi
-if [ -n "$_LINK" ]; then
-  export LD="$_LINK"
+if [ -n "${EON_MSVC_LINK:-}" ] && [ -x "$EON_MSVC_LINK" ]; then
+  export LD="$EON_MSVC_LINK"
 else
   export LD=link
 fi
 
-# Drop conda clang/lld flags that break MSVC link lines
 unset LDFLAGS || true
-# Do not force lld via FFLAGS for C++ link
 if [ -n "${FFLAGS:-}" ]; then
   FFLAGS="$(printf '%s' "$FFLAGS" | sed 's/-fuse-ld=lld//g')"
   export FFLAGS
-fi
-
-# Sanity
-command -v cl.exe >/dev/null
-command -v link.exe >/dev/null
-# link must not be GNU
-if link --help 2>&1 | head -1 | grep -qi 'Usage: link'; then
-  : # MSVC link --help says "usage: LINK" sometimes; check differently
-  true
-fi
-if command -v link.exe | grep -Eqi 'Git|usr/bin|mingw'; then
-  echo "ERROR: link.exe is still GNU: $(command -v link.exe)" >&2
-  exit 1
 fi

--- a/scripts/ci/win_msvc_path.sh
+++ b/scripts/ci/win_msvc_path.sh
@@ -1,31 +1,80 @@
 # shellcheck shell=bash
-# Source from pixi-run bash steps on Windows GHA.
-# Prefer conda DLL dirs (torch), then MSVC cl/link, never Git /usr/bin link.
-_path_strip_usr_bin() {
+# Windows GHA: make MSVC available for meson without breaking torch DLL load.
+#
+# Order matters:
+# 1) Capture absolute cl/link while vcvars PATH is still present
+# 2) Rebuild PATH with conda + torch/lib first (shm.dll deps)
+# 3) Append MSVC tool dir after conda so Python loads conda CRTs first
+# 4) Drop Git /usr/bin so GNU link.exe cannot win
+
+_path_without_usr_bin() {
   local _out="" _p
   local IFS=':'
-  for _p in $PATH; do
+  for _p in $1; do
     [ "$_p" = "/usr/bin" ] && continue
+    [ -z "$_p" ] && continue
     if [ -z "$_out" ]; then
       _out="$_p"
     else
-      _out="$_out:$_p"
+      _out="${_out}:${_p}"
     fi
   done
-  PATH="$_out"
-  export PATH
+  printf '%s' "$_out"
 }
 
-_path_strip_usr_bin
-export PATH="${CONDA_PREFIX}/Scripts:${CONDA_PREFIX}:${CONDA_PREFIX}/Library/bin:${PATH}"
-_cl="$(command -v cl.exe 2>/dev/null || true)"
-if [ -n "$_cl" ]; then
-  _cldir="$(dirname "$_cl")"
-  if [ -x "${_cldir}/link.exe" ]; then
-    export PATH="${_cldir}:${PATH}"
+# Capture MSVC tools before we rewrite PATH
+_CL="$(command -v cl.exe 2>/dev/null || true)"
+_LINK="$(command -v link.exe 2>/dev/null || true)"
+# Prefer real MSVC link if GNU link is first
+if [ -n "$_CL" ]; then
+  _CLDIR="$(dirname "$_CL")"
+  if [ -x "${_CLDIR}/link.exe" ]; then
+    _LINK="${_CLDIR}/link.exe"
   fi
 fi
+
+PATH="$(_path_without_usr_bin "$PATH")"
+export PATH
+
+# Conda / pixi first (DLLs for torch, numpy, etc.)
+if [ -n "${CONDA_PREFIX:-}" ]; then
+  export PATH="${CONDA_PREFIX}/Scripts:${CONDA_PREFIX}:${CONDA_PREFIX}/Library/bin:${PATH}"
+  # torch native libs (shm.dll and friends)
+  _torch_lib="${CONDA_PREFIX}/Lib/site-packages/torch/lib"
+  if [ -d "$_torch_lib" ]; then
+    export PATH="${_torch_lib}:${PATH}"
+  fi
+fi
+
+# MSVC tool dir after conda so LoadLibrary prefers conda CRT/OpenMP
+if [ -n "$_CL" ]; then
+  export CC="$_CL"
+  export CXX="$_CL"
+  export PATH="$(dirname "$_CL"):${PATH}"
+fi
+if [ -n "$_LINK" ]; then
+  export LD="$_LINK"
+else
+  export LD=link
+fi
+
+# Drop conda clang/lld flags that break MSVC link lines
 unset LDFLAGS || true
-export LD=link
-export CC=cl
-export CXX=cl
+# Do not force lld via FFLAGS for C++ link
+if [ -n "${FFLAGS:-}" ]; then
+  FFLAGS="$(printf '%s' "$FFLAGS" | sed 's/-fuse-ld=lld//g')"
+  export FFLAGS
+fi
+
+# Sanity
+command -v cl.exe >/dev/null
+command -v link.exe >/dev/null
+# link must not be GNU
+if link --help 2>&1 | head -1 | grep -qi 'Usage: link'; then
+  : # MSVC link --help says "usage: LINK" sometimes; check differently
+  true
+fi
+if command -v link.exe | grep -Eqi 'Git|usr/bin|mingw'; then
+  echo "ERROR: link.exe is still GNU: $(command -v link.exe)" >&2
+  exit 1
+fi

--- a/scripts/ci/win_msvc_path.sh
+++ b/scripts/ci/win_msvc_path.sh
@@ -1,0 +1,31 @@
+# shellcheck shell=bash
+# Source from pixi-run bash steps on Windows GHA.
+# Prefer conda DLL dirs (torch), then MSVC cl/link, never Git /usr/bin link.
+_path_strip_usr_bin() {
+  local _out="" _p
+  local IFS=':'
+  for _p in $PATH; do
+    [ "$_p" = "/usr/bin" ] && continue
+    if [ -z "$_out" ]; then
+      _out="$_p"
+    else
+      _out="$_out:$_p"
+    fi
+  done
+  PATH="$_out"
+  export PATH
+}
+
+_path_strip_usr_bin
+export PATH="${CONDA_PREFIX}/Scripts:${CONDA_PREFIX}:${CONDA_PREFIX}/Library/bin:${PATH}"
+_cl="$(command -v cl.exe 2>/dev/null || true)"
+if [ -n "$_cl" ]; then
+  _cldir="$(dirname "$_cl")"
+  if [ -x "${_cldir}/link.exe" ]; then
+    export PATH="${_cldir}:${PATH}"
+  fi
+fi
+unset LDFLAGS || true
+export LD=link
+export CC=cl
+export CXX=cl

--- a/subprojects/inih.wrap
+++ b/subprojects/inih.wrap
@@ -5,6 +5,7 @@ source_filename = inih-r62.tar.gz
 source_hash = 9c15fa751bb8093d042dae1b9f125eb45198c32c6704cd5481ccde460d4f8151
 source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/inih_r62-1/inih-r62.tar.gz
 wrapdb_version = r62-1
+patch_directory = inih
 
 [provide]
 inih = inih_dep

--- a/subprojects/packagefiles/inih/tests/runtest.sh
+++ b/subprojects/packagefiles/inih/tests/runtest.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -eu
+
+# Strip CR so MSVC text-mode stdout (CRLF) matches LF baselines.
+cd "$(dirname "${1}")"
+"$2" | tr -d '\r' | diff "${1}" -

--- a/tools/win_pip_torch_path.py
+++ b/tools/win_pip_torch_path.py
@@ -1,0 +1,109 @@
+"""Emit torch/metatensor native lib dirs for Windows LoadLibrary.
+
+Git Bash PATH must use colon-separated /c/... paths. Also call
+os.add_dll_directory for the current process when --register is passed.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import pathlib
+import site
+import sys
+
+
+def native_lib_dirs() -> list[pathlib.Path]:
+    roots: list[pathlib.Path] = []
+    for sp in site.getsitepackages():
+        base = pathlib.Path(sp)
+        candidates = [
+            base / "torch" / "lib",
+            base / "torch" / "bin",
+            base / "vesin" / "lib",
+            base / "metatensor" / "lib",
+        ]
+        for pat in (
+            "metatensor_torch/torch-*/lib",
+            "metatomic/torch/torch-*/lib",
+        ):
+            candidates.extend(base.glob(pat))
+        for d in candidates:
+            if d.is_dir():
+                roots.append(d.resolve())
+    # stable unique
+    out: list[pathlib.Path] = []
+    seen: set[str] = set()
+    for d in roots:
+        key = str(d).lower()
+        if key not in seen:
+            seen.add(key)
+            out.append(d)
+    return out
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument(
+        "--register",
+        action="store_true",
+        help="os.add_dll_directory for this process and prepend PATH",
+    )
+    p.add_argument(
+        "--bash-path",
+        action="store_true",
+        help="print colon-separated Git-Bash PATH prefix (cygpath if available)",
+    )
+    p.add_argument(
+        "--import-check",
+        action="store_true",
+        help="register dirs then import vesin/metatensor/metatomic torch stack",
+    )
+    args = p.parse_args()
+    dirs = native_lib_dirs()
+    if not dirs:
+        print("no native lib dirs found under site-packages", file=sys.stderr)
+        return 1
+
+    if args.register or args.import_check:
+        for d in dirs:
+            if hasattr(os, "add_dll_directory"):
+                os.add_dll_directory(str(d))
+            os.environ["PATH"] = str(d) + os.pathsep + os.environ.get("PATH", "")
+
+    if args.bash_path:
+        parts: list[str] = []
+        for d in dirs:
+            s = str(d)
+            # Prefer cygpath for Git Bash; fall back to /d/ form
+            try:
+                import subprocess
+
+                u = subprocess.check_output(
+                    ["cygpath", "-u", s], text=True
+                ).strip()
+                parts.append(u)
+            except Exception:
+                # D:\foo\bar -> /d/foo/bar
+                if len(s) >= 2 and s[1] == ":":
+                    parts.append("/" + s[0].lower() + s[2:].replace("\\", "/"))
+                else:
+                    parts.append(s.replace("\\", "/"))
+        print(":".join(parts))
+        return 0
+
+    if args.import_check:
+        import metatensor  # noqa: F401
+        import metatensor.torch  # noqa: F401
+        import metatomic.torch  # noqa: F401
+        import vesin  # noqa: F401
+
+        print("pip_metatomic imports ok")
+        return 0
+
+    for d in dirs:
+        print(d)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Continuous ASV history for eOn with an [asv-tachyon](https://github.com/HaoZeke/asv_tachyon) static dashboard.

- **History** lives on orphan branch `asv-results` (`.asv/results/**` only; survives Actions cache eviction)
- **UI** deploys to `gh-pages` under `/bench/` (`keep_files` so docs stay at site root)
- **Optional Netlify** deploy when `NETLIFY_AUTH_TOKEN` + `NETLIFY_SITE_ID` secrets are set (fork already live at https://bench.eondocs.org/)

PR performance comments remain on the existing [asv-perch](https://github.com/HaoZeke/asv-perch) path.

## Preview (fork)

| Surface | URL |
|---------|-----|
| Bench host | https://bench.eondocs.org/ |
| Netlify app | https://eon-bench.netlify.app/ |
| GH Pages path (after deploy) | https://haozeke.github.io/eOn/bench/ |
| History branch | `asv-results` |

First successful fork run: **43** revisions, **8** benchmarks (time + peakmem for saddle/point/NEB/LJ minimize).

## Changes

- `.github/workflows/ci_asv_dashboard.yml` — build eonclient, restore/push `asv-results`, asv run/publish, tachyon install, deploy
- `scripts/asv_run_history.sh` — loop `--set-commit-hash` for `existing:` env
- `asv.conf.json` — `show_commit_url`
- `benchmarks/README.md` — local + CI docs

## Test plan

- [x] Fork `ASV dashboard` workflow succeeds on `main`
- [x] Artifact has `index.json` + tachyon `index.html`
- [x] `asv-results` has result JSON under `.asv/results/`
- [x] https://bench.eondocs.org/ returns 200 with eOn data
- [ ] Upstream secrets (optional): `NETLIFY_AUTH_TOKEN`, `NETLIFY_SITE_ID` for prod Netlify deploy
- [ ] Docs at eondocs.org root still intact after `/bench/` deploy

## Notes for maintainers

Netlify custom domain + DNS for `bench.eondocs.org` is already configured on the owner Netlify team (fork preview). Upstream can either reuse that site or create its own; GH Pages `/bench/` works without Netlify.
