### PR TITLE
fix(client): results.dat timing footer value-key contract

### DIFF
--- a/client/ClientEON.cpp
+++ b/client/ClientEON.cpp
@@ -475,12 +475,14 @@ int main(int argc, char **argv) {
       QUILL_LOG_INFO(logger, "  User time: {:.3f} seconds", utime);
       QUILL_LOG_INFO(logger, "  System time: {:.3f} seconds", stime);
 
+      // results.dat contract is "<value> <key>" (same as all job writers and
+      // eon.fileio.parse_results / eon_schema.jobs adapters).
       std::ofstream result_file("results.dat", std::ios::app);
       if (result_file.is_open()) {
-        result_file << "time_seconds " << elapsed.count() << "\n";
+        result_file << elapsed.count() << " time_seconds\n";
 #ifndef _WIN32
-        result_file << "user_time " << utime << "\n";
-        result_file << "system_time " << stime << "\n";
+        result_file << utime << " user_time\n";
+        result_file << stime << " system_time\n";
 #endif
       } else {
         QUILL_LOG_ERROR(logger, "Failed to write timing to results.dat");

--- a/client/python/bind/bind_jobs.cpp
+++ b/client/python/bind/bind_jobs.cpp
@@ -90,7 +90,8 @@ void bind_jobs(nb::module_ &m) {
         if (!out.is_open())
           throw std::runtime_error("append_results_timing: cannot open " +
                                    path);
-        // results.dat contract: "<value> <key>" (parse_results / eon_schema.jobs)
+        // results.dat contract: "<value> <key>" (parse_results /
+        // eon_schema.jobs)
         out << elapsed_seconds << " time_seconds\n";
 #ifndef _WIN32
         out << user_time << " user_time\n";

--- a/client/python/bind/bind_jobs.cpp
+++ b/client/python/bind/bind_jobs.cpp
@@ -90,15 +90,16 @@ void bind_jobs(nb::module_ &m) {
         if (!out.is_open())
           throw std::runtime_error("append_results_timing: cannot open " +
                                    path);
-        out << "time_seconds " << elapsed_seconds << "\n";
+        // results.dat contract: "<value> <key>" (parse_results / eon_schema.jobs)
+        out << elapsed_seconds << " time_seconds\n";
 #ifndef _WIN32
-        out << "user_time " << user_time << "\n";
-        out << "system_time " << system_time << "\n";
+        out << user_time << " user_time\n";
+        out << system_time << " system_time\n";
 #endif
       },
       nb::arg("path") = "results.dat", nb::arg("elapsed_seconds"),
       nb::arg("user_time") = 0.0, nb::arg("system_time") = 0.0,
-      "Append ClientEON timing footer to results.dat.");
+      "Append ClientEON timing footer to results.dat (value-key lines).");
 
   m.def(
       "steady_clock_now",

--- a/client/python/pyeonclient/steps.py
+++ b/client/python/pyeonclient/steps.py
@@ -122,8 +122,9 @@ def append_timing(
 ) -> None:
     """Step: append ``time_seconds`` / ``user_time`` / ``system_time``.
 
-    Pass *t0* from :func:`steady_clock_now` before the work, or *elapsed*
-    wall seconds directly.
+    Lines use the results.dat ``<value> <key>`` contract (same as job writers
+    and ``parse_results``). Pass *t0* from :func:`steady_clock_now` before the
+    work, or *elapsed* wall seconds directly.
     """
     if elapsed is None:
         if t0 is None:

--- a/docs/newsfragments/382.fixed.md
+++ b/docs/newsfragments/382.fixed.md
@@ -1,0 +1,4 @@
+ClientEON and pyeonclient ``append_results_timing`` write the
+``results.dat`` timing footer as ``<value> <key>`` (same contract as
+job writers and ``parse_results``), so ``time_seconds`` /
+``user_time`` / ``system_time`` parse as floats under those keys.

--- a/tests/test_results_dat_timing_footer.py
+++ b/tests/test_results_dat_timing_footer.py
@@ -1,0 +1,42 @@
+"""results.dat timing footer must be value-key for parse_results."""
+from __future__ import annotations
+
+from eon.fileio import parse_results
+from eon_schema.jobs import job_result_scalars_from_results_dat, results_dat_to_dict
+
+
+def test_parse_results_value_key_timing():
+    text = (
+        "0 termination_reason\n"
+        "good termination_reason_text\n"
+        "1.234567 time_seconds\n"
+        "0.5 user_time\n"
+        "0.1 system_time\n"
+    )
+    d = parse_results(__import__("io").StringIO(text))
+    assert abs(d["time_seconds"] - 1.234567) < 1e-12
+    assert abs(d["user_time"] - 0.5) < 1e-12
+    assert abs(d["system_time"] - 0.1) < 1e-12
+
+
+def test_inverted_key_value_timing_does_not_yield_float_keys():
+    """Historical inverted footer put the key first; parsers must not
+    treat that as the value-key contract."""
+    inverted = "time_seconds 1.234567\n"
+    d = parse_results(__import__("io").StringIO(inverted))
+    # key becomes the number string; no float under time_seconds
+    assert "time_seconds" not in d or not isinstance(d.get("time_seconds"), float)
+
+
+def test_job_result_adapter_reads_timing():
+    text = (
+        "0 termination_reason\n"
+        "2.5 time_seconds\n"
+        "1.0 user_time\n"
+        "0.25 system_time\n"
+    )
+    mapped = job_result_scalars_from_results_dat(text)
+    assert abs(mapped["wall_time_seconds"] - 2.5) < 1e-12
+    assert abs(mapped["user_time_seconds"] - 1.0) < 1e-12
+    assert abs(mapped["system_time_seconds"] - 0.25) < 1e-12
+    assert abs(results_dat_to_dict(text)["time_seconds"] - 2.5) < 1e-12


### PR DESCRIPTION
## Summary

- ClientEON and pyeonclient `append_results_timing` wrote `key value` lines for `time_seconds` / `user_time` / `system_time`.
- Job writers and `eon.fileio.parse_results` / `eon_schema.jobs` expect `<value> <key>`, so timing never landed as floats under those keys (and JobResult wall-time adapters stayed at 0).
- Footer now matches the value-key contract; tests cover parse + JobResult scalar mapping.

## Test plan

- [x] `pytest tests/test_results_dat_timing_footer.py`
- [ ] CI green