### PR TITLE
fix(ase): throw on pot errors instead of exit(1)

### DIFF
--- a/client/potentials/ASE/ASE.cpp
+++ b/client/potentials/ASE/ASE.cpp
@@ -13,10 +13,10 @@
 #include "eon/potentials/ASE/ASE.h"
 #include "eon/PyGuard.h"
 #include "eon/fpe_handler.h"
-#include <cstdlib> // for exit()
 #include <pybind11/embed.h>
 #include <pybind11/numpy.h> // for py::array_t
 #include <pybind11/pybind11.h>
+#include <stdexcept>
 #include <string>
 #include <tuple>
 #include <vector>

--- a/client/potentials/ASE/ASE.cpp
+++ b/client/potentials/ASE/ASE.cpp
@@ -65,7 +65,8 @@ ASE::ASE(const Parameters &a_params)
             e.what());
     fprintf(stderr, "%s should exist and have no errors on the Python side.\n",
             py_file.c_str());
-    exit(1);
+    throw std::runtime_error(std::string("ASE calculator import failed: ") +
+                             e.what());
   }
   return;
 }
@@ -95,10 +96,12 @@ void ASE::force(long nAtoms, const double *R, const int *atomicNrs, double *F,
 
   } catch (py::error_already_set &e) {
     fprintf(stderr, "ASE calculator: Python error: %s\n", e.what());
-    exit(1);
+    throw std::runtime_error(std::string("ASE calculator Python error: ") +
+                             e.what());
   } catch (const std::exception &e) {
     fprintf(stderr, "ASE calculator: C++ exception: %s\n", e.what());
-    exit(1);
+    throw std::runtime_error(std::string("ASE calculator C++ exception: ") +
+                             e.what());
   }
 
   counter++;

--- a/docs/newsfragments/385.fixed.md
+++ b/docs/newsfragments/385.fixed.md
@@ -1,0 +1,3 @@
+ASE potential import and force failures throw ``std::runtime_error``
+instead of ``exit(1)``, so pyeonclient / in-process callers can recover
+instead of killing the whole process.


### PR DESCRIPTION
## Summary

ASE potential used `exit(1)` on import/force failures, which kills the whole process (including pyeonclient / LocalInProcess). After logging to stderr, raise `std::runtime_error` instead.

## Test plan

- [ ] CI paths that compile ASE pot
- [x] Static review of catch paths