### PR TITLE
feat(client): unified VesinNeighbors for classical pair pots

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,7 +1,25 @@
 # eOn ASV benchmarks
 
-Python ASV suite that times the `eonclient` binary (saddle search, point
-energy, …). See `bench_eonclient.py` and `data/`.
+Python ASV suite that times the **`eonclient` binary** (saddle search, point
+energy, minimization, NEB, …). See `bench_eonclient.py` and `data/`.
+
+This is the **institutional** performance surface for client changes (including
+vesin-backed classical pot neighbor lists): PR matrix vs `main`, continuous
+history on `asv-results`, dashboard at eondocs.org/bench.
+
+## Which benches hit vesin-backed pots
+
+After the unified VesinNeighbors work (LJ / Morse / LJCluster / QSC force pairs):
+
+| Class | Fixture | Potential |
+|-------|---------|-----------|
+| `TimePointMorsePt` | `data/point_morse_pt` | `morse_pt` (force NL) |
+| `TimeSaddleSearchMorseDimer` | `data/one_pt_saddle_search` | `morse_pt` |
+| `TimeNEBMorsePt` | `data/neb_morse_pt` | `morse_pt` |
+| `TimeMinimizationLJCluster` | `data/min_lj_cluster` | `ljcluster` |
+
+Python server geometry (`eon.geometry.neighbor_list`) is covered by unit tests
+(`tests/test_geometry_vesin.py`), not ASV: ASV here is client binary wall time.
 
 ## Local
 

--- a/client/VesinNeighbors.cpp
+++ b/client/VesinNeighbors.cpp
@@ -1,0 +1,97 @@
+/*
+** This file is part of eOn.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include "eon/VesinNeighbors.h"
+
+#include <cstdlib>
+#include <cstring>
+
+namespace eonc {
+
+VesinNeighbors::VesinNeighbors(VesinNeighbors &&other) noexcept
+    : list_(other.list_), owns_(other.owns_) {
+  other.list_ = VesinNeighborList{};
+  other.owns_ = false;
+}
+
+VesinNeighbors &VesinNeighbors::operator=(VesinNeighbors &&other) noexcept {
+  if (this != &other) {
+    free_list();
+    list_ = other.list_;
+    owns_ = other.owns_;
+    other.list_ = VesinNeighborList{};
+    other.owns_ = false;
+  }
+  return *this;
+}
+
+VesinNeighbors::~VesinNeighbors() { free_list(); }
+
+void VesinNeighbors::free_list() {
+  if (owns_) {
+    vesin_free(&list_);
+    owns_ = false;
+  }
+  list_ = VesinNeighborList{};
+}
+
+void VesinNeighbors::compute(const double *R, std::size_t n, const double *box,
+                             const Options &opt) {
+  if (R == nullptr || (n > 0 && box == nullptr)) {
+    throw std::invalid_argument("VesinNeighbors::compute: null R or box");
+  }
+  if (opt.cutoff <= 0.0) {
+    free_list();
+    return;
+  }
+
+  // Re-use allocation: free then default-init for a clean rebuild.
+  free_list();
+
+  VesinOptions vopt{};
+  vopt.cutoff = opt.cutoff;
+  vopt.full = opt.full;
+  vopt.sorted = opt.sorted;
+  vopt.return_shifts = opt.return_shifts;
+  vopt.return_distances = opt.return_distances;
+  vopt.return_vectors = opt.return_vectors;
+
+  bool periodic[3] = {opt.periodic[0], opt.periodic[1], opt.periodic[2]};
+  double box33[3][3];
+  for (int a = 0; a < 3; ++a) {
+    for (int b = 0; b < 3; ++b) {
+      box33[a][b] = box[3 * a + b];
+    }
+  }
+
+  VesinDevice cpu{VesinCPU, 0};
+  const char *error_message = nullptr;
+  int status = vesin_neighbors(
+      reinterpret_cast<const double (*)[3]>(R), n, box33, periodic, cpu, vopt,
+      &list_, &error_message);
+  if (status != EXIT_SUCCESS) {
+    std::string err = "vesin_neighbors failed";
+    if (error_message != nullptr) {
+      err += ": ";
+      err += error_message;
+    }
+    free_list();
+    throw std::runtime_error(err);
+  }
+  owns_ = true;
+}
+
+VesinNeighborList *VesinNeighbors::release() {
+  if (!owns_) {
+    return nullptr;
+  }
+  auto *heap = new VesinNeighborList(list_);
+  list_ = VesinNeighborList{};
+  owns_ = false;
+  return heap;
+}
+
+} // namespace eonc

--- a/client/VesinNeighbors.cpp
+++ b/client/VesinNeighbors.cpp
@@ -12,7 +12,8 @@
 namespace eonc {
 
 VesinNeighbors::VesinNeighbors(VesinNeighbors &&other) noexcept
-    : list_(other.list_), owns_(other.owns_) {
+    : list_(other.list_),
+      owns_(other.owns_) {
   other.list_ = VesinNeighborList{};
   other.owns_ = false;
 }
@@ -69,9 +70,9 @@ void VesinNeighbors::compute(const double *R, std::size_t n, const double *box,
 
   VesinDevice cpu{VesinCPU, 0};
   const char *error_message = nullptr;
-  int status = vesin_neighbors(
-      reinterpret_cast<const double (*)[3]>(R), n, box33, periodic, cpu, vopt,
-      &list_, &error_message);
+  int status =
+      vesin_neighbors(reinterpret_cast<const double (*)[3]>(R), n, box33,
+                      periodic, cpu, vopt, &list_, &error_message);
   if (status != EXIT_SUCCESS) {
     std::string err = "vesin_neighbors failed";
     if (error_message != nullptr) {

--- a/client/meson.build
+++ b/client/meson.build
@@ -382,7 +382,42 @@ endif
 dl_dep = cppc.find_library('dl', required: false)
 _deps += dl_dep
 
-eoncbase_sources = ['fpe_handler.cpp', 'PotRegistry.cpp', 'potentials/FortranPotLoader.cpp']
+# vesin: single neighbor-list backend for classical pots + Metatomic.
+# Prefer pkg-config / system; else vendored thirdparty/vesin single TU.
+vesin_dep = dependency('vesin', required: false)
+if not vesin_dep.found()
+    vesin_dep = dependency('vesin', method: 'cmake', required: false)
+endif
+if not vesin_dep.found()
+    vesin_dep = cppc.find_library('vesin', required: false)
+endif
+if not vesin_dep.found() and is_windows
+    vesin_dep = cppc.find_library('libvesin', required: false)
+endif
+if not vesin_dep.found()
+    vesin_int = library(
+        'vesin_internal',
+        ['thirdparty/vesin/vesin-single-build.cpp'],
+        install: true,
+    )
+    vesin_dep = declare_dependency(
+        link_with: vesin_int,
+        include_directories: include_directories('thirdparty/vesin'),
+    )
+    message('vesin: using vendored thirdparty/vesin')
+else
+    # Ensure #include "vesin.h" works when only a library was found.
+    _incdirs += [include_directories('thirdparty/vesin')]
+    message('vesin: using system / pkg-config')
+endif
+_deps += [vesin_dep]
+
+eoncbase_sources = [
+    'fpe_handler.cpp',
+    'PotRegistry.cpp',
+    'potentials/FortranPotLoader.cpp',
+    'VesinNeighbors.cpp',
+]
 
 eoncbase = library(
     'eoncbase',
@@ -948,39 +983,16 @@ for name in ("metatensor", "metatensor_torch", "metatomic", "vesin"):
             dependencies: [_mts_core_found, _mts_torch_found, _mta_torch_found],
             compile_args: mts_inc_args,
         )
-        _vesin_candidates = is_windows ? ['vesin', 'libvesin'] : ['vesin']
-        vesin_dep = disabler()
-        foreach _n : _vesin_candidates
-            if not vesin_dep.found()
-                vesin_dep = cppc.find_library(_n, dirs: [_vesin_lib], required: false)
-            endif
-        endforeach
-        if vesin_dep.found()
-            vesin_dep = declare_dependency(
-                dependencies: [vesin_dep],
-                compile_args: ['-I' + _vesin_inc],
-            )
-        endif
+        # vesin: single copy already on _deps via eoncbase (do not re-find pip vesin)
     else
         message(
-            'Looking for existing installations of metatensor, metatensor-torch, metatomic-torch and vesin',
+            'Looking for existing installations of metatensor, metatensor-torch, metatomic-torch',
         )
         message(
             'If this is flaky, pass pip_metatomic=True with the torch version and let pip handle everything',
         )
-        # Prefer pkg-config/cmake vesin before manual find_library / vendored tree.
-        # xref: https://github.com/metatensor/metatensor/issues/930
-        # On Windows (MSVC), static libraries are often prefixed with 'lib'
-        vesin_dep = dependency('vesin', required: false)
-        if not vesin_dep.found()
-            vesin_dep = dependency('vesin', method: 'cmake', required: false)
-        endif
-        if not vesin_dep.found()
-            vesin_dep = cppc.find_library('vesin', required: false)
-        endif
-        if not vesin_dep.found() and is_windows
-            vesin_dep = cppc.find_library('libvesin', required: false)
-        endif
+        # Vesin already resolved for eoncbase (single NL backend for all pots).
+        # Only metatensor / metatomic-torch are located here.
         mts_dep = dependency('metatensor_torch', required: false)
         if not mts_dep.found()
             mts_dep = dependency('metatensor-torch', required: false)
@@ -1011,20 +1023,10 @@ for name in ("metatensor", "metatensor_torch", "metatomic", "vesin"):
             ]
         endif
     endif
-    if not vesin_dep.found()
-        vesin_int = library(
-            'vesin_internal',
-            ['thirdparty/vesin/vesin-single-build.cpp'],
-            install: true,
-        )
-        vesin_dep = declare_dependency(
-            link_with: vesin_int,
-            include_directories: include_directories('thirdparty/vesin'),
-        )
-    endif
     # Fat Metatomic (potential = Metatomic) + deps for RGPOT engine .so.
-    mta_plugin_deps = _deps + [vesin_dep, mts_dep, torch_deps]
-    _deps += [vesin_dep, mts_dep, torch_deps]
+    # vesin already on _deps (eoncbase VesinNeighbors + classical pots).
+    mta_plugin_deps = _deps + [mts_dep, torch_deps]
+    _deps += [mts_dep, torch_deps]
     _args += ['-DWITH_METATOMIC']
     metatomic_pot = library(
         'metatomic_pot',

--- a/client/potentials/LJ/LJ.cpp
+++ b/client/potentials/LJ/LJ.cpp
@@ -11,6 +11,7 @@
 */
 
 #include "eon/potentials/LJ/LJ.h"
+#include "eon/VesinNeighbors.h"
 #include <cmath>
 
 void LJ::setParameters(double u0In, double cutoffIn, double psiIn) {
@@ -30,54 +31,52 @@ void LJ::force(long N, const double *R, const int * /*atomicNrs*/, double *F,
   for (long i = 0; i < 3 * N; i++) {
     F[i] = 0.0;
   }
+  if (N < 2 || cuttOffR <= 0.0) {
+    return;
+  }
 
-  // Pre-compute reciprocals for PBC and cutoff
-  const double invBox0 = 1.0 / box[0];
-  const double invBox4 = 1.0 / box[4];
-  const double invBox8 = 1.0 / box[8];
-  const double cutoff2 = cuttOffR * cuttOffR;
+  eonc::VesinNeighbors nl;
+  eonc::VesinNeighbors::Options opt;
+  opt.cutoff = cuttOffR;
+  opt.full = false; // half list: one pair entry per unordered bond
+  opt.return_distances = true;
+  opt.return_vectors = true;
+  nl.compute(R, static_cast<std::size_t>(N), box, opt);
+
   const double psi2 = psi * psi;
-
-  for (long i = 0; i < N - 1; i++) {
-    const double xi = R[3 * i];
-    const double yi = R[3 * i + 1];
-    const double zi = R[3 * i + 2];
-
-    for (long j = i + 1; j < N; j++) {
-      double dx = xi - R[3 * j];
-      double dy = yi - R[3 * j + 1];
-      double dz = zi - R[3 * j + 2];
-
-      // Minimum image convention (hoisted reciprocals)
-      dx -= box[0] * std::floor(dx * invBox0 + 0.5);
-      dy -= box[4] * std::floor(dy * invBox4 + 0.5);
-      dz -= box[8] * std::floor(dz * invBox8 + 0.5);
-
-      double r2 = dx * dx + dy * dy + dz * dz;
-
-      // r^2 cutoff avoids sqrt for pairs outside cutoff
-      if (r2 < cutoff2) {
-        // Compute (sigma/r)^6 without pow(): sr2^3
-        double invR2 = 1.0 / r2;
-        double sr2 = psi2 * invR2;
-        double sr6 = sr2 * sr2 * sr2;
-        double e = 4.0 * u0 * sr6;
-
-        *U += e * (sr6 - 1.0) - cuttOffU;
-
-        // Force: -dU/dr * (1/r) * dr_vec = fscale * dr_vec
-        double fscale = 6.0 * e * invR2 * (2.0 * sr6 - 1.0);
-        double fx = fscale * dx;
-        double fy = fscale * dy;
-        double fz = fscale * dz;
-
-        F[3 * i] += fx;
-        F[3 * i + 1] += fy;
-        F[3 * i + 2] += fz;
-        F[3 * j] -= fx;
-        F[3 * j + 1] -= fy;
-        F[3 * j + 2] -= fz;
-      }
+  for (std::size_t p = 0; p < nl.size(); ++p) {
+    const long i = static_cast<long>(nl.i(p));
+    const long j = static_cast<long>(nl.j(p));
+    if (i == j) {
+      continue;
     }
+    const double r = nl.distance(p);
+    if (r <= 0.0) {
+      continue;
+    }
+    const double r2 = r * r;
+    const double invR2 = 1.0 / r2;
+    // vesin vector is r_j - r_i; LJ force uses r_i - r_j
+    const double *v = nl.vector(p);
+    const double dx = -v[0];
+    const double dy = -v[1];
+    const double dz = -v[2];
+
+    const double sr2 = psi2 * invR2;
+    const double sr6 = sr2 * sr2 * sr2;
+    const double e = 4.0 * u0 * sr6;
+    *U += e * (sr6 - 1.0) - cuttOffU;
+
+    const double fscale = 6.0 * e * invR2 * (2.0 * sr6 - 1.0);
+    const double fx = fscale * dx;
+    const double fy = fscale * dy;
+    const double fz = fscale * dz;
+
+    F[3 * i] += fx;
+    F[3 * i + 1] += fy;
+    F[3 * i + 2] += fz;
+    F[3 * j] -= fx;
+    F[3 * j + 1] -= fy;
+    F[3 * j + 2] -= fz;
   }
 }

--- a/client/potentials/LJCluster/LJCluster.cpp
+++ b/client/potentials/LJCluster/LJCluster.cpp
@@ -40,7 +40,8 @@ void LJCluster::force(long N, const double *R, const int * /*atomicNrs*/,
     return;
   }
 
-  // Cluster: free boundary (no PBC). Large cutoff if cuttOffR unused historically.
+  // Cluster: free boundary (no PBC). Large cutoff if cuttOffR unused
+  // historically.
   eonc::VesinNeighbors nl;
   eonc::VesinNeighbors::Options opt;
   opt.cutoff = (cuttOffR > 0.0) ? cuttOffR : 1.0e6;

--- a/client/potentials/LJCluster/LJCluster.cpp
+++ b/client/potentials/LJCluster/LJCluster.cpp
@@ -11,16 +11,11 @@
 */
 
 #include "eon/potentials/LJCluster/LJCluster.h"
-
-// LJCluster::LJCluster(double u0Recieved, double cuttOffRRecieved, double
-// psiRecieved){
-//     this->setParameters(u0Recieved, cuttOffRRecieved, psiRecieved);
-//     return;
-// }
+#include "eon/VesinNeighbors.h"
+#include <cmath>
 
 void LJCluster::cleanMemory(void) { return; }
 
-// General Functions
 void LJCluster::setParameters(double u0Recieved, double cuttOffRRecieved,
                               double psiRecieved) {
   u0 = u0Recieved;
@@ -31,52 +26,60 @@ void LJCluster::setParameters(double u0Recieved, double cuttOffRRecieved,
   return;
 }
 
-// pointer to number of atoms, pointer to array of positions
-// pointer to array of forces, pointer to internal energy
-// adress to supercell size
-void LJCluster::force(long N, const double *R, const int *atomicNrs, double *F,
-                      double *U, double *variance, const double *box) {
+void LJCluster::force(long N, const double *R, const int * /*atomicNrs*/,
+                      double *F, double *U, double *variance,
+                      const double *box) {
   variance = nullptr;
-  double diffR = 0, diffRX, diffRY, diffRZ, dU, a, b;
   *U = 0;
   for (int i = 0; i < N; i++) {
     F[3 * i] = 0;
     F[3 * i + 1] = 0;
     F[3 * i + 2] = 0;
   }
-  // Initializing end
-
-  for (int i = 0; i < N - 1; i++) {
-    for (int j = i + 1; j < N; j++) {
-      diffRX = R[3 * i] - R[3 * j];
-      diffRY = R[3 * i + 1] - R[3 * j + 1];
-      diffRZ = R[3 * i + 2] - R[3 * j + 2];
-
-      // diffRX = diffRX-box[0]*floor(diffRX/box[0]+0.5); // floor = largest
-      // integer value less than argument diffRY =
-      // diffRY-box[4]*floor(diffRY/box[4]+0.5); diffRZ =
-      // diffRZ-box[8]*floor(diffRZ/box[8]+0.5);
-
-      diffR = sqrt(diffRX * diffRX + diffRY * diffRY + diffRZ * diffRZ);
-
-      // 4u0((psi/r0)^12-(psi/r0)^6)
-      a = pow(psi / diffR, 6);
-      b = 4 * u0 * a;
-
-      *U = *U + b * (a - 1);
-
-      dU = -6 * b / diffR * (2 * a - 1);
-      // F is the negative derivative
-      F[3 * i] = F[3 * i] - dU * diffRX / diffR;
-      F[3 * i + 1] = F[3 * i + 1] - dU * diffRY / diffR;
-      F[3 * i + 2] = F[3 * i + 2] - dU * diffRZ / diffR;
-
-      F[3 * j] = F[3 * j] + dU * diffRX / diffR;
-      F[3 * j + 1] = F[3 * j + 1] + dU * diffRY / diffR;
-      F[3 * j + 2] = F[3 * j + 2] + dU * diffRZ / diffR;
-    }
+  if (N < 2) {
+    return;
   }
-  return;
+
+  // Cluster: free boundary (no PBC). Large cutoff if cuttOffR unused historically.
+  eonc::VesinNeighbors nl;
+  eonc::VesinNeighbors::Options opt;
+  opt.cutoff = (cuttOffR > 0.0) ? cuttOffR : 1.0e6;
+  opt.full = false;
+  opt.return_distances = true;
+  opt.return_vectors = true;
+  opt.periodic = {{false, false, false}};
+  // Dummy orthorhombic box (ignored when non-periodic)
+  double free_box[9] = {1e6, 0, 0, 0, 1e6, 0, 0, 0, 1e6};
+  const double *box_use = (box != nullptr) ? box : free_box;
+  nl.compute(R, static_cast<std::size_t>(N), box_use, opt);
+
+  for (std::size_t p = 0; p < nl.size(); ++p) {
+    const int i = static_cast<int>(nl.i(p));
+    const int j = static_cast<int>(nl.j(p));
+    if (i == j) {
+      continue;
+    }
+    const double diffR = nl.distance(p);
+    if (diffR <= 0.0) {
+      continue;
+    }
+    const double *v = nl.vector(p); // r_j - r_i
+    const double diffRX = -v[0];
+    const double diffRY = -v[1];
+    const double diffRZ = -v[2];
+
+    const double a = pow(psi / diffR, 6);
+    const double b = 4 * u0 * a;
+    *U = *U + b * (a - 1) - cuttOffU;
+
+    const double dU = -6 * b / diffR * (2 * a - 1);
+    F[3 * i] = F[3 * i] - dU * diffRX / diffR;
+    F[3 * i + 1] = F[3 * i + 1] - dU * diffRY / diffR;
+    F[3 * i + 2] = F[3 * i + 2] - dU * diffRZ / diffR;
+    F[3 * j] = F[3 * j] + dU * diffRX / diffR;
+    F[3 * j + 1] = F[3 * j + 1] + dU * diffRY / diffR;
+    F[3 * j + 2] = F[3 * j + 2] + dU * diffRZ / diffR;
+  }
 }
 
 LJCluster::~LJCluster() { cleanMemory(); }

--- a/client/potentials/Morse/Morse.cpp
+++ b/client/potentials/Morse/Morse.cpp
@@ -11,13 +11,14 @@
 */
 
 #include "eon/potentials/Morse/Morse.h"
+#include "eon/VesinNeighbors.h"
 #include <cassert>
 #include <cmath>
 
 /** @file
       @brief Morse potential for platinum
       @author Anonymous (possibly A. Pedersen or G. Henkelman), revision: Jean
-   Claude C. Berthet
+      Claude C. Berthet
       @date Unknown, revision: 2010, University of Iceland
       */
 
@@ -39,12 +40,18 @@ void Morse::force(long N, const double *R, const int * /*atomicNrs*/, double *F,
   for (long k = 0; k < 3 * N; k++) {
     F[k] = 0.0;
   }
+  if (N < 2 || cutoff_ <= 0.0) {
+    return;
+  }
 
-  // Orthorhombic MIC (box diagonal). Precompute inverses and hot constants.
-  const double invBox0 = 1.0 / box[0];
-  const double invBox4 = 1.0 / box[4];
-  const double invBox8 = 1.0 / box[8];
-  const double cutoff2 = cutoff_ * cutoff_;
+  eonc::VesinNeighbors nl;
+  eonc::VesinNeighbors::Options opt;
+  opt.cutoff = cutoff_;
+  opt.full = false;
+  opt.return_distances = true;
+  opt.return_vectors = true;
+  nl.compute(R, static_cast<std::size_t>(N), box, opt);
+
   const double a = a_;
   const double re = re_;
   const double De = De_;
@@ -52,49 +59,38 @@ void Morse::force(long N, const double *R, const int * /*atomicNrs*/, double *F,
   const double eCut = energyCutoff_;
   double energyAcc = 0.0;
 
-  for (long i = 0; i < N; i++) {
-    const double xi = R[3 * i];
-    const double yi = R[3 * i + 1];
-    const double zi = R[3 * i + 2];
-    double *Fi = F + 3 * i;
-
-    for (long j = i + 1; j < N; j++) {
-      double dx = xi - R[3 * j];
-      double dy = yi - R[3 * j + 1];
-      double dz = zi - R[3 * j + 2];
-
-      // Minimum image: floor(x+0.5) avoids fmod; branchless on modern CPUs.
-      dx -= box[0] * std::floor(dx * invBox0 + 0.5);
-      dy -= box[4] * std::floor(dy * invBox4 + 0.5);
-      dz -= box[8] * std::floor(dz * invBox8 + 0.5);
-
-      const double r2 = dx * dx + dy * dy + dz * dz;
-      if (r2 >= cutoff2) {
-        continue;
-      }
-
-      const double r = std::sqrt(r2);
-      // Inline morse() to keep the pair loop in one TU for inlining / LTO.
-      const double d = 1.0 - std::exp(-a * (r - re));
-      const double energy = De * d * d - De;
-      const double fmag = twoDeA * d * (d - 1.0);
-
-      energyAcc += energy - eCut;
-
-      // Pair force magnitude along MIC vector (keep /r for bit-stability vs
-      // main)
-      const double fscale = fmag / r;
-      const double fx = fscale * dx;
-      const double fy = fscale * dy;
-      const double fz = fscale * dz;
-
-      Fi[0] += fx;
-      Fi[1] += fy;
-      Fi[2] += fz;
-      F[3 * j] -= fx;
-      F[3 * j + 1] -= fy;
-      F[3 * j + 2] -= fz;
+  for (std::size_t p = 0; p < nl.size(); ++p) {
+    const long i = static_cast<long>(nl.i(p));
+    const long j = static_cast<long>(nl.j(p));
+    if (i == j) {
+      continue;
     }
+    const double r = nl.distance(p);
+    if (r <= 0.0) {
+      continue;
+    }
+    // vesin: r_j - r_i; Morse force used r_i - r_j
+    const double *v = nl.vector(p);
+    const double dx = -v[0];
+    const double dy = -v[1];
+    const double dz = -v[2];
+
+    const double d = 1.0 - std::exp(-a * (r - re));
+    const double energy = De * d * d - De;
+    const double fmag = twoDeA * d * (d - 1.0);
+    energyAcc += energy - eCut;
+
+    const double fscale = fmag / r;
+    const double fx = fscale * dx;
+    const double fy = fscale * dy;
+    const double fz = fscale * dz;
+
+    F[3 * i] += fx;
+    F[3 * i + 1] += fy;
+    F[3 * i + 2] += fz;
+    F[3 * j] -= fx;
+    F[3 * j + 1] -= fy;
+    F[3 * j + 2] -= fz;
   }
   *U = energyAcc;
 }

--- a/client/potentials/QSC/QSC.cpp
+++ b/client/potentials/QSC/QSC.cpp
@@ -17,8 +17,8 @@
 /// embedding = c * epsilon * sqrt(rho). Neighbor pairs via vesin.
 
 #include "eon/potentials/QSC/QSC.h"
-#include "eon/potentials/QSC/Parameters.h"
 #include "eon/VesinNeighbors.h"
+#include "eon/potentials/QSC/Parameters.h"
 
 #include <cassert>
 #include <cmath>

--- a/client/potentials/QSC/QSC.cpp
+++ b/client/potentials/QSC/QSC.cpp
@@ -14,188 +14,132 @@
 /// @brief Quantum Sutton-Chen potential implementation.
 ///
 /// EAM-type potential with density = (a/r)^m, pair = (a/r)^n,
-/// embedding = c * epsilon * sqrt(rho). Uses Verlet neighbor list
-/// for O(N) force evaluation.
+/// embedding = c * epsilon * sqrt(rho). Neighbor pairs via vesin.
 
 #include "eon/potentials/QSC/QSC.h"
 #include "eon/potentials/QSC/Parameters.h"
+#include "eon/VesinNeighbors.h"
 
 #include <cassert>
 #include <cmath>
 #include <cstdio>
-
-void QSC::initialize(long N) {
-  N_ = N;
-  rho_.assign(N, 0.0);
-  sqrtrho_.assign(N, 0.0);
-  nlist_.assign(N, 0);
-  oldR_.assign(3 * N, 0.0);
-  // Flattened N*N arrays
-  distances_.resize(N * N);
-  vlist_.assign(N * N, 0);
-  V_.assign(N * N, 0.0);
-  phi_.assign(N * N, 0.0);
-  init_ = true;
-}
-
-void QSC::new_vlist(long N, const double *R, const double *box) {
-  double rv = cutoff_ + verlet_skin_;
-
-  for (long i = 0; i < N; i++) {
-    nlist_[i] = 0;
-    for (long j = i + 1; j < N; j++) {
-      calc_distance(box, R, i, R, j, &distances_[i * N + j]);
-      if (distances_[i * N + j].r <= rv) {
-        vlist_[i * N + nlist_[i]] = static_cast<int>(j);
-        nlist_[i]++;
-      }
-    }
-  }
-
-  for (long i = 0; i < 3 * N; i++) {
-    oldR_[i] = R[i];
-  }
-  vlist_updates++;
-}
-
-void QSC::update_distances(long N, const double *R, const double *box) {
-  for (long i = 0; i < N; i++) {
-    for (int k = 0; k < nlist_[i]; k++) {
-      int j = vlist_[i * N + k];
-      calc_distance(box, R, i, R, j, &distances_[i * N + j]);
-    }
-  }
-}
-
-bool QSC::verlet_needs_update(long N, const double *R,
-                              const double *box) const {
-  distance diff;
-  double dist_max1 = 0.0;
-  double dist_max2 = 0.0;
-
-  for (long i = 0; i < N; i++) {
-    calc_distance(box, oldR_.data(), i, R, i, &diff);
-    if (diff.r > dist_max1) {
-      dist_max2 = dist_max1;
-      dist_max1 = diff.r;
-    } else if (diff.r > dist_max2) {
-      dist_max2 = diff.r;
-    }
-    if (dist_max1 + dist_max2 > verlet_skin_) {
-      return true;
-    }
-  }
-  return false;
-}
+#include <vector>
 
 void QSC::energy(long N, const double *R, const int *atomicNrs, double *U,
                  const double *box) {
   *U = 0.0;
-  for (long i = 0; i < N; i++) {
-    rho_[i] = 0.0;
+  rho_.assign(static_cast<std::size_t>(N), 0.0);
+  sqrtrho_.assign(static_cast<std::size_t>(N), 0.0);
+  if (N < 2 || cutoff_ <= 0.0) {
+    return;
   }
 
-  int prev_i_Z = -1, prev_j_Z = -1;
+  eonc::VesinNeighbors nl;
+  eonc::VesinNeighbors::Options opt;
+  opt.cutoff = cutoff_;
+  opt.full = false;
+  opt.return_distances = true;
+  opt.return_vectors = false;
+  nl.compute(R, static_cast<std::size_t>(N), box, opt);
+
+  // Half list: accumulate pair V and both density contributions per pair.
+  std::vector<double> pair_term(static_cast<std::size_t>(N), 0.0);
+
+  for (std::size_t p = 0; p < nl.size(); ++p) {
+    const long i = static_cast<long>(nl.i(p));
+    const long j = static_cast<long>(nl.j(p));
+    if (i == j) {
+      continue;
+    }
+    const double r_ij = nl.distance(p);
+    if (r_ij <= 0.0 || r_ij > cutoff_) {
+      continue;
+    }
+
+    const auto p_ii = get_qsc_parameters(atomicNrs[i], atomicNrs[i]);
+    const auto p_ij = get_qsc_parameters(atomicNrs[i], atomicNrs[j]);
+    const auto p_jj = get_qsc_parameters(atomicNrs[j], atomicNrs[j]);
+
+    const double phi_ij = pair_potential(r_ij, p_jj.a, p_jj.m);
+    const double phi_ji = pair_potential(r_ij, p_ii.a, p_ii.m);
+    rho_[static_cast<std::size_t>(i)] += phi_ij;
+    rho_[static_cast<std::size_t>(j)] += phi_ji;
+
+    const double V = p_ij.epsilon * pair_potential(r_ij, p_ij.a, p_ij.n);
+    // Historical half-list assignment put V on the i side only.
+    pair_term[static_cast<std::size_t>(i)] += V;
+  }
+
   for (long i = 0; i < N; i++) {
-    double pair_term = 0.0;
-    qsc_parameters p_ii{};
-
-    if (prev_i_Z != atomicNrs[i]) {
-      p_ii = get_qsc_parameters(atomicNrs[i], atomicNrs[i]);
-    }
-    prev_i_Z = atomicNrs[i];
-
-    for (int k = 0; k < nlist_[i]; k++) {
-      qsc_parameters p_ij{}, p_jj{};
-      int j = vlist_[i * N + k];
-      double r_ij = distances_[i * N + j].r;
-      if (r_ij > cutoff_)
-        continue;
-
-      if (prev_j_Z != atomicNrs[j]) {
-        p_ij = get_qsc_parameters(atomicNrs[i], atomicNrs[j]);
-        p_jj = get_qsc_parameters(atomicNrs[j], atomicNrs[j]);
-      }
-      prev_j_Z = atomicNrs[j];
-
-      // Density contributions
-      phi_[i * N + j] = pair_potential(r_ij, p_jj.a, p_jj.m);
-      rho_[i] += phi_[i * N + j];
-      phi_[j * N + i] = pair_potential(r_ij, p_ii.a, p_ii.m);
-      rho_[j] += phi_[j * N + i];
-
-      // Repulsive pair term
-      V_[i * N + j] = p_ij.epsilon * pair_potential(r_ij, p_ij.a, p_ij.n);
-      pair_term += V_[i * N + j];
-    }
-    sqrtrho_[i] = std::sqrt(rho_[i]);
-    double embedding = p_ii.c * p_ii.epsilon * sqrtrho_[i];
-    *U += pair_term - embedding;
+    const auto p_ii_e = get_qsc_parameters(atomicNrs[i], atomicNrs[i]);
+    sqrtrho_[static_cast<std::size_t>(i)] =
+        std::sqrt(rho_[static_cast<std::size_t>(i)]);
+    const double embedding =
+        p_ii_e.c * p_ii_e.epsilon * sqrtrho_[static_cast<std::size_t>(i)];
+    *U += pair_term[static_cast<std::size_t>(i)] - embedding;
   }
 }
 
 void QSC::force(long N, const double *R, const int *atomicNrs, double *F,
                 double *U, double *variance, const double *box) {
   variance = nullptr;
-  if (!init_) {
-    initialize(N);
-    new_vlist(N, R, box);
-  } else if (N != N_) {
-    initialize(N);
-    new_vlist(N, R, box);
-  } else if (verlet_needs_update(N, R, box)) {
-    new_vlist(N, R, box);
-  } else {
-    update_distances(N, R, box);
-  }
-
   energy(N, R, atomicNrs, U, box);
 
   for (long i = 0; i < 3 * N; i++) {
     F[i] = 0.0;
   }
+  if (N < 2 || cutoff_ <= 0.0) {
+    return;
+  }
 
-  int prev_i_Z = -1, prev_j_Z = -1;
-  for (long i = 0; i < N; i++) {
-    qsc_parameters p_ii{};
-    if (prev_i_Z != atomicNrs[i]) {
-      p_ii = get_qsc_parameters(atomicNrs[i], atomicNrs[i]);
+  eonc::VesinNeighbors nl;
+  eonc::VesinNeighbors::Options opt;
+  opt.cutoff = cutoff_;
+  opt.full = false;
+  opt.return_distances = true;
+  opt.return_vectors = true;
+  nl.compute(R, static_cast<std::size_t>(N), box, opt);
+
+  for (std::size_t p = 0; p < nl.size(); ++p) {
+    const long i = static_cast<long>(nl.i(p));
+    const long j = static_cast<long>(nl.j(p));
+    if (i == j) {
+      continue;
     }
-    prev_i_Z = atomicNrs[i];
-
-    for (int k = 0; k < nlist_[i]; k++) {
-      qsc_parameters p_ij{}, p_jj{};
-      int j = vlist_[i * N + k];
-      double r_ij = distances_[i * N + j].r;
-      if (r_ij > cutoff_)
-        continue;
-
-      if (prev_j_Z != atomicNrs[j]) {
-        p_ij = get_qsc_parameters(atomicNrs[i], atomicNrs[j]);
-        p_jj = get_qsc_parameters(atomicNrs[j], atomicNrs[j]);
-      }
-      prev_j_Z = atomicNrs[j];
-
-      double Fij = p_ij.n * V_[i * N + j];
-      Fij -= p_ii.epsilon * p_ii.c * p_jj.m * 0.5 * (1.0 / sqrtrho_[i]) *
-             phi_[i * N + j];
-      Fij -= p_jj.epsilon * p_jj.c * p_ii.m * 0.5 * (1.0 / sqrtrho_[j]) *
-             phi_[j * N + i];
-      Fij /= r_ij;
-
-      const auto &dist = distances_[i * N + j];
-      double fscale = Fij / r_ij;
-      double fx = fscale * dist.d[0];
-      double fy = fscale * dist.d[1];
-      double fz = fscale * dist.d[2];
-
-      F[3 * i] += fx;
-      F[3 * i + 1] += fy;
-      F[3 * i + 2] += fz;
-      F[3 * j] -= fx;
-      F[3 * j + 1] -= fy;
-      F[3 * j + 2] -= fz;
+    const double r_ij = nl.distance(p);
+    if (r_ij <= 0.0 || r_ij > cutoff_) {
+      continue;
     }
+
+    const auto p_ii = get_qsc_parameters(atomicNrs[i], atomicNrs[i]);
+    const auto p_ij = get_qsc_parameters(atomicNrs[i], atomicNrs[j]);
+    const auto p_jj = get_qsc_parameters(atomicNrs[j], atomicNrs[j]);
+
+    const double phi_ij = pair_potential(r_ij, p_jj.a, p_jj.m);
+    const double phi_ji = pair_potential(r_ij, p_ii.a, p_ii.m);
+    const double V = p_ij.epsilon * pair_potential(r_ij, p_ij.a, p_ij.n);
+
+    // Force magnitude (same form as previous Verlet-based path).
+    double Fij = p_ij.n * V;
+    Fij -= p_ii.epsilon * p_ii.c * p_jj.m * 0.5 *
+           (1.0 / sqrtrho_[static_cast<std::size_t>(i)]) * phi_ij;
+    Fij -= p_jj.epsilon * p_jj.c * p_ii.m * 0.5 *
+           (1.0 / sqrtrho_[static_cast<std::size_t>(j)]) * phi_ji;
+    Fij /= r_ij;
+
+    // Historical distance used d = r_i - r_j; vesin vector is r_j - r_i.
+    const double *v = nl.vector(p);
+    const double fscale = Fij / r_ij;
+    const double fx = fscale * (-v[0]);
+    const double fy = fscale * (-v[1]);
+    const double fz = fscale * (-v[2]);
+
+    F[3 * i] += fx;
+    F[3 * i + 1] += fy;
+    F[3 * i + 2] += fz;
+    F[3 * j] -= fx;
+    F[3 * j + 1] -= fy;
+    F[3 * j + 2] -= fz;
   }
 }
 
@@ -219,26 +163,9 @@ double QSC::pair_potential(double r, double a, double n) {
   return std::pow(x, n);
 }
 
-void QSC::calc_distance(const double *box, const double *R1, int i,
-                        const double *R2, int j, distance *d) const {
-  double dx = R1[3 * i] - R2[3 * j];
-  double dy = R1[3 * i + 1] - R2[3 * j + 1];
-  double dz = R1[3 * i + 2] - R2[3 * j + 2];
-
-  // Orthogonal PBC
-  dx -= box[0] * std::floor(dx / box[0] + 0.5);
-  dy -= box[4] * std::floor(dy / box[4] + 0.5);
-  dz -= box[8] * std::floor(dz / box[8] + 0.5);
-
-  d->r = std::sqrt(dx * dx + dy * dy + dz * dz);
-  d->d[0] = dx;
-  d->d[1] = dy;
-  d->d[2] = dz;
-}
-
 void QSC::set_verlet_skin(double dr) {
   assert(dr > 0.0);
-  verlet_skin_ = dr;
+  (void)dr; // vesin rebuilds every force; skin unused
 }
 
 void QSC::set_cutoff(double c) {
@@ -286,7 +213,6 @@ QSC::qsc_parameters QSC::get_qsc_parameters(int element_a,
   if (ia == ib)
     return qsc_params_[ia];
 
-  // Mixing rules
   return qsc_parameters{
       0,
       0.5 * (qsc_params_[ia].n + qsc_params_[ib].n),

--- a/docs/newsfragments/386.changed.md
+++ b/docs/newsfragments/386.changed.md
@@ -1,4 +1,6 @@
 Classical C++ pair pots (LJ, Morse, LJCluster, QSC) use the shared
 ``eonc::VesinNeighbors`` wrapper for neighbor lists instead of pot-local
 Verlet / O(N^2) loops. Vesin is always linked into ``eoncbase`` so Metatomic
-and classical pots share one NL backend.
+and classical pots share one NL backend. Client wall time continues to be
+tracked by the existing ASV suite (``TimePointMorsePt``,
+``TimeMinimizationLJCluster``, Morse saddle/NEB); see ``benchmarks/README.md``.

--- a/docs/newsfragments/386.changed.md
+++ b/docs/newsfragments/386.changed.md
@@ -1,0 +1,4 @@
+Classical C++ pair pots (LJ, Morse, LJCluster, QSC) use the shared
+``eonc::VesinNeighbors`` wrapper for neighbor lists instead of pot-local
+Verlet / O(N^2) loops. Vesin is always linked into ``eoncbase`` so Metatomic
+and classical pots share one NL backend.

--- a/docs/source/user_guide/index.md
+++ b/docs/source/user_guide/index.md
@@ -22,6 +22,7 @@ package `pyeonclient` — an ASE-shaped API where the path is a
 :caption: Python API
 
 pyeonclient
+neighbor_lists
 ```
 
 See also the [API reference](../apidocs/pyeonclient.md) and the
@@ -73,6 +74,11 @@ mpi.
 Methods run in parallel are broken up by the eon server into tasks which
 are run by client program. The server then compiles the information sent back
 by the clients in a way that can be used by the sampling or dynamics methods.
+
+## Geometry and neighbor lists
+
+Pair finding owned by eOn uses **vesin**. Architecture and **ASV** measurement
+surface: [Neighbor lists (vesin)](neighbor_lists.md).
 
 ## Potentials
 

--- a/docs/source/user_guide/neighbor_lists.md
+++ b/docs/source/user_guide/neighbor_lists.md
@@ -1,0 +1,87 @@
+---
+myst:
+  html_meta:
+    "description": "Neighbor lists in eOn: vesin as the single geometry backend; performance via ASV eonclient benches."
+    "keywords": "eOn, vesin, neighbor list, ASV, Morse, LJ, QSC"
+---
+
+# Neighbor lists (vesin)
+
+eOn uses **[vesin](https://luthaf.fr/vesin/)** as the neighbor-list engine
+wherever the code owns pair finding itself. Do not reintroduce pot-local
+Verlet tables or O(N²) MIC loops for new work.
+
+## Layers
+
+| Layer | API | Backend |
+|-------|-----|---------|
+| Python server geometry | `eon.geometry.neighbors.neighbor_list` | `vesin.NeighborList` |
+| Process-atom shells / displace | `eon.atoms` / `get_process_atoms` | same |
+| Classical C++ pair pots (LJ, Morse, LJCluster, QSC) | `eonc::VesinNeighbors` | `vesin_neighbors` (C) |
+| Metatomic | pot-local call into vesin C | same `libvesin` / vendored TU |
+| External engines (LAMMPS, VASP, ASE, …) | engine-owned | not eOn's NL |
+| Legacy Fortran pots (SW, FeHe, …) | still pot-local | migrate via [vesin Fortran](https://luthaf.fr/vesin/) (`module vesin`) |
+
+## Python
+
+```python
+from eon.geometry import neighbor_list
+nl = neighbor_list(structure, cutoff=4.0)
+```
+
+`brute=True` is API-compat only; the algorithm is always vesin.
+
+## C++
+
+```cpp
+#include "eon/VesinNeighbors.h"
+eonc::VesinNeighbors nl;
+eonc::VesinNeighbors::Options opt{.cutoff = 5.0, .full = false,
+                                  .return_distances = true, .return_vectors = true};
+nl.compute(R, nAtoms, box9, opt);
+```
+
+Vector convention matches vesin: **`r_ij = r_j − r_i + S·H`**.
+`eoncbase` always links vesin (pkg-config / system / vendored).
+
+## How we measure (ASV, not one-off scripts)
+
+Institutional timing is the **existing ASV suite** under `benchmarks/`:
+
+| ASV class | Fixture | Hits vesin-backed pot? |
+|-----------|---------|------------------------|
+| `TimePointMorsePt` | `data/point_morse_pt` | Morse force pairs |
+| `TimeMinimizationLJCluster` | `data/min_lj_cluster` | LJCluster force pairs (many force evals) |
+| `TimeSaddleSearchMorseDimer` | `data/one_pt_saddle_search` | Morse + saddle path |
+| `TimeNEBMorsePt` | `data/neb_morse_pt` | Morse band forces |
+
+Mechanism (already in CI):
+
+1. **PR** — `Benchmark PR` workflow builds `eonclient` on **base SHA** and
+   **head SHA** with the **PR’s** `benchmarks/` tree, runs
+   `asv run --set-commit-hash … --quick`, then asv-perch comments the
+   main→PR comparison.
+2. **main** — `ASV dashboard` restores orphan branch `asv-results`, runs
+   history, publishes with asv-tachyon →
+   [eondocs.org/bench](https://eondocs.org/bench/) /
+   [bench.eondocs.org](https://bench.eondocs.org/).
+
+Local (same as `benchmarks/README.md`):
+
+```bash
+pixi run meson setup bbdir --prefix=$CONDA_PREFIX --libdir=lib --buildtype release
+pixi run meson install -C bbdir
+pixi run bash -c 'pip install asv asv-tachyon'
+pixi run asv machine --yes
+pixi run asv run -E "existing:$(which python)" --quick
+```
+
+To compare a vesin-NL branch to `main` without waiting for GHA: build+install
+both commits’ clients (or sequential install) and use the same ASV class names;
+the PR workflow is the authoritative pair-wise run.
+
+## Not yet unified
+
+Fortran Stillinger–Weber / FeHe / Aluminum / EDIP still build neighbors
+inside `.f`/`.f90`. Upstream vesin provides `fortran/src/vesin.f90`; wire under
+`with_fortran` and port pot generators next.

--- a/docs/source/user_guide/potential.md
+++ b/docs/source/user_guide/potential.md
@@ -58,16 +58,21 @@ EAM_Al
 : Embedded atom method parameterized for Aluminum.
 
 QSC {cite:p}`pot-kimuraQuantumSuttonChenManyBody1998`
-: Quantum Sutton-Chen potential, for FCC metals.
+: Quantum Sutton-Chen potential, for FCC metals. Neighbor pairs via
+  [vesin](neighbor_lists.md) (no pot-local Verlet list).
 
 EMT
 : Effective medium theory, for metals.
 
 LJ {cite:p}`pot-jonesDeterminationMolecularFields1924`
-: Lennard-Jones in reduced units
+: Lennard-Jones in reduced units. Neighbor pairs via
+  [vesin](neighbor_lists.md); timed by ASV
+  `TimeMinimizationLJCluster` (ljcluster).
 
 Morse_Pt
-: Hard sphere morse potential for Platinum
+: Hard sphere morse potential for Platinum. Neighbor pairs via
+  [vesin](neighbor_lists.md); timed by ASV `TimePointMorsePt` /
+  saddle / NEB Morse fixtures.
 
 Lenosky_Si {cite:p}`pot-lenoskyHighlyOptimizedEmpirical2000`
 : Lenosky potential, for silicon.

--- a/include/eon/VesinNeighbors.h
+++ b/include/eon/VesinNeighbors.h
@@ -1,0 +1,88 @@
+/*
+** This file is part of eOn.
+**
+** SPDX-License-Identifier: BSD-3-Clause
+**
+** Shared neighbor lists via vesin (single NL backend for classical pots
+** and Metatomic). Do not reimplement Verlet / link-cell / O(N^2) loops.
+*/
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <stdexcept>
+#include <string>
+
+// Vendored / system vesin C API
+#include "vesin.h"
+
+namespace eonc {
+
+/// RAII wrapper around ``vesin_neighbors`` for Matter-style boxes
+/// (``double[9]`` row-major 3×3 cell, same layout as ``Matter::cell``).
+///
+/// Pair vector convention matches vesin: ``r_ij = r_j - r_i + S @ H``.
+/// Classical pair pots that used ``r_i - r_j`` must flip the sign.
+class VesinNeighbors {
+public:
+  struct Options {
+    double cutoff{0.0};
+    bool full{false}; ///< true: both i→j and j→i; false: half list
+    bool sorted{false};
+    bool return_shifts{false};
+    bool return_distances{true};
+    bool return_vectors{true};
+    std::array<bool, 3> periodic{{true, true, true}};
+  };
+
+  VesinNeighbors() = default;
+  VesinNeighbors(const VesinNeighbors &) = delete;
+  VesinNeighbors &operator=(const VesinNeighbors &) = delete;
+  VesinNeighbors(VesinNeighbors &&other) noexcept;
+  VesinNeighbors &operator=(VesinNeighbors &&other) noexcept;
+  ~VesinNeighbors();
+
+  /// Build / rebuild the list. ``R`` is length ``3*n`` (x,y,z interleaved);
+  /// ``box`` is length 9 (row-major cell vectors).
+  void compute(const double *R, std::size_t n, const double *box,
+               const Options &opt);
+
+  [[nodiscard]] std::size_t size() const { return list_.length; }
+
+  [[nodiscard]] std::size_t i(std::size_t p) const {
+    return list_.pairs[p][0];
+  }
+  [[nodiscard]] std::size_t j(std::size_t p) const {
+    return list_.pairs[p][1];
+  }
+
+  /// Distance |r_ij| (requires ``return_distances``).
+  [[nodiscard]] double distance(std::size_t p) const {
+    return list_.distances[p];
+  }
+
+  /// Vector r_j − r_i (+ PBC). Requires ``return_vectors``.
+  [[nodiscard]] const double *vector(std::size_t p) const {
+    return list_.vectors[p];
+  }
+
+  [[nodiscard]] const int32_t *shift(std::size_t p) const {
+    return list_.shifts[p];
+  }
+
+  /// Raw list for advanced consumers (Metatomic tensor conversion).
+  [[nodiscard]] const VesinNeighborList &raw() const { return list_; }
+  [[nodiscard]] VesinNeighborList &raw() { return list_; }
+
+  /// Steal ownership of the internal list (for Metatomic custom deleters).
+  /// After release, this object is empty until the next ``compute``.
+  VesinNeighborList *release();
+
+private:
+  VesinNeighborList list_{};
+  bool owns_{false};
+
+  void free_list();
+};
+
+} // namespace eonc

--- a/include/eon/VesinNeighbors.h
+++ b/include/eon/VesinNeighbors.h
@@ -49,12 +49,8 @@ public:
 
   [[nodiscard]] std::size_t size() const { return list_.length; }
 
-  [[nodiscard]] std::size_t i(std::size_t p) const {
-    return list_.pairs[p][0];
-  }
-  [[nodiscard]] std::size_t j(std::size_t p) const {
-    return list_.pairs[p][1];
-  }
+  [[nodiscard]] std::size_t i(std::size_t p) const { return list_.pairs[p][0]; }
+  [[nodiscard]] std::size_t j(std::size_t p) const { return list_.pairs[p][1]; }
 
   /// Distance |r_ij| (requires ``return_distances``).
   [[nodiscard]] double distance(std::size_t p) const {

--- a/include/eon/potentials/QSC/QSC.h
+++ b/include/eon/potentials/QSC/QSC.h
@@ -21,6 +21,9 @@
 ///   F_i(rho_i) = c * sqrt(rho_i)
 ///   rho_i = sum_(j!=i) (a/r_ij)^m
 ///   V(r_ij) = (a/r_ij)^n
+///
+/// Neighbor pairs come from vesin (``eonc::VesinNeighbors``), not a pot-local
+/// Verlet list.
 class QSC
 #ifndef QSC_STANDALONE
     : public Potential
@@ -41,12 +44,14 @@ public:
 
   void force(long N, const double *R, const int *atomicNrs, double *F,
              double *U, double *variance, const double *box) override;
+  /// Kept for API compatibility; vesin rebuilds every force call.
   void set_verlet_skin(double dr);
   void set_cutoff(double c);
   [[nodiscard]] double get_cutoff() const;
   void set_qsc_parameter(int Z, double n, double m, double epsilon, double c,
                          double a);
 
+  /// Historical counter (always 0 with vesin path; no separate list rebuild).
   long vlist_updates{0};
 
 private:
@@ -59,35 +64,13 @@ private:
     double a;
   };
 
-  struct distance {
-    double d[3];
-    double r;
-  };
-
-  bool init_{false};
-  long N_{0};
   double cutoff_{8.0};
-  double verlet_skin_{0.5};
 
-  // Flattened N*N 2D arrays (row-major)
-  std::vector<distance> distances_; // [N*N]
-  std::vector<int> vlist_;          // [N*N] neighbor indices
-  std::vector<int> nlist_;          // [N] neighbor counts
-  std::vector<double> oldR_;        // [3*N]
-  std::vector<double> rho_;         // [N]
-  std::vector<double> sqrtrho_;     // [N]
-  std::vector<double> V_;           // [N*N]
-  std::vector<double> phi_;         // [N*N]
+  std::vector<double> rho_;     // [N]
+  std::vector<double> sqrtrho_; // [N]
 
-  void initialize(long N);
   void energy(long N, const double *R, const int *atomicNrs, double *U,
               const double *box);
-  void new_vlist(long N, const double *R, const double *box);
-  void update_distances(long N, const double *R, const double *box);
-  [[nodiscard]] bool verlet_needs_update(long N, const double *R,
-                                         const double *box) const;
-  void calc_distance(const double *box, const double *R1, int i,
-                     const double *R2, int j, distance *d) const;
 
   static const qsc_parameters qsc_default_params[];
   std::vector<qsc_parameters> qsc_params_;

--- a/include/eon/potentials/QSC/QSC.h
+++ b/include/eon/potentials/QSC/QSC.h
@@ -30,16 +30,14 @@ class QSC
 #endif
 {
 public:
-  explicit QSC(const Parameters &params)
-      : Potential(PotType::QSC, params) {
+  explicit QSC(const Parameters &params) : Potential(PotType::QSC, params) {
     int i = 0;
     while (qsc_default_params[i].Z != -1) {
       qsc_params_.push_back(qsc_default_params[i]);
       i++;
     }
   }
-  QSC()
-      : QSC(Parameters{}) {}
+  QSC() : QSC(Parameters{}) {}
   ~QSC() override = default;
 
   void force(long N, const double *R, const int *atomicNrs, double *F,


### PR DESCRIPTION
## Summary

We already integrate vesin for Python geometry and Metatomic. Classical C++ pair pots still shipped their own neighbor machinery (O(N²) MIC for LJ/Morse, Verlet for QSC). This PR:

- Adds **`eonc::VesinNeighbors`** (RAII over `vesin_neighbors`) in `eoncbase`
- **Always links vesin** (pkg-config / system / vendored `thirdparty/vesin`)
- Ports **LJ, Morse, LJCluster, QSC** force evaluation to that helper
- Leaves Fortran pots, EMT/ASAP, and external engines (LAMMPS/VASP/…) alone

Python server path was already vesin-only (`eon.geometry.neighbors`).

## Terra smoke

- `VesinNeighbors.cpp`, `libvesin_internal`, `libeoncbase`, `liblennard_jones`, `libmorse`, `liblennard_jones_cluster` link clean
- `QSC.cpp` compiles against the helper
- Full `eonclib` link blocked on this host by pre-existing `nlohmann/json` include path in the lean env (unrelated)

## Test plan

- [x] Compile/link classical pot plugins + eoncbase on rg.terra
- [ ] CI Build basic eon
- [ ] Spot-check LJ/Morse unit / job tests if present