### PR TITLE
feat(pyeonclient): 0.4.0 wheels, with a TestPyPI rehearsal path

### DIFF
--- a/.github/workflows/pyeonclient-wheels.yml
+++ b/.github/workflows/pyeonclient-wheels.yml
@@ -18,9 +18,16 @@ on:
   workflow_dispatch:
     inputs:
       publish:
-        description: "Publish built wheels to PyPI"
+        description: "Publish built wheels"
         type: boolean
         default: false
+      target:
+        description: "Index to publish to (rehearse on TestPyPI first)"
+        type: choice
+        options:
+          - testpypi
+          - pypi
+        default: testpypi
       build_metatomic:
         description: "Also build CPU-metatomic wheels"
         type: boolean
@@ -263,8 +270,8 @@ jobs:
       || (github.event_name == 'workflow_dispatch' && inputs.publish)
     runs-on: ubuntu-latest
     environment:
-      name: pypi-pyeonclient
-      url: https://pypi.org/p/pyeonclient
+      name: ${{ (github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi') && 'testpypi-pyeonclient' || 'pypi-pyeonclient' }}
+      url: ${{ (github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi') && 'https://test.pypi.org/p/pyeonclient' || 'https://pypi.org/p/pyeonclient' }}
     permissions:
       contents: read
       id-token: write
@@ -289,9 +296,12 @@ jobs:
             ls upload | sort | uniq -d
             exit 1
           fi
-      - name: Publish to PyPI
+      # A tag publishes to PyPI; a manual run defaults to TestPyPI so the
+      # upload can be rehearsed before the irreversible one.
+      - name: Publish
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: upload/
+          repository-url: ${{ (github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi') && 'https://test.pypi.org/legacy/' || '' }}
           skip-existing: true
           verbose: true

--- a/docs/newsfragments/+pyeonclient-040.changed.md
+++ b/docs/newsfragments/+pyeonclient-040.changed.md
@@ -1,0 +1,8 @@
+pyeonclient 0.4.0: the potentials it exposes come from ``librgpot`` now
+rather than eOn's in-tree kernels, so the wheels bundle that library and
+no longer carry per-pot plugin objects. The Python API is unchanged --
+the same ``potential`` names select the same physics.
+
+Its wheel workflow gained a ``target`` input so an upload can be
+rehearsed against TestPyPI before the irreversible one; a
+``pyeonclient-v*`` tag still goes straight to PyPI.

--- a/pyproject-pyeonclient.toml
+++ b/pyproject-pyeonclient.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyeonclient"
-version = "0.3.6"
+version = "0.4.0"
 description = "Nanobind bindings to the eOn C++ client (Matter, Parameters, Potential, Jobs, NEB, RGPOT)"
 authors = [
     {name = "Rohit Goswami", email = "rgoswami@ieee.org"},


### PR DESCRIPTION
pyeonclient 0.4.0: its potentials come from `librgpot` after the v3.0.0 cutover, so the wheels bundle that library instead of per-pot plugin objects. The Python API is unchanged.

The wheel workflow gains a `target` input (`testpypi` default, `pypi`) so a manual run can rehearse the upload against TestPyPI before the irreversible one. A `pyeonclient-v*` tag still publishes straight to PyPI, as before.

Publishing to TestPyPI needs a trusted publisher (or token) configured for the project on test.pypi.org against the `testpypi-pyeonclient` environment -- that part is account-side and not in this PR.