### PR TITLE
docs(site): drop Umami/Plausible; keep Antics

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -1,11 +1,5 @@
 {% extends "!layout.html" %}
 
-{% block extrahead %}
-<script defer src="https://analytics.turtletech.us/script.js" data-website-id="09b37a22-b593-41a1-8842-b4b2ec1ec3a3"></script>
-<script defer src="https://antics-api.turtletech.us/antics.js"></script>
-<script>window.umami=window.umami||{track:function(){}};document.addEventListener('click',function(e){var a=e.target.closest('a');if(a&&a.hostname!==location.hostname)umami.track('Outbound Link',{url:a.href})});</script>
-{% endblock %}
-
 {% block footer %}
 <div
   style="
@@ -57,8 +51,8 @@
   </svg>
   <span style="white-space: nowrap">
     Analytics via
-    <a href="https://umami.is/" target="_blank" rel="noopener noreferrer"
-      >Umami</a
+    <a href="https://antics.turtletech.us/" target="_blank" rel="noopener noreferrer"
+      >Antics</a
     >, provided by
   </span>
 


### PR DESCRIPTION
## Summary

eondocs.org was loading both `antics-api.turtletech.us/antics.js` and the old `analytics.turtletech.us` tracker (Umami script / Plausible `data-domain` on the live site). Antics is the dashboard in use.

- Remove the `analytics.turtletech.us` script and the Umami outbound-click hook from `docs/source/_templates/layout.html`
- Keep Antics via `html_js_files` in `docs/source/conf.py`
- Footer credit is Antics, not Umami

## Test plan

- [ ] Docs build
- [ ] View-source on eondocs.org after deploy: antics.js present, no `analytics.turtletech.us`, no `plausible`, no `umami`