### PR TITLE
fix(meson): force-include Cap'n Proto MSVC interface guard

### DIFF
--- a/docs/newsfragments/398.fixed.md
+++ b/docs/newsfragments/398.fixed.md
@@ -1,0 +1,1 @@
+MSVC Cap'n Proto builds force-include a guard that undefines ``interface`` after ``project()``, so Meson 1.12's ``cl.exe`` sanity check no longer sees ``/FID:/...``.

--- a/meson.build
+++ b/meson.build
@@ -16,6 +16,18 @@ project(
 
 host_system = host_machine.system()
 
+# MSVC: Cap'n Proto templates break when windows.h defines `interface`.
+# Force-include the guard after compiler detection. A /FI path in CXXFLAGS
+# is applied to Meson's cl.exe sanity check; a drive-letter path becomes
+# /FID:/... and Meson reports that cl.exe cannot compile programs.
+if host_system == 'windows' and meson.get_compiler('cpp').get_id() == 'msvc'
+    add_project_arguments(
+        '/FI',
+        meson.current_source_dir() / 'msvc_capnp_guard.h',
+        language: 'cpp',
+    )
+endif
+
 _args = []  # Extra arguments
 _fargs = []  # Fortran arguments
 _deps = []  # Dependencies

--- a/msvc_capnp_guard.h
+++ b/msvc_capnp_guard.h
@@ -1,0 +1,7 @@
+#pragma once
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#ifdef interface
+#undef interface
+#endif


### PR DESCRIPTION
## Summary

MSVC `windows.h` defines `interface`, which breaks Cap'n Proto templates. The feedstock was putting `/FI msvc_capnp_guard.h` in `CXXFLAGS`; Meson 1.12 feeds those flags into the `cl.exe` sanity compile, a drive-letter include becomes `/FID:/...`, and setup dies with "Compiler cl.exe cannot compile programs."

`add_project_arguments('/FI', ...)` after `project()` applies the force-include only to the real compile. Same guard as conda-forge/eon-feedstock#30 (`0001-win-msvc-capnp-fi-after-project.patch`). After the next tarball the feedstock can drop that patch.

The remaining win-64 activation work (clear GNU `LDFLAGS` so `cl` does not see `-Wl,...` / D8021; `clang_rt` / `flang_rt` `LIBPATH`) stays on the feedstock. That is compiler-activation, not eOn source.

## Test plan

- [x] conda-forge/eon-feedstock#30 win_64 py3.10-3.14 SUCCESS with this source change as a recipe patch
- [ ] GHA Windows job on this branch