### PR TITLE
fix(lammps): worker survives bad geometry; process-search endpoint report

### DIFF
--- a/client/ProcessSearchJob.cpp
+++ b/client/ProcessSearchJob.cpp
@@ -247,13 +247,12 @@ int ProcessSearchJob::doProcessSearch() {
     // stopped just outside the state-identity tolerance or relaxed into a
     // different state entirely calls for opposite fixes, and the status
     // alone does not distinguish them.
-    const double tol =
-        params.structure_comparison_options.distance_difference;
+    const double tol = params.structure_comparison_options.distance_difference;
     auto countMoved = [&](const Matter &m) {
       long moved = 0;
       for (long i = 0; i < initial->numberOfAtoms(); ++i) {
-        if (initial->pbc(initial->getPositions().row(i) -
-                         m.getPositions().row(i))
+        if (initial
+                ->pbc(initial->getPositions().row(i) - m.getPositions().row(i))
                 .norm() > tol) {
           ++moved;
         }

--- a/client/ProcessSearchJob.cpp
+++ b/client/ProcessSearchJob.cpp
@@ -243,7 +243,28 @@ int ProcessSearchJob::doProcessSearch() {
   }
 
   if (!initial->compare(*min1)) {
-    QUILL_LOG_DEBUG(log, "initial != min1");
+    // Report how far off the endpoint landed. Whether the minimisation
+    // stopped just outside the state-identity tolerance or relaxed into a
+    // different state entirely calls for opposite fixes, and the status
+    // alone does not distinguish them.
+    const double tol =
+        params.structure_comparison_options.distance_difference;
+    auto countMoved = [&](const Matter &m) {
+      long moved = 0;
+      for (long i = 0; i < initial->numberOfAtoms(); ++i) {
+        if (initial->pbc(initial->getPositions().row(i) -
+                         m.getPositions().row(i))
+                .norm() > tol) {
+          ++moved;
+        }
+      }
+      return moved;
+    };
+    QUILL_LOG_INFO(log,
+                   "initial != min1: {} of {} atoms past the {} A tolerance "
+                   "for min1 ({} for min2); largest separation {} A",
+                   countMoved(*min1), initial->numberOfAtoms(), tol,
+                   countMoved(*min2), initial->perAtomNorm(*min1));
     return MinModeSaddleSearch::STATUS_BAD_NOT_CONNECTED;
   }
 

--- a/client/potentials/LAMMPS/LAMMPSPot.cpp
+++ b/client/potentials/LAMMPS/LAMMPSPot.cpp
@@ -74,6 +74,25 @@ void LAMMPSPot::cleanMemory() {
 // Process-per-image worker plumbing (POSIX only)
 // ---------------------------------------------------------------------------
 namespace {
+// Report a geometry the worker could not evaluate as an impassable wall.
+//
+// Every failure path here used to throw, and nothing between the potential
+// call and main catches it, so the client terminated. That loses the whole
+// job, including searches that had already converged: a copper V/SIA search
+// reached a saddle at 0.082 eV with a force of 0.027 eV/A and a curvature of
+// -0.47, then died on the next evaluation before the result was written.
+//
+// A large finite energy with zeroed forces reads to the optimiser as a wall,
+// so it backs out of the step and the search abandons this configuration and
+// carries on. Callers stop the worker first; ensureWorker respawns it on the
+// next evaluation.
+void rejectGeometry(double *U, double *F, long N) {
+  *U = 1.0e6;
+  for (long i = 0; i < 3 * N; ++i) {
+    F[i] = 0.0;
+  }
+}
+
 // Blocking read/write of exactly n bytes over a pipe.  Returns false on EOF or
 // error, so a dead peer is detected rather than silently producing garbage.
 bool readExact(int fd, void *buf, size_t n) {
@@ -254,20 +273,22 @@ void LAMMPSPot::force(long N, const double *R, const int *atomicNrs, double *F,
         kill(workerPid, SIGKILL);
       }
       stopWorker();
-      throw std::runtime_error(
-          "LAMMPSPot: worker force eval timed out; killed (eon-7416)");
+      rejectGeometry(U, F, N);
+      return;
     }
   }
   int status = 0;
   if (!readExact(resFd, &status, sizeof(status)) ||
       !readExact(resFd, U, sizeof(double)) ||
       !readExact(resFd, F, sizeof(double) * static_cast<size_t>(3 * N))) {
-    throw std::runtime_error(
-        "LAMMPSPot: worker process died during force eval");
+    stopWorker();
+    rejectGeometry(U, F, N);
+    return;
   }
   if (status != 0) {
-    throw std::runtime_error(
-        "LAMMPSPot: worker reported a force evaluation error");
+    stopWorker();
+    rejectGeometry(U, F, N);
+    return;
   }
   // A saddle search that never terminates silently truncates the event
   // table: the KMC residence time is 1/sum_j k_j over the discovered
@@ -292,10 +313,7 @@ void LAMMPSPot::force(long N, const double *R, const int *atomicNrs, double *F,
     nonfinite = !std::isfinite(F[i]);
   }
   if (nonfinite) {
-    *U = 1.0e6;
-    for (long i = 0; i < 3 * N; ++i) {
-      F[i] = 0.0;
-    }
+    rejectGeometry(U, F, N);
   }
 #endif
 }

--- a/client/potentials/LAMMPS/LAMMPSPot.cpp
+++ b/client/potentials/LAMMPS/LAMMPSPot.cpp
@@ -10,6 +10,7 @@
 ** https://github.com/TheochemUI/eOn
 */
 #include "eon/potentials/LAMMPS/LAMMPSPot.h"
+#include "eon/EonLogger.h"
 #include "eon/fpe_handler.h"
 #include "eon/potentials/LAMMPS/LammpsLoader.h"
 
@@ -282,6 +283,7 @@ void LAMMPSPot::force(long N, const double *R, const int *atomicNrs, double *F,
   // Drive the dedicated worker process so this image's LAMMPS runs in its own
   // process (own MPI_COMM_WORLD).  Per-image NEB threads thus evaluate forces
   // as truly concurrent processes with no shared-communicator contention.
+  std::lock_guard<std::mutex> workerLock(workerMutex);
   if (workerRespawnsLeft <= 0) {
     rejectGeometry(U, F, N);
     return;
@@ -296,6 +298,8 @@ void LAMMPSPot::force(long N, const double *R, const int *atomicNrs, double *F,
     // pipe closed, so the first send after it fails. Respawning happens on
     // the next evaluation; reject this one rather than end the client.
     --workerRespawnsLeft;
+    EONC_LOG_WARNING("[LAMMPSPot] send to worker failed; {} respawns left "
+                     "(eon-7416)", workerRespawnsLeft);
     stopWorker();
     rejectGeometry(U, F, N);
     return;
@@ -318,6 +322,8 @@ void LAMMPSPot::force(long N, const double *R, const int *atomicNrs, double *F,
         kill(workerPid, SIGKILL);
       }
       --workerRespawnsLeft;
+      EONC_LOG_WARNING("[LAMMPSPot] worker force eval timed out; {} respawns left "
+                       "(eon-7416)", workerRespawnsLeft);
       stopWorker();
       rejectGeometry(U, F, N);
       return;
@@ -328,12 +334,16 @@ void LAMMPSPot::force(long N, const double *R, const int *atomicNrs, double *F,
       !readExact(resFd, U, sizeof(double)) ||
       !readExact(resFd, F, sizeof(double) * static_cast<size_t>(3 * N))) {
     --workerRespawnsLeft;
+    EONC_LOG_WARNING("[LAMMPSPot] worker died during force eval; {} respawns left "
+                     "(eon-7416)", workerRespawnsLeft);
     stopWorker();
     rejectGeometry(U, F, N);
     return;
   }
   if (status != 0) {
     --workerRespawnsLeft;
+    EONC_LOG_WARNING("[LAMMPSPot] worker reported an evaluation error; {} respawns left "
+                     "(eon-7416)", workerRespawnsLeft);
     stopWorker();
     rejectGeometry(U, F, N);
     return;
@@ -361,6 +371,8 @@ void LAMMPSPot::force(long N, const double *R, const int *atomicNrs, double *F,
     nonfinite = !std::isfinite(F[i]);
   }
   if (nonfinite) {
+    EONC_LOG_WARNING("[LAMMPSPot] non-finite force or energy; rejecting "
+                     "geometry (eon-7416)");
     rejectGeometry(U, F, N);
   }
 #endif

--- a/client/potentials/LAMMPS/LAMMPSPot.cpp
+++ b/client/potentials/LAMMPS/LAMMPSPot.cpp
@@ -281,14 +281,20 @@ void LAMMPSPot::force(long N, const double *R, const int *atomicNrs, double *F,
   // rather than crashing. The min-mode search then spins on non-finite
   // gradients until the akmc pass times out (0 processes). Reject the
   // evaluation so the search discards that displacement and continues.
-  if (!std::isfinite(*U)) {
-    throw std::runtime_error(
-        "LAMMPSPot: non-finite energy from worker (eon-7416)");
+  // Reject the geometry, not the process. Nothing between this call and
+  // main catches a throw here, so the client terminates: a search that was
+  // making progress is lost, and every other search sharing the pass goes
+  // with it. A large finite energy with zeroed forces reads to the
+  // optimiser as an impassable wall, so it backs out of the step and the
+  // search abandons this configuration and carries on.
+  bool nonfinite = !std::isfinite(*U);
+  for (long i = 0; i < 3 * N && !nonfinite; ++i) {
+    nonfinite = !std::isfinite(F[i]);
   }
-  for (long i = 0; i < 3 * N; ++i) {
-    if (!std::isfinite(F[i])) {
-      throw std::runtime_error(
-          "LAMMPSPot: non-finite force from worker (eon-7416)");
+  if (nonfinite) {
+    *U = 1.0e6;
+    for (long i = 0; i < 3 * N; ++i) {
+      F[i] = 0.0;
     }
   }
 #endif

--- a/client/potentials/LAMMPS/LAMMPSPot.cpp
+++ b/client/potentials/LAMMPS/LAMMPSPot.cpp
@@ -299,7 +299,8 @@ void LAMMPSPot::force(long N, const double *R, const int *atomicNrs, double *F,
     // the next evaluation; reject this one rather than end the client.
     --workerRespawnsLeft;
     EONC_LOG_WARNING("[LAMMPSPot] send to worker failed; {} respawns left "
-                     "(eon-7416)", workerRespawnsLeft);
+                     "(eon-7416)",
+                     workerRespawnsLeft);
     stopWorker();
     rejectGeometry(U, F, N);
     return;
@@ -322,8 +323,10 @@ void LAMMPSPot::force(long N, const double *R, const int *atomicNrs, double *F,
         kill(workerPid, SIGKILL);
       }
       --workerRespawnsLeft;
-      EONC_LOG_WARNING("[LAMMPSPot] worker force eval timed out; {} respawns left "
-                       "(eon-7416)", workerRespawnsLeft);
+      EONC_LOG_WARNING(
+          "[LAMMPSPot] worker force eval timed out; {} respawns left "
+          "(eon-7416)",
+          workerRespawnsLeft);
       stopWorker();
       rejectGeometry(U, F, N);
       return;
@@ -334,16 +337,20 @@ void LAMMPSPot::force(long N, const double *R, const int *atomicNrs, double *F,
       !readExact(resFd, U, sizeof(double)) ||
       !readExact(resFd, F, sizeof(double) * static_cast<size_t>(3 * N))) {
     --workerRespawnsLeft;
-    EONC_LOG_WARNING("[LAMMPSPot] worker died during force eval; {} respawns left "
-                     "(eon-7416)", workerRespawnsLeft);
+    EONC_LOG_WARNING(
+        "[LAMMPSPot] worker died during force eval; {} respawns left "
+        "(eon-7416)",
+        workerRespawnsLeft);
     stopWorker();
     rejectGeometry(U, F, N);
     return;
   }
   if (status != 0) {
     --workerRespawnsLeft;
-    EONC_LOG_WARNING("[LAMMPSPot] worker reported an evaluation error; {} respawns left "
-                     "(eon-7416)", workerRespawnsLeft);
+    EONC_LOG_WARNING(
+        "[LAMMPSPot] worker reported an evaluation error; {} respawns left "
+        "(eon-7416)",
+        workerRespawnsLeft);
     stopWorker();
     rejectGeometry(U, F, N);
     return;

--- a/client/potentials/LAMMPS/LAMMPSPot.cpp
+++ b/client/potentials/LAMMPS/LAMMPSPot.cpp
@@ -88,8 +88,19 @@ namespace {
 // next evaluation.
 void rejectGeometry(double *U, double *F, long N) {
   *U = 1.0e6;
+  // Zero forces would be read as convergence: an optimiser judges a point
+  // converged on force magnitude alone, so a rejected geometry with no force
+  // is accepted as a minimum and the wall energy is recorded as that
+  // minimum's energy. It then reaches the barrier as E_saddle - 1e6, which
+  // eOn reports as a negative barrier and discards -- a real 0.062 eV copper
+  // saddle was lost exactly this way. Return a force far above any
+  // convergence threshold so the point can never be mistaken for a
+  // stationary one, alternating its sign so the frame gains no net force.
   for (long i = 0; i < 3 * N; ++i) {
     F[i] = 0.0;
+  }
+  for (long i = 0; i < N; ++i) {
+    F[3 * i] = (i % 2 == 0) ? 1.0 : -1.0;
   }
 }
 

--- a/client/potentials/LAMMPS/LAMMPSPot.cpp
+++ b/client/potentials/LAMMPS/LAMMPSPot.cpp
@@ -253,7 +253,12 @@ void LAMMPSPot::force(long N, const double *R, const int *atomicNrs, double *F,
       !writeExact(reqFd, atomicNrs, sizeof(int) * static_cast<size_t>(N)) ||
       !writeExact(reqFd, box, sizeof(double) * 9) ||
       !writeExact(reqFd, R, sizeof(double) * static_cast<size_t>(3 * N))) {
-    throw std::runtime_error("LAMMPSPot: failed to send request to worker");
+    // A worker stopped by an earlier rejected geometry leaves the request
+    // pipe closed, so the first send after it fails. Respawning happens on
+    // the next evaluation; reject this one rather than end the client.
+    stopWorker();
+    rejectGeometry(U, F, N);
+    return;
   }
 
   // eon-7416: a worker stuck on a pathological geometry (LAMMPS spinning, or

--- a/client/potentials/LAMMPS/LAMMPSPot.cpp
+++ b/client/potentials/LAMMPS/LAMMPSPot.cpp
@@ -226,8 +226,24 @@ void LAMMPSPot::stopWorker() {
     resFd = -1;
   }
   if (workerPid > 0) {
+    // A wedged worker never acts on the sentinel or the closed pipe, and an
+    // unconditional wait then blocks the client forever at no CPU cost -- the
+    // hang this teardown exists to avoid. Give the child a brief chance to
+    // exit on its own, then insist.
     int st = 0;
-    waitpid(workerPid, &st, 0);
+    bool reaped = false;
+    for (int i = 0; i < 100; ++i) { // up to ~1 s
+      pid_t r = waitpid(workerPid, &st, WNOHANG);
+      if (r == workerPid || r < 0) {
+        reaped = true;
+        break;
+      }
+      usleep(10000);
+    }
+    if (!reaped) {
+      kill(workerPid, SIGKILL);
+      waitpid(workerPid, &st, 0);
+    }
     workerPid = -1;
   }
   workerSpawned = false;
@@ -247,6 +263,10 @@ void LAMMPSPot::force(long N, const double *R, const int *atomicNrs, double *F,
   // Drive the dedicated worker process so this image's LAMMPS runs in its own
   // process (own MPI_COMM_WORLD).  Per-image NEB threads thus evaluate forces
   // as truly concurrent processes with no shared-communicator contention.
+  if (workerFailed) {
+    rejectGeometry(U, F, N);
+    return;
+  }
   ensureWorker();
 
   if (!writeExact(reqFd, &N, sizeof(N)) ||
@@ -256,6 +276,7 @@ void LAMMPSPot::force(long N, const double *R, const int *atomicNrs, double *F,
     // A worker stopped by an earlier rejected geometry leaves the request
     // pipe closed, so the first send after it fails. Respawning happens on
     // the next evaluation; reject this one rather than end the client.
+    workerFailed = true;
     stopWorker();
     rejectGeometry(U, F, N);
     return;
@@ -277,6 +298,7 @@ void LAMMPSPot::force(long N, const double *R, const int *atomicNrs, double *F,
       if (workerPid > 0) {
         kill(workerPid, SIGKILL);
       }
+      workerFailed = true;
       stopWorker();
       rejectGeometry(U, F, N);
       return;
@@ -286,11 +308,13 @@ void LAMMPSPot::force(long N, const double *R, const int *atomicNrs, double *F,
   if (!readExact(resFd, &status, sizeof(status)) ||
       !readExact(resFd, U, sizeof(double)) ||
       !readExact(resFd, F, sizeof(double) * static_cast<size_t>(3 * N))) {
+    workerFailed = true;
     stopWorker();
     rejectGeometry(U, F, N);
     return;
   }
   if (status != 0) {
+    workerFailed = true;
     stopWorker();
     rejectGeometry(U, F, N);
     return;

--- a/client/potentials/LAMMPS/LAMMPSPot.cpp
+++ b/client/potentials/LAMMPS/LAMMPSPot.cpp
@@ -274,7 +274,7 @@ void LAMMPSPot::force(long N, const double *R, const int *atomicNrs, double *F,
   // Drive the dedicated worker process so this image's LAMMPS runs in its own
   // process (own MPI_COMM_WORLD).  Per-image NEB threads thus evaluate forces
   // as truly concurrent processes with no shared-communicator contention.
-  if (workerFailed) {
+  if (workerRespawnsLeft <= 0) {
     rejectGeometry(U, F, N);
     return;
   }
@@ -287,7 +287,7 @@ void LAMMPSPot::force(long N, const double *R, const int *atomicNrs, double *F,
     // A worker stopped by an earlier rejected geometry leaves the request
     // pipe closed, so the first send after it fails. Respawning happens on
     // the next evaluation; reject this one rather than end the client.
-    workerFailed = true;
+    --workerRespawnsLeft;
     stopWorker();
     rejectGeometry(U, F, N);
     return;
@@ -309,7 +309,7 @@ void LAMMPSPot::force(long N, const double *R, const int *atomicNrs, double *F,
       if (workerPid > 0) {
         kill(workerPid, SIGKILL);
       }
-      workerFailed = true;
+      --workerRespawnsLeft;
       stopWorker();
       rejectGeometry(U, F, N);
       return;
@@ -319,13 +319,13 @@ void LAMMPSPot::force(long N, const double *R, const int *atomicNrs, double *F,
   if (!readExact(resFd, &status, sizeof(status)) ||
       !readExact(resFd, U, sizeof(double)) ||
       !readExact(resFd, F, sizeof(double) * static_cast<size_t>(3 * N))) {
-    workerFailed = true;
+    --workerRespawnsLeft;
     stopWorker();
     rejectGeometry(U, F, N);
     return;
   }
   if (status != 0) {
-    workerFailed = true;
+    --workerRespawnsLeft;
     stopWorker();
     rejectGeometry(U, F, N);
     return;

--- a/client/potentials/LAMMPS/LAMMPSPot.cpp
+++ b/client/potentials/LAMMPS/LAMMPSPot.cpp
@@ -172,6 +172,14 @@ void LAMMPSPot::ensureWorker() {
   }
 
   // Parent: keep reqPipe write end and resPipe read end.
+  //
+  // Writing to a worker that has already exited raises SIGPIPE, whose default
+  // action kills the client outright -- before writeExact can return the
+  // error the caller is written to handle. A search that had converged on a
+  // saddle at 0.062 eV died this way with signal 13 as its endpoints were
+  // about to be minimised. Ignoring it turns the same condition into an
+  // EPIPE return, which reaches the geometry-rejection path and respawns.
+  std::signal(SIGPIPE, SIG_IGN);
   close(reqPipe[0]);
   close(resPipe[1]);
   reqFd = reqPipe[1];

--- a/docs/newsfragments/387.fixed.md
+++ b/docs/newsfragments/387.fixed.md
@@ -1,0 +1,4 @@
+LAMMPS worker path survives a bad geometry: non-finite or failed evaluations
+reject the structure without ending the client, with bounded respawns,
+SIGPIPE ignored on the pipe, serialised concurrent exchanges, and process
+search reporting of how far a rejected endpoint landed from the reactant.

--- a/include/eon/potentials/LAMMPS/LAMMPSPot.h
+++ b/include/eon/potentials/LAMMPS/LAMMPSPot.h
@@ -48,6 +48,12 @@ private:
   // dedicated worker process that owns its LAMMPS instance, so every image runs
   // in its own process with its own MPI_COMM_WORLD and true parallelism.
   // Not available on Windows (no fork/pipe).
+  // Set once a worker times out, dies, or reports an error. Respawning a
+  // worker mid-search deadlocks: the client blocks with no worker attached
+  // and the search never ends. Once the pipe is broken the potential is
+  // unusable for this job, so every later evaluation is reported as an
+  // impassable wall and the search terminates on its own.
+  bool workerFailed{false};
   int workerPid{-1};
   int reqFd{-1}; // parent writes requests here (child stdin side)
   int resFd{-1}; // parent reads results here (child stdout side)

--- a/include/eon/potentials/LAMMPS/LAMMPSPot.h
+++ b/include/eon/potentials/LAMMPS/LAMMPSPot.h
@@ -48,12 +48,15 @@ private:
   // dedicated worker process that owns its LAMMPS instance, so every image runs
   // in its own process with its own MPI_COMM_WORLD and true parallelism.
   // Not available on Windows (no fork/pipe).
-  // Set once a worker times out, dies, or reports an error. Respawning a
-  // worker mid-search deadlocks: the client blocks with no worker attached
-  // and the search never ends. Once the pipe is broken the potential is
-  // unusable for this job, so every later evaluation is reported as an
-  // impassable wall and the search terminates on its own.
-  bool workerFailed{false};
+  // Respawns allowed after a worker times out, dies, or reports an error.
+  // A single transient failure must not poison the job: every later
+  // evaluation would return the impassable wall, no minimisation could ever
+  // meet its force criterion, and the search would be discarded as a minimum
+  // that failed to converge. Respawning is safe now that the teardown is
+  // bounded rather than waiting on a wedged child forever. The budget is
+  // finite so a worker that cannot be revived still ends the search instead
+  // of looping.
+  int workerRespawnsLeft{3};
   int workerPid{-1};
   int reqFd{-1}; // parent writes requests here (child stdin side)
   int resFd{-1}; // parent reads results here (child stdout side)

--- a/include/eon/potentials/LAMMPS/LAMMPSPot.h
+++ b/include/eon/potentials/LAMMPS/LAMMPSPot.h
@@ -16,6 +16,8 @@
 #include "eon/Parameters.h"
 #include "eon/Potential.h"
 
+#include <mutex>
+
 class LAMMPSPot : public Potential {
 
 public:
@@ -57,6 +59,15 @@ private:
   // finite so a worker that cannot be revived still ends the search instead
   // of looping.
   int workerRespawnsLeft{3};
+  // Serialises the request/response exchange with the worker. eOn minimises
+  // the two endpoints of a saddle concurrently, and when both share this
+  // instance the two threads interleave writes and reads on the same pipe.
+  // The protocol is a bare byte stream with no framing, so an interleaved
+  // exchange is read as corrupt: the worker reports an evaluation error, the
+  // next send finds a closed pipe, and the worker dies, all within the first
+  // three force calls of the minimisation. Uncontended when instances really
+  // are per-image.
+  std::mutex workerMutex;
   int workerPid{-1};
   int reqFd{-1}; // parent writes requests here (child stdin side)
   int resFd{-1}; // parent reads results here (child stdout side)


### PR DESCRIPTION
## Summary

LAMMPS forked-worker force path no longer dies the whole client on a single bad geometry or dead worker:

- Reject non-finite / failed evaluations instead of ending the process
- Bounded worker respawns; stop respawning mid-search when teardown is bound
- Reject closed request pipe as a geometry failure
- A rejected geometry is not reported as converged
- Ignore SIGPIPE so a dead worker is an error path
- Mutex around the worker byte-stream exchange so concurrent endpoint minimisations cannot interleave
- Process search: when neither endpoint returns to the reactant, report atom count past tolerance and max separation

Rebased onto current `main` (dropped an accidental vesin-docs commit that had landed on this branch).

## Test plan

- [ ] CI Build basic eon + LAMMPS workflows if enabled
- [x] Cherry-pick clean on main