### PR TITLE
fix(docs): drop stale Doxygen aliases from the C++ API landing page

### DIFF
--- a/client/ClientEON.txt
+++ b/client/ClientEON.txt
@@ -1,10 +1,5 @@
 /*! \mainpage The eOnClient API
 
-<b>Version \version</b>, Build Date: \builddate
-
-Built by: \builduser on \buildhost
-<hr>
-
 \section Overview
 
 The eOnClient API is a set of pages dedicated to the internal documentation of the client-side eOn codebase. eOn is a software package that is used to explore the configuration space of molecular systems and to accelerate the simulation of their dynamics over long times. The information presented in this document gives weight to a full spectrum coverage of the code as opposed to program usability; the intended goal is to document the full extent and capabilities of the program, and to answer the questions what or how the code is actual running.

--- a/docs/newsfragments/401.fixed.md
+++ b/docs/newsfragments/401.fixed.md
@@ -1,0 +1,1 @@
+The C++ API mainpage no longer prints undefined Makefile Doxygen aliases, and the theme header version matches 3.2.0.

--- a/docs/source/Doxyfile_doxyyoda.cfg
+++ b/docs/source/Doxyfile_doxyyoda.cfg
@@ -1,7 +1,7 @@
 # eOn -- standalone Doxygen HTML via doxyYoda (sibling of the Sphinx book)
 
 PROJECT_NAME            = "eOn"
-PROJECT_NUMBER          = "client"
+PROJECT_NUMBER          = "3.2.0"
 PROJECT_BRIEF           = "Long-timescale dynamics: aKMC, NEB, parallel replica"
 
 OUTPUT_DIRECTORY        = "../doxygen-html"


### PR DESCRIPTION
The C++ API mainpage was written against Makefile aliases (`\version`, `\builddate`, `\builduser`, `\buildhost`). Those are not defined in the sibling Doxyfile. `\version` is also a Doxygen paragraph command, so the landing page showed two Version headings and literal backslash tokens.

Drop that banner. The theme header already shows `PROJECT_NUMBER` (now 3.2.0 to match `pyproject.toml`).