### PR TITLE
docs: publish a sibling doxyYoda C++ API site

### DIFF
--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -63,6 +63,7 @@ jobs:
             -Dwith_metatomic=True -Dtorch_version=2.10 -Dpip_metatomic=True
           meson install --skip-subprojects -C bbdir
           sphinx-build -b html -j auto docs/source docs/build/html
+          pixi run -e docs-mta install-doxyhtml
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -170,6 +170,8 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+/docs/doxyYoda/
+/docs/doxygen-html/
 
 # PyBuilder
 target/

--- a/docs/newsfragments/+doxyyoda-sibling-html.added.md
+++ b/docs/newsfragments/+doxyyoda-sibling-html.added.md
@@ -1,0 +1,1 @@
+Standalone doxyYoda C++ API HTML is published at `/api-cpp/` next to the Sphinx book.

--- a/docs/source/Doxyfile_doxyyoda.cfg
+++ b/docs/source/Doxyfile_doxyyoda.cfg
@@ -40,9 +40,7 @@ INLINE_SOURCES          = YES
 SOURCE_BROWSER          = YES
 JAVADOC_AUTOBRIEF       = YES
 BUILTIN_STL_SUPPORT     = YES
-HAVE_DOT                = YES
-DOT_IMAGE_FORMAT        = svg
-INTERACTIVE_SVG         = YES
+HAVE_DOT                = NO
 
 QUIET                   = YES
 WARNINGS                = YES

--- a/docs/source/Doxyfile_doxyyoda.cfg
+++ b/docs/source/Doxyfile_doxyyoda.cfg
@@ -1,0 +1,53 @@
+# eOn -- standalone Doxygen HTML via doxyYoda (sibling of the Sphinx book)
+
+PROJECT_NAME            = "eOn"
+PROJECT_NUMBER          = "client"
+PROJECT_BRIEF           = "Long-timescale dynamics: aKMC, NEB, parallel replica"
+
+OUTPUT_DIRECTORY        = "../doxygen-html"
+GENERATE_HTML           = YES
+GENERATE_LATEX          = NO
+GENERATE_XML            = NO
+HTML_OUTPUT             = html
+
+HTML_HEADER             = "../doxyYoda/html/header.html"
+HTML_FOOTER             = "../doxyYoda/html/footer.html"
+HTML_EXTRA_STYLESHEET   = "../doxyYoda/css/doxyYoda.min.css"
+LAYOUT_FILE             = "../doxyYoda/xml/doxyYoda.xml"
+
+GENERATE_TREEVIEW       = YES
+FULL_SIDEBAR            = NO
+HTML_DYNAMIC_SECTIONS   = YES
+HTML_CODE_FOLDING       = YES
+USE_MATHJAX             = YES
+MATHJAX_VERSION         = MathJax_3
+
+RECURSIVE               = YES
+INPUT                   = "../../client" \
+                          "../../include"
+EXCLUDE                 = "../../client/tests" \
+                          "../../client/unit_tests" \
+                          "../../client/thirdparty" \
+                          "../../client/libs" \
+                          "../../client/python" \
+                          "../../client/potentials/EMT/Asap"
+FILE_PATTERNS           = *.h *.hpp *.hh *.cpp *.cc *.cxx *.dox
+
+EXTRACT_ALL             = YES
+EXTRACT_PRIVATE         = YES
+EXTRACT_STATIC          = YES
+INLINE_SOURCES          = YES
+SOURCE_BROWSER          = YES
+JAVADOC_AUTOBRIEF       = YES
+BUILTIN_STL_SUPPORT     = YES
+HAVE_DOT                = YES
+DOT_IMAGE_FORMAT        = svg
+INTERACTIVE_SVG         = YES
+
+QUIET                   = YES
+WARNINGS                = YES
+WARN_IF_UNDOCUMENTED    = NO
+
+# Local Variables:
+# mode: conf
+# End:

--- a/docs/source/Doxyfile_doxyyoda.cfg
+++ b/docs/source/Doxyfile_doxyyoda.cfg
@@ -31,7 +31,7 @@ EXCLUDE                 = "../../client/tests" \
                           "../../client/libs" \
                           "../../client/python" \
                           "../../client/potentials/EMT/Asap"
-FILE_PATTERNS           = *.h *.hpp *.hh *.cpp *.cc *.cxx *.dox
+FILE_PATTERNS           = *.h *.hpp *.hh *.cpp *.cc *.cxx *.txt
 
 EXTRACT_ALL             = YES
 EXTRACT_PRIVATE         = YES

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -107,6 +107,10 @@ html_theme_options = {
     "globaltoc_expand_depth": 2,
     "nav_links": [
         {
+            "title": "C++ API",
+            "url": "/api-cpp/index.html",
+        },
+        {
             "title": "Ecosystem",
             "children": [
                 {

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -109,6 +109,7 @@ html_theme_options = {
         {
             "title": "C++ API",
             "url": "/api-cpp/index.html",
+            "resource": True,
         },
         {
             "title": "Ecosystem",

--- a/docs/source/devdocs/docbuild.md
+++ b/docs/source/devdocs/docbuild.md
@@ -37,6 +37,16 @@ uvx pdm run pip install . -vvv
 uvx pdm run sphinx-build -b html docs/source docs/build/html
 ```
 
+The current in-tree path is pixi:
+
+```{code-block} bash
+pixi run -e docs makedocs
+pixi run -e docs install-doxyhtml
+```
+
+`makedocs` is the Sphinx book. `install-doxyhtml` writes the sibling
+doxyYoda C++ API tree to `docs/build/html/api-cpp/`.
+
 This can be viewed locally with an HTTP server.
 
 ```{code-block} bash

--- a/docs/source/devdocs/release.md
+++ b/docs/source/devdocs/release.md
@@ -478,23 +478,16 @@ Then [§3](#3-post-bump-actions) push and channel completion.
 
 ## 8. API / Doxygen documentation check
 
-rgpot maintains `docs/source/Doxyfile_*.cfg` and integrates Doxygen output into
-the Sphinx site. **eOn does not yet include an equivalent in-tree Doxygen pipeline**
-for the C++ `client/` tree; Python API docs use Sphinx autodoc/autodoc2 in the
-existing `docs/` build (`ci_docs.yml` / `docs/source/devdocs/docbuild.md`).
+Python API docs stay on Sphinx autodoc/autodoc2. The C++ `client/` tree is
+a sibling doxyYoda HTML site at `/api-cpp/` (`docs/source/Doxyfile_doxyyoda.cfg`,
+`pixi run -e docs install-doxyhtml`, wired in `ci_docs.yml`).
 
 **Release check (current policy):**
 
 - [ ] Sphinx docs build is green on `main` (`ci_docs.yml` or local
   `pixi r -e docs …` / project-documented doc target).
+- [ ] `docs/build/html/api-cpp/index.html` exists after `install-doxyhtml`.
 - [ ] Curated release notes exist under `docs/source/releases/vX.Y.Z/`.
-- [ ] No broken “run doxygen” step is required for a cut.
-
-**Deferred (explicit non-goal until a dedicated docs PR):** full Doxygen +
-doxyrest/breathe wiring for `client/**/*.h` analogous to rgpot. Track as
-follow-up; do not block semver cuts solely on Doxygen absence. When added,
-extend this section with the generate command and wire it into `ci_docs.yml`
-plus this checklist.
 
 ## 9. Paper tags
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -105,6 +105,13 @@ To schedule `eonclient` on a laptop or a Slurm login node, install
 [aiida-eon](https://pypi.org/project/aiida-eon/) and see
 {doc}`user_guide/aiida`.
 
+# C++ API
+
+Python bindings are documented in this book under {doc}`apidocs/index`.
+The C++ `client/` tree has a sibling [doxyYoda HTML site](https://eondocs.org/api-cpp/)
+(inline source, treeview). Locally that is `api-cpp/index.html` under
+`docs/build/html` after `pixi run -e docs install-doxyhtml`.
+
 # User guide
 
 ```{toctree}

--- a/pixi.lock
+++ b/pixi.lock
@@ -6049,6 +6049,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cmake-4.2.0-hc85cc9f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/compilers-1.10.0-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-1.10.0-h1a2810e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/doxygen-1.17.0-py313hfca462b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/eigen-3.4.0-h171cf75_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/enchant-2.8.2-h02132a2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fortran-compiler-1.10.0-h36df796_0.conda
@@ -6332,6 +6333,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/compiler-rt-18.1.8-he914875_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/compilers-1.10.0-h694c41f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cxx-compiler-1.10.0-h20888b2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/doxygen-1.17.0-py313hda38850_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/eigen-3.4.0-hfc0b2d5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/fortran-compiler-1.10.0-h02557f8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/gfortran-13.3.0-hcc3c99d_1.conda
@@ -6559,6 +6561,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/compiler-rt-18.1.8-h855ad52_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/compilers-1.10.0-hce30654_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cxx-compiler-1.10.0-hba80287_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/doxygen-1.17.0-py311h5836f99_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/eigen-3.4.0-h49c215f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fortran-compiler-1.10.0-h5692697_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gfortran-13.2.0-h1ca8e4b_1.conda
@@ -6782,6 +6785,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/compiler-rt-19.1.7-h49e36cd_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/compilers-1.11.0-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cxx-compiler-1.11.0-h1c1089f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/doxygen-1.17.0-py311pl5321hfd67193_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/eigen-3.4.0-h477610d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/flang-19.1.7-hbeecb71_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/flang_impl_win-64-19.1.7-h719f0c7_0.conda
@@ -6956,6 +6960,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/compilers-1.11.0-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-14.3.0-he8ccf15_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-1.11.0-hfcd1e18_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/doxygen-1.17.0-py313hfca462b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/eigen-3.4.0-h54a6638_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/enchant-2.8.2-h02132a2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fortran-compiler-1.11.0-h9bea470_0.conda
@@ -7299,6 +7304,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/compiler-rt-19.1.7-h855ad52_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/compilers-1.11.0-hce30654_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cxx-compiler-1.11.0-h88570a1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/doxygen-1.17.0-py311h5836f99_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/eigen-3.4.0-h784d473_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fortran-compiler-1.11.0-h81a4f41_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gfortran-14.3.0-h3ef1dbf_0.conda
@@ -7552,6 +7558,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/compiler-rt-19.1.7-h49e36cd_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/compilers-1.11.0-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cxx-compiler-1.11.0-h1c1089f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/doxygen-1.17.0-py311pl5321hfd67193_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/eigen-3.4.0-h5112557_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/flang-19.1.7-hbeecb71_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/flang_impl_win-64-19.1.7-h719f0c7_0.conda
@@ -11078,6 +11085,21 @@ packages:
   purls: []
   size: 590934
   timestamp: 1743766913008
+- conda: https://conda.anaconda.org/conda-forge/linux-64/doxygen-1.17.0-py313hfca462b_0.conda
+  sha256: c27f0c1aed5ca4b28bf7d84132c85907cf59740a1a3fa50395cff27d517b5b56
+  md5: 203fdb48d08089c8de9bf3f2df52f0ed
+  depends:
+  - libiconv
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libiconv >=1.18,<2.0a0
+  license: GPL-2.0-only
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 13762539
+  timestamp: 1782819135560
 - conda: https://conda.anaconda.org/conda-forge/linux-64/eigen-3.4.0-h171cf75_1.conda
   sha256: fee3738c2431c13f4930778e9d7daca9328e7e2f2a38928cf6ca5a0daa86474a
   md5: ea2db216eae84bc83b0b2961f38f5c0d
@@ -18756,6 +18778,20 @@ packages:
   purls: []
   size: 579258
   timestamp: 1743767040118
+- conda: https://conda.anaconda.org/conda-forge/osx-64/doxygen-1.17.0-py313hda38850_0.conda
+  sha256: 4ffbbc9010a23a1344d369c8968c849859d0cd96f1cb9e5e21875b47e1569ea9
+  md5: 479943dea6e8375c9a4971fd8f0a9598
+  depends:
+  - libiconv
+  - libcxx >=19
+  - __osx >=11.0
+  - libiconv >=1.18,<2.0a0
+  license: GPL-2.0-only
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 14393936
+  timestamp: 1782819306484
 - conda: https://conda.anaconda.org/conda-forge/osx-64/eigen-3.4.0-h2fb4741_1.conda
   sha256: 7dbc71717ebd1e59b5593f739c68f5da9e24d4a654a4b17468099783800a0e8a
   md5: cd30a50f824ee8094fae403949f8e09b
@@ -23056,6 +23092,20 @@ packages:
   purls: []
   size: 580945
   timestamp: 1743767421738
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/doxygen-1.17.0-py311h5836f99_0.conda
+  sha256: cd1d89d7291985ac727b31945cb28118c30cf1f67464b47cca569b66ac7a4ff0
+  md5: cefd281d2893576a3b70909e5266bc54
+  depends:
+  - libiconv
+  - libcxx >=19
+  - __osx >=11.0
+  - libiconv >=1.18,<2.0a0
+  license: GPL-2.0-only
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 13554822
+  timestamp: 1782819157798
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/eigen-3.4.0-h49c215f_1.conda
   sha256: 045b7e0994cc5740984551a79a56f7ff905a8deebcbdc02d6a28ad3ccae0abce
   md5: cceeb206b14c099ff52dc5a67b096904
@@ -26903,6 +26953,21 @@ packages:
   purls: []
   size: 405536
   timestamp: 1732522031398
+- conda: https://conda.anaconda.org/conda-forge/win-64/doxygen-1.17.0-py311pl5321hfd67193_0.conda
+  sha256: 6f3ce81605ab7b8c7942393088ef094c253e505e0ce9ecdb7825986d38557d19
+  md5: 1e55efbc6b766ebd9edd6854b32c26d5
+  depends:
+  - libiconv
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - libiconv >=1.18,<2.0a0
+  license: GPL-2.0-only
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 10992646
+  timestamp: 1782819171119
 - conda: https://conda.anaconda.org/conda-forge/win-64/eigen-3.4.0-h477610d_1.conda
   sha256: 39d6fa1245ef8c226ff3e485e947770e3b9c7d65fed6c42bd297e2b218b4ddab
   md5: 8ac3430db715982d054a004133ae8ae2

--- a/pixi.toml
+++ b/pixi.toml
@@ -154,6 +154,7 @@ psutil = ">=7.0.0, <8"
 sphinx = ">=7"
 shibuya = "*"
 uv = "*"
+doxygen = ">=1.17,<2"
 
 [feature.docs.target.linux-64.dependencies]
 ira = ">=2"
@@ -178,6 +179,21 @@ sphinx-autodoc2 = "*"
 rgpycrumbs = { version = ">=1.9.9,<2", extras = ["analysis"] }
 chemparseplot = { version = ">=1.9.7,<2", extras = ["neb", "plot"] }
 adjustText = "*"
+
+[feature.docs.tasks.fetch-doxyyoda]
+description = "Download the doxyYoda 0.2.2 HTML theme"
+cmd = "bash scripts/get_doxyyoda.sh"
+
+[feature.docs.tasks.doxyhtml]
+description = "Standalone doxyYoda C++ API HTML"
+cwd = "docs/source"
+depends-on = ["fetch-doxyyoda"]
+cmd = "doxygen Doxyfile_doxyyoda.cfg"
+
+[feature.docs.tasks.install-doxyhtml]
+description = "Copy doxyYoda HTML into the Sphinx publish tree"
+depends-on = ["doxyhtml"]
+cmd = "test -d docs/build/html && rm -rf docs/build/html/api-cpp && cp -a docs/doxygen-html/html docs/build/html/api-cpp"
 
 [feature.docs.tasks.makedocs]
 cmd = "sphinx-build docs/source docs/build/html"

--- a/pixi.toml
+++ b/pixi.toml
@@ -193,7 +193,7 @@ cmd = "doxygen Doxyfile_doxyyoda.cfg"
 [feature.docs.tasks.install-doxyhtml]
 description = "Copy doxyYoda HTML into the Sphinx publish tree"
 depends-on = ["doxyhtml"]
-cmd = "test -d docs/build/html && rm -rf docs/build/html/api-cpp && cp -a docs/doxygen-html/html docs/build/html/api-cpp"
+cmd = "test -d docs/build/html && rm -rf docs/build/html/api-cpp && cp -R docs/doxygen-html/html docs/build/html/api-cpp"
 
 [feature.docs.tasks.makedocs]
 cmd = "sphinx-build docs/source docs/build/html"
@@ -204,7 +204,7 @@ depends-on = [
   { task = "doxyhtml", environment = "docs" },
 ]
 cmd = """
-test -d docs/build/html && rm -rf docs/build/html/api-cpp && cp -a docs/doxygen-html/html docs/build/html/api-cpp
+test -d docs/build/html && rm -rf docs/build/html/api-cpp && cp -R docs/doxygen-html/html docs/build/html/api-cpp
 cd docs/build/html && python -m http.server 8234
 """
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -201,8 +201,10 @@ cmd = "sphinx-build docs/source docs/build/html"
 [feature.docs.tasks.srvdocs]
 depends-on = [
   { task = "makedocs", environment = "docs" },
+  { task = "doxyhtml", environment = "docs" },
 ]
 cmd = """
+test -d docs/build/html && rm -rf docs/build/html/api-cpp && cp -a docs/doxygen-html/html docs/build/html/api-cpp
 cd docs/build/html && python -m http.server 8234
 """
 

--- a/scripts/get_doxyyoda.sh
+++ b/scripts/get_doxyyoda.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Fetch the doxyYoda HTML theme into docs/doxyYoda/.
+set -euo pipefail
+ver=0.2.2
+root=$(git rev-parse --show-toplevel)
+dest="$root/docs/doxyYoda"
+if [ -f "$dest/html/header.html" ]; then
+  echo "doxyYoda already present"
+  exit 0
+fi
+tmp=$(mktemp)
+trap 'rm -f "$tmp"' EXIT
+curl -fSL "https://github.com/HaoZeke/doxyYoda/releases/download/v${ver}/doxyYoda_${ver}.tar.gz" -o "$tmp"
+mkdir -p "$root/docs"
+tar -xf "$tmp" -C "$root/docs"
+echo "extracted doxyYoda ${ver} -> docs/doxyYoda"


### PR DESCRIPTION
Sphinx stays the book. Add a standalone doxyYoda HTML tree for `client/` and `include/eon` at `/api-cpp/`, linked from the nav and the landing page. `ci_docs.yml` copies it into the publish tree after `sphinx-build`. Doxygen in the docs env is floored at 1.17 to match the 0.2.2 templates.