### PR TITLE
fix(ams_io): pass xc to fprintf format string

### DIFF
--- a/client/potentials/AMS_IO/AMS_IO.cpp
+++ b/client/potentials/AMS_IO/AMS_IO.cpp
@@ -110,7 +110,7 @@ void AMS_IO::passToSystem(long N, const double *R, const int *atomicNrs,
     fprintf(out, "     Model %s\n", model);
   }
   if (strlen(xc) > 0) {
-    fprintf(out, "xc %s\n");
+    fprintf(out, "xc %s\n", xc);
     fprintf(out, "     hybrid %s\n",
             xc); // basis set not specified (default = DZ)
     fprintf(out, "end\n");

--- a/docs/newsfragments/384.fixed.md
+++ b/docs/newsfragments/384.fixed.md
@@ -1,0 +1,3 @@
+AMS_IO writes the XC functional name into the run script: the
+``fprintf("xc %s\\n")`` call was missing its ``xc`` argument (undefined
+behavior).


### PR DESCRIPTION
## Summary

`AMS_IO.cpp` used `fprintf(out, "xc %s\n")` without the `xc` argument (undefined behavior). The following hybrid line already passed `xc` correctly.

## Test plan

- [ ] CI compile paths that enable AMS_IO
- [x] Static fix of format/args mismatch