### PR TITLE
feat(schema): Cap'n Proto JobRequest/JobResult envelope

### DIFF
--- a/docs/newsfragments/381.added.md
+++ b/docs/newsfragments/381.added.md
@@ -1,0 +1,4 @@
+Cap'n Proto ``schema/eon_job_result.capnp`` defines typed ``JobRequest`` /
+``JobResult`` / flat ``Geometry`` envelopes for the in-process control plane
+(kill-file-IPC). ``eon_schema.jobs`` provides ``results.dat`` adapters for
+legacy paths.

--- a/packages/eon-schema/CHANGELOG.md
+++ b/packages/eon-schema/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## [0.2.3] — 2026-07-24
+
+### Added
+
+- ``eon_schema.jobs``: Cap'n Proto ``JobRequest`` / ``JobResult`` / ``Geometry``
+  schema path helper (vendored from monorepo ``schema/eon_job_result.capnp``)
+  and ``results.dat`` parse/serialize adapters for the kill-file-IPC control plane.
+
 ## [0.2.2] — 2026-07-17
 
 ### Changed

--- a/packages/eon-schema/README.md
+++ b/packages/eon-schema/README.md
@@ -4,7 +4,8 @@
 
 | Layer | Module | Role |
 |-------|--------|------|
-| **L0** | `eon_schema.ssot` | Cap’n Proto field graph (vendored from monorepo `schema/`) |
+| **L0** | `eon_schema.ssot` | Cap’n Proto params field graph (vendored from monorepo `schema/`) |
+| **L0** | `eon_schema.jobs` | Cap’n Proto `JobRequest` / `JobResult` / `Geometry` + `results.dat` adapters |
 | **L1** | `eon_schema.config` | Full job-config pydantic models (`MainConfig`, `Metatomic`, `Config`, …) |
 | **L2** | `eon_schema.api` / `fields` | In-process specs (`DimerSpec`, `NebSpec`, enums) |
 
@@ -47,8 +48,11 @@ pip install -e packages/eon-schema
 ## Quick use
 
 ```python
-# L0
+# L0 params
 from eon_schema.ssot import capnp_path, load_catalog
+
+# L0 job envelope
+from eon_schema.jobs import job_result_capnp_path, results_dat_to_dict
 
 # L1 (same objects as eon.schema.*)
 from eon_schema.config import MainConfig, Metatomic, Config
@@ -58,6 +62,7 @@ from eon_schema.api import DimerSpec
 from eon_schema.fields import MinModeMethod, Accelerant
 
 print(capnp_path())
+print(job_result_capnp_path())
 print(MainConfig().job)
 print(DimerSpec(method=MinModeMethod.improved, accelerant=Accelerant.gp).core_kwargs())
 ```
@@ -78,7 +83,8 @@ from pyeonclient.models import DimerSpec, NebSpec  # re-export
 
 ```text
 src/eon_schema/
-  ssot/          # L0 vendored Cap'n Proto + catalog
+  ssot/          # L0 vendored params Cap'n Proto + catalog
+  jobs/          # L0 JobRequest/JobResult schema + results.dat adapters
   config/        # L1 job-config models (models.py)
   fields/        # enums
   api/           # L2 DimerSpec, NebSpec

--- a/packages/eon-schema/pyproject.toml
+++ b/packages/eon-schema/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "eon-schema"
-version = "0.2.2"
+version = "0.2.3"
 description = "Shared eOn L0 Cap'n Proto SSoT, L1 job-config pydantic models, and L2 API specs for eon-akmc + pyeonclient"
 readme = "README.md"
 license = {text = "BSD-3-Clause"}
@@ -48,3 +48,4 @@ include = [
 "src/eon_schema/ssot/eon_params.capnp" = "eon_schema/ssot/eon_params.capnp"
 "src/eon_schema/ssot/eon_params_catalog.json" = "eon_schema/ssot/eon_params_catalog.json"
 "src/eon_schema/ssot/README.md" = "eon_schema/ssot/README.md"
+"src/eon_schema/jobs/eon_job_result.capnp" = "eon_schema/jobs/eon_job_result.capnp"

--- a/packages/eon-schema/scripts/sync_ssot_into_package.sh
+++ b/packages/eon-schema/scripts/sync_ssot_into_package.sh
@@ -1,18 +1,22 @@
 #!/usr/bin/env bash
 # Copy monorepo SSoT (schema/) into the eon-schema split package so the
 # PyPI wheel ships a self-contained Cap'n Proto + catalog copy.
-# Authoring is always schema/eon_params.capnp — edit there, then codegen.
+# Authoring is always schema/eon_params.capnp and schema/eon_job_result.capnp.
 set -euo pipefail
 PKG="$(cd "$(dirname "$0")/.." && pwd)"
 ROOT="$(cd "$PKG/../.." && pwd)"
 SRC="$ROOT/schema"
 DEST="$PKG/src/eon_schema/ssot"
+JOBS_DEST="$PKG/src/eon_schema/jobs"
 cp -a "$SRC/eon_params.capnp" "$DEST/"
 cp -a "$SRC/eon_params_catalog.json" "$DEST/"
+mkdir -p "$JOBS_DEST"
+cp -a "$SRC/eon_job_result.capnp" "$JOBS_DEST/"
 cat > "$DEST/README.md" << 'NOTE'
 # Cap'n Proto L0 SSoT (vendored for this package)
 
-**Authoring home:** monorepo `schema/eon_params.capnp`
+**Authoring home:** monorepo `schema/eon_params.capnp` (params) and
+`schema/eon_job_result.capnp` (job request/result envelope).
 
 This directory is a **vendored copy** shipped in the PyPI `eon-schema` wheel
 so installs work without the full monorepo. Do not edit field graphs here.
@@ -26,4 +30,4 @@ python tools/params_ssot/codegen.py
 
 Fat conda-forge releases use a full monorepo `git archive` tarball (not this package alone).
 NOTE
-echo "synced $SRC → $DEST (vendored into eon-schema split)"
+echo "synced $SRC → $DEST + $JOBS_DEST (vendored into eon-schema split)"

--- a/packages/eon-schema/src/eon_schema/__init__.py
+++ b/packages/eon-schema/src/eon_schema/__init__.py
@@ -39,4 +39,3 @@ __all__ = [
     "dict_to_results_dat",
     "job_result_scalars_from_results_dat",
 ]
-

--- a/packages/eon-schema/src/eon_schema/__init__.py
+++ b/packages/eon-schema/src/eon_schema/__init__.py
@@ -2,7 +2,8 @@
 
 Layers
 ------
-* **L0** — Cap'n Proto field graph (vendored copy of monorepo ``schema/``).
+* **L0** — Cap'n Proto field graph (vendored copy of monorepo ``schema/``):
+  params (``eon_schema.ssot``) and job request/result (``eon_schema.jobs``).
 * **L1** — full job config pydantic models (``eon_schema.config``); also
   re-exported as ``eon.schema`` from eon-akmc for Sphinx / legacy imports.
 * **L2** — in-process API composition (``DimerSpec``, ``NebSpec``).
@@ -11,19 +12,31 @@ Import::
 
     import eon_schema
     from eon_schema.ssot import capnp_path, load_catalog
+    from eon_schema.jobs import job_result_capnp_path, results_dat_to_dict
     from eon_schema.config import MainConfig, Config  # needs pydantic
     from eon_schema.api import DimerSpec, NebSpec
 """
 
 from __future__ import annotations
 
-__version__ = "0.2.1"
+__version__ = "0.2.3"
 
 from eon_schema.ssot import capnp_path, catalog_path, load_catalog
+from eon_schema.jobs import (
+    dict_to_results_dat,
+    job_result_capnp_path,
+    job_result_scalars_from_results_dat,
+    results_dat_to_dict,
+)
 
 __all__ = [
     "__version__",
     "capnp_path",
     "catalog_path",
     "load_catalog",
+    "job_result_capnp_path",
+    "results_dat_to_dict",
+    "dict_to_results_dat",
+    "job_result_scalars_from_results_dat",
 ]
+

--- a/packages/eon-schema/src/eon_schema/jobs/__init__.py
+++ b/packages/eon-schema/src/eon_schema/jobs/__init__.py
@@ -1,0 +1,103 @@
+"""Job request/result L0 schema and results.dat adapters.
+
+Authoring home: monorepo ``schema/eon_job_result.capnp``.
+This package vendors a copy for PyPI installs.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Mapping, Optional
+
+_PKG = Path(__file__).resolve().parent
+_VEND_CAPNP = _PKG / "eon_job_result.capnp"
+_MONO_CAPNP = Path(__file__).resolve().parents[5] / "schema" / "eon_job_result.capnp"
+
+
+def job_result_capnp_path() -> Path:
+    """Path to JobResult Cap'n Proto schema (vendored, else monorepo)."""
+    if _VEND_CAPNP.is_file():
+        return _VEND_CAPNP
+    if _MONO_CAPNP.is_file():
+        return _MONO_CAPNP
+    raise FileNotFoundError("eon_job_result.capnp not found (package or monorepo)")
+
+
+def results_dat_to_dict(text: str) -> Dict[str, Any]:
+    """Parse classic ``results.dat`` lines into a dict (legacy adapter)."""
+    results: Dict[str, Any] = {}
+    for line in text.splitlines():
+        parts = line.split()
+        if len(parts) < 2:
+            continue
+        key = parts[1]
+        raw = parts[0]
+        if "." in raw or "e" in raw.lower() or "E" in raw:
+            try:
+                results[key] = float(raw)
+                continue
+            except ValueError:
+                pass
+        try:
+            results[key] = int(raw)
+        except ValueError:
+            results[key] = raw
+    return results
+
+
+def dict_to_results_dat(data: Mapping[str, Any]) -> str:
+    """Serialize a dict to classic ``results.dat`` text (legacy adapter)."""
+    lines = []
+    for key, val in data.items():
+        if isinstance(val, float):
+            lines.append(f"{val:.12e} {key}")
+        else:
+            lines.append(f"{val} {key}")
+    return "\n".join(lines) + ("\n" if lines else "")
+
+
+def job_result_scalars_from_results_dat(text: str) -> Dict[str, Any]:
+    """Map results.dat keys into JobResult-oriented scalar names.
+
+    Geometries are not present in results.dat; load .con separately into
+    Geometry / ConFrame.
+    """
+    d = results_dat_to_dict(text)
+    out: Dict[str, Any] = {
+        "status_code": d.get("termination_reason", 0),
+        "status_text": d.get("termination_reason_text", ""),
+        "job_type": d.get("job_type", ""),
+        "potential_type": d.get("potential_type", ""),
+        "random_seed": d.get("random_seed", -1),
+        "potential_energy": d.get("potential_energy", d.get("Energy", 0.0)),
+        "potential_energy_saddle": d.get("potential_energy_saddle", 0.0),
+        "potential_energy_reactant": d.get("potential_energy_reactant", 0.0),
+        "potential_energy_product": d.get("potential_energy_product", 0.0),
+        "barrier_reactant_to_product": d.get("barrier_reactant_to_product", 0.0),
+        "barrier_product_to_reactant": d.get("barrier_product_to_reactant", 0.0),
+        "prefactor_reactant_to_product": d.get("prefactor_reactant_to_product", 0.0),
+        "prefactor_product_to_reactant": d.get("prefactor_product_to_reactant", 0.0),
+        "displacement_saddle_distance": d.get("displacement_saddle_distance", 0.0),
+        "force_calls": {
+            "total": d.get("total_force_calls", d.get("force_calls", 0)),
+            "minimization": d.get("force_calls_minimization", 0),
+            "saddle": d.get("force_calls_saddle", 0),
+            "prefactors": d.get("force_calls_prefactors", 0),
+            "neb": d.get("force_calls_neb", 0),
+        },
+        "wall_time_seconds": d.get("time_seconds", 0.0),
+        "user_time_seconds": d.get("user_time", 0.0),
+        "system_time_seconds": d.get("system_time", 0.0),
+    }
+    if "simulation_time" in d:
+        out["simulation_time"] = d["simulation_time"]
+        out["md_temperature"] = d.get("md_temperature", 0.0)
+        out["has_dynamics"] = True
+    return out
+
+
+__all__ = [
+    "job_result_capnp_path",
+    "results_dat_to_dict",
+    "dict_to_results_dat",
+    "job_result_scalars_from_results_dat",
+]

--- a/packages/eon-schema/src/eon_schema/jobs/eon_job_result.capnp
+++ b/packages/eon-schema/src/eon_schema/jobs/eon_job_result.capnp
@@ -1,0 +1,114 @@
+# eOn job request/result envelope — Cap'n Proto L0 for kill-file-IPC.
+#
+# Geometry is flat C-order positions (len=3N) and box (len=9), not .con text.
+# ConFrame remains the on-disk codec; this is the runtime / wire contract.
+# Wire ordinals are API: never renumber existing fields.
+#
+# statusCode preserves historical results.dat integer termination_reason values.
+# statusText is human-readable (describeStatus).
+
+@0x9e4f1c2a8b7d6301;
+
+using Cxx = import "/capnp/c++.capnp";
+$Cxx.namespace("eonc::job_ssot");
+
+# ---------------------------------------------------------------------
+# Geometry: one configuration (reactant / saddle / product / image)
+# ---------------------------------------------------------------------
+struct Geometry {
+  # Cartesian positions, C-order, length 3 * nAtoms
+  positions @0 :List(Float64);
+  # Cell matrix, row-major, length 9 (same convention as Matter / Structure)
+  box @1 :List(Float64);
+  atomicNumbers @2 :List(UInt16);
+  # Empty list means all free; otherwise length nAtoms (true = frozen)
+  frozen @3 :List(Bool);
+  # Optional chemical symbols (when Z alone is insufficient for I/O)
+  symbols @4 :List(Text);
+  masses @5 :List(Float64);
+  # Optional energy associated with this geometry (eV)
+  energy @6 :Float64 = 0.0;
+  hasEnergy @7 :Bool = false;
+}
+
+# ---------------------------------------------------------------------
+# Job request (server → mechanics engine)
+# ---------------------------------------------------------------------
+struct JobRequest {
+  jobId @0 :Text;
+  # Matches Results.dat / Parameters job names (process_search, minimization, …)
+  jobType @1 :Text;
+  # Optional packed Parameters (JSON UTF-8) when not sharing an in-process object
+  paramsJson @2 :Text;
+  reactant @3 :Geometry;
+  # Optional saddle seed / mode (3N)
+  mode @4 :List(Float64);
+  displacement @5 :Geometry;
+  # NEB endpoints / path seeds
+  product @6 :Geometry;
+  images @7 :List(Geometry);
+}
+
+# ---------------------------------------------------------------------
+# Force-call accounting (union of job writers)
+# ---------------------------------------------------------------------
+struct ForceCalls {
+  total @0 :UInt64 = 0;
+  minimization @1 :UInt64 = 0;
+  saddle @2 :UInt64 = 0;
+  prefactors @3 :UInt64 = 0;
+  neb @4 :UInt64 = 0;
+  dephase @5 :UInt64 = 0;
+  dynamics @6 :UInt64 = 0;
+  refine @7 :UInt64 = 0;
+  sampling @8 :UInt64 = 0;
+}
+
+# ---------------------------------------------------------------------
+# Job result (mechanics → server)
+# ---------------------------------------------------------------------
+struct ScalarExtra {
+  key @0 :Text;
+  value @1 :Float64;
+}
+
+struct JobResult {
+  jobId @0 :Text;
+  jobType @1 :Text;
+  # Historical results.dat integer (e.g. MinMode status / RunStatus)
+  statusCode @2 :Int32 = 0;
+  statusText @3 :Text = "good";
+  potentialType @4 :Text;
+  randomSeed @5 :Int64 = -1;
+
+  forceCalls @6 :ForceCalls;
+  potentialEnergy @7 :Float64 = 0.0;
+  potentialEnergySaddle @8 :Float64 = 0.0;
+  potentialEnergyReactant @9 :Float64 = 0.0;
+  potentialEnergyProduct @10 :Float64 = 0.0;
+  barrierReactantToProduct @11 :Float64 = 0.0;
+  barrierProductToReactant @12 :Float64 = 0.0;
+  prefactorReactantToProduct @13 :Float64 = 0.0;
+  prefactorProductToReactant @14 :Float64 = 0.0;
+  displacementSaddleDistance @15 :Float64 = 0.0;
+
+  # Optional dynamics saddle fields
+  simulationTime @16 :Float64 = 0.0;
+  mdTemperature @17 :Float64 = 0.0;
+  hasDynamics @18 :Bool = false;
+
+  reactant @19 :Geometry;
+  saddle @20 :Geometry;
+  product @21 :Geometry;
+  minimized @22 :Geometry;
+  # Mode at saddle (3N) or empty
+  mode @23 :List(Float64);
+  # NEB intermediate images (excluding or including ends — job-defined)
+  path @24 :List(Geometry);
+
+  wallTimeSeconds @25 :Float64 = 0.0;
+  userTimeSeconds @26 :Float64 = 0.0;
+  systemTimeSeconds @27 :Float64 = 0.0;
+  extras @28 :List(ScalarExtra);
+  clientVersion @29 :Text;
+}

--- a/packages/eon-schema/tests/test_job_result.py
+++ b/packages/eon-schema/tests/test_job_result.py
@@ -1,0 +1,49 @@
+from eon_schema.jobs import (
+    dict_to_results_dat,
+    job_result_capnp_path,
+    job_result_scalars_from_results_dat,
+    results_dat_to_dict,
+)
+
+
+def test_job_result_capnp_exists():
+    path = job_result_capnp_path()
+    assert path.is_file()
+    text = path.read_text(encoding="utf-8")
+    assert "struct JobResult" in text
+    assert "struct Geometry" in text
+    assert "struct JobRequest" in text
+    assert "positions" in text
+    assert "statusCode" in text
+
+
+def test_results_dat_roundtrip_scalars():
+    sample = (
+        "0 termination_reason\n"
+        "good termination_reason_text\n"
+        "process_search job_type\n"
+        "lj potential_type\n"
+        "42 total_force_calls\n"
+        "1.234567890123e+00 potential_energy_saddle\n"
+        "1.000000000000e+00 potential_energy_reactant\n"
+        "1.100000000000e+00 potential_energy_product\n"
+        "2.345678901234e-01 barrier_reactant_to_product\n"
+    )
+    d = results_dat_to_dict(sample)
+    assert d["termination_reason"] == 0
+    assert d["job_type"] == "process_search"
+    assert abs(d["potential_energy_saddle"] - 1.234567890123) < 1e-12
+    mapped = job_result_scalars_from_results_dat(sample)
+    assert mapped["status_code"] == 0
+    assert mapped["force_calls"]["total"] == 42
+    assert abs(mapped["barrier_reactant_to_product"] - 0.2345678901234) < 1e-10
+    # round-trip text
+    again = dict_to_results_dat(
+        {
+            "termination_reason": 0,
+            "termination_reason_text": "good",
+            "total_force_calls": 42,
+        }
+    )
+    assert "0 termination_reason" in again
+    assert "42 total_force_calls" in again

--- a/schema/README.md
+++ b/schema/README.md
@@ -26,3 +26,16 @@ That regenerates:
 Layout under `schema/` or `packages/` can change; the release contract is that
 the **fat** tarball is a complete monorepo archive the feedstock can build, while
 splits publish independently with their own versions when useful.
+
+## Job request / result envelope
+
+**Authoring home:** `schema/eon_job_result.capnp`
+
+Runtime control-plane types for kill-file-IPC (not parameter authoring):
+
+- `Geometry` — flat `positions` (3N), `box` (9), Z, frozen mask
+- `JobRequest` / `JobResult` — status codes, barriers, force-call buckets, optional geometries
+
+Python: `eon_schema.jobs` (path helper + `results.dat` adapters).
+
+`.con` / `results.dat` remain **durable adapters**, not the in-process primary API.

--- a/schema/eon_job_result.capnp
+++ b/schema/eon_job_result.capnp
@@ -1,0 +1,114 @@
+# eOn job request/result envelope — Cap'n Proto L0 for kill-file-IPC.
+#
+# Geometry is flat C-order positions (len=3N) and box (len=9), not .con text.
+# ConFrame remains the on-disk codec; this is the runtime / wire contract.
+# Wire ordinals are API: never renumber existing fields.
+#
+# statusCode preserves historical results.dat integer termination_reason values.
+# statusText is human-readable (describeStatus).
+
+@0x9e4f1c2a8b7d6301;
+
+using Cxx = import "/capnp/c++.capnp";
+$Cxx.namespace("eonc::job_ssot");
+
+# ---------------------------------------------------------------------
+# Geometry: one configuration (reactant / saddle / product / image)
+# ---------------------------------------------------------------------
+struct Geometry {
+  # Cartesian positions, C-order, length 3 * nAtoms
+  positions @0 :List(Float64);
+  # Cell matrix, row-major, length 9 (same convention as Matter / Structure)
+  box @1 :List(Float64);
+  atomicNumbers @2 :List(UInt16);
+  # Empty list means all free; otherwise length nAtoms (true = frozen)
+  frozen @3 :List(Bool);
+  # Optional chemical symbols (when Z alone is insufficient for I/O)
+  symbols @4 :List(Text);
+  masses @5 :List(Float64);
+  # Optional energy associated with this geometry (eV)
+  energy @6 :Float64 = 0.0;
+  hasEnergy @7 :Bool = false;
+}
+
+# ---------------------------------------------------------------------
+# Job request (server → mechanics engine)
+# ---------------------------------------------------------------------
+struct JobRequest {
+  jobId @0 :Text;
+  # Matches Results.dat / Parameters job names (process_search, minimization, …)
+  jobType @1 :Text;
+  # Optional packed Parameters (JSON UTF-8) when not sharing an in-process object
+  paramsJson @2 :Text;
+  reactant @3 :Geometry;
+  # Optional saddle seed / mode (3N)
+  mode @4 :List(Float64);
+  displacement @5 :Geometry;
+  # NEB endpoints / path seeds
+  product @6 :Geometry;
+  images @7 :List(Geometry);
+}
+
+# ---------------------------------------------------------------------
+# Force-call accounting (union of job writers)
+# ---------------------------------------------------------------------
+struct ForceCalls {
+  total @0 :UInt64 = 0;
+  minimization @1 :UInt64 = 0;
+  saddle @2 :UInt64 = 0;
+  prefactors @3 :UInt64 = 0;
+  neb @4 :UInt64 = 0;
+  dephase @5 :UInt64 = 0;
+  dynamics @6 :UInt64 = 0;
+  refine @7 :UInt64 = 0;
+  sampling @8 :UInt64 = 0;
+}
+
+# ---------------------------------------------------------------------
+# Job result (mechanics → server)
+# ---------------------------------------------------------------------
+struct ScalarExtra {
+  key @0 :Text;
+  value @1 :Float64;
+}
+
+struct JobResult {
+  jobId @0 :Text;
+  jobType @1 :Text;
+  # Historical results.dat integer (e.g. MinMode status / RunStatus)
+  statusCode @2 :Int32 = 0;
+  statusText @3 :Text = "good";
+  potentialType @4 :Text;
+  randomSeed @5 :Int64 = -1;
+
+  forceCalls @6 :ForceCalls;
+  potentialEnergy @7 :Float64 = 0.0;
+  potentialEnergySaddle @8 :Float64 = 0.0;
+  potentialEnergyReactant @9 :Float64 = 0.0;
+  potentialEnergyProduct @10 :Float64 = 0.0;
+  barrierReactantToProduct @11 :Float64 = 0.0;
+  barrierProductToReactant @12 :Float64 = 0.0;
+  prefactorReactantToProduct @13 :Float64 = 0.0;
+  prefactorProductToReactant @14 :Float64 = 0.0;
+  displacementSaddleDistance @15 :Float64 = 0.0;
+
+  # Optional dynamics saddle fields
+  simulationTime @16 :Float64 = 0.0;
+  mdTemperature @17 :Float64 = 0.0;
+  hasDynamics @18 :Bool = false;
+
+  reactant @19 :Geometry;
+  saddle @20 :Geometry;
+  product @21 :Geometry;
+  minimized @22 :Geometry;
+  # Mode at saddle (3N) or empty
+  mode @23 :List(Float64);
+  # NEB intermediate images (excluding or including ends — job-defined)
+  path @24 :List(Geometry);
+
+  wallTimeSeconds @25 :Float64 = 0.0;
+  userTimeSeconds @26 :Float64 = 0.0;
+  systemTimeSeconds @27 :Float64 = 0.0;
+  extras @28 :List(ScalarExtra);
+  clientVersion @29 :Text;
+}

--- a/tests/test_job_result_schema.py
+++ b/tests/test_job_result_schema.py
@@ -1,0 +1,27 @@
+"""Monorepo: JobResult Cap'n Proto file + results.dat adapters."""
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_schema_file_in_monorepo():
+    p = ROOT / "schema" / "eon_job_result.capnp"
+    assert p.is_file()
+    text = p.read_text(encoding="utf-8")
+    assert "struct JobResult" in text
+    assert "struct JobRequest" in text
+    assert "struct Geometry" in text
+    # Flat geometry, not con text blobs
+    assert "positions @0" in text
+    assert ".con" not in text or "not .con text" in text
+
+
+def test_adapters_importable_from_package():
+    import sys
+
+    sys.path.insert(0, str(ROOT / "packages" / "eon-schema" / "src"))
+    from eon_schema.jobs import job_result_capnp_path, results_dat_to_dict
+
+    assert job_result_capnp_path().is_file()
+    d = results_dat_to_dict("0 termination_reason\ngood termination_reason_text\n")
+    assert d["termination_reason"] == 0


### PR DESCRIPTION
## Summary

- Add `schema/eon_job_result.capnp` L0 types: flat `Geometry` (positions 3N, box 9), `JobRequest`, `JobResult`, `ForceCalls`.
- Ship vendored copy + `results.dat` adapters in `eon-schema.jobs` (package 0.2.3).
- Tests for schema presence and scalar round-trip; monorepo + package.

This is the typed control-plane contract for kill-file-IPC (in-process / Cap'n Proto boundary). `.con` and `results.dat` remain durable adapters only.

## Test plan

- [x] `PYTHONPATH=packages/eon-schema/src pytest packages/eon-schema/tests/ tests/test_job_result_schema.py`
- [ ] CI green on this PR
- [ ] Consumer wiring (Explorer / LocalInProcess / C++ Results) is separate work