### PR TITLE
fix(metatomic): load PET-MAD on metatensor-torch 0.10.3

### DIFF
--- a/client/potentials/Metatomic/MetatomicPotential.cpp
+++ b/client/potentials/Metatomic/MetatomicPotential.cpp
@@ -24,6 +24,31 @@
 
 using namespace std::string_literals;
 
+namespace {
+
+// metatensor-torch 0.10.3 Module::to() walks every attribute when
+// `_mts_buffer_names` is missing. Exported PET-MAD stores mixed dicts as
+// ordinary attrs; empty containers count as non-metatensor and throw.
+// Weights already moved. Swallow only that mixed-dict error. Do not
+// register `_mts_buffer_names` on scripted modules (JIT slot assert).
+bool is_mixed_mts_to_error(const c10::Error &e) {
+  const std::string w = e.what_without_backtrace();
+  return w.find("metatensor and non-metatensor") != std::string::npos;
+}
+
+void move_atomistic_model(metatensor_torch::Module &model,
+                          torch::Device device) {
+  try {
+    model.to(device);
+  } catch (const c10::Error &e) {
+    if (!is_mixed_mts_to_error(e)) {
+      throw;
+    }
+  }
+}
+
+} // namespace
+
 static torch::optional<std::string> normalize_variant(const std::string &s) {
   if (s.empty() || s == "off")
     return torch::nullopt;
@@ -107,7 +132,7 @@ MetatomicPotential::MetatomicPotential(const Parameters &params)
   device_ = torch::Device(device_type_);
   QUILL_LOG_INFO(m_log, "[MetatomicPotential] Using device: {}", device_.str());
 
-  this->model_.to(this->device_);
+  move_atomistic_model(this->model_, this->device_);
 
   // 4. Set data type (float32/float64) based on model capabilities
   if (this->capabilities_->dtype() == "float64") {

--- a/docs/newsfragments/+metatomic-to-mts-buffer.fixed.md
+++ b/docs/newsfragments/+metatomic-to-mts-buffer.fixed.md
@@ -1,0 +1,3 @@
+Fat ``MetatomicPotential`` loads exported PET-MAD (and similar) models on
+metatensor-torch 0.10.3: scripted modules without ``_mts_buffer_names`` no
+longer trip the mixed-dict ``.to()`` walk.


### PR DESCRIPTION
## Why

metatensor-torch 0.10.3 `Module::to()` walks every attribute when
`_mts_buffer_names` is missing and treats empty containers as
non-metatensor. Exported PET-MAD stores mixed dicts as ordinary attrs, so
fat `MetatomicPotential` create fails the same way rgpot does.

Cookbook #293 uses rgpot dlopen, not this fat path. Same bug, same fix.

## What

Swallow only the mixed-dict `c10::Error` from `.to()`. Do not
`register_attribute("_mts_buffer_names")` on scripted PET-MAD.

Companion: OmniPotentRPC/rgpot `fix/metatomic-to-mts-buffer-names`.
